### PR TITLE
copy: align messaging to Solar/Wärmepumpen positioning

### DIFF
--- a/blocksy-child/404.php
+++ b/blocksy-child/404.php
@@ -60,7 +60,7 @@ $primary_urls = function_exists( 'nexus_get_primary_public_url_map' ) ? nexus_ge
 							<a href="<?php echo esc_url( nexus_get_audit_url() ); ?>"
 							   data-track-action="404_nav_audit"
 							   data-track-category="error_recovery">
-								<?php esc_html_e( 'Growth Audit', 'blocksy-child' ); ?>
+								<?php esc_html_e( 'System-Diagnose', 'blocksy-child' ); ?>
 							</a>
 						</li>
 						<li>

--- a/blocksy-child/assets/js/audit-linkedin.js
+++ b/blocksy-child/assets/js/audit-linkedin.js
@@ -2,7 +2,7 @@
  * LinkedIn Audit Landing Page — Form Handling
  *
  * Lean single-step form that submits to the existing nexus/v1/audit-request
- * endpoint. Reuses the same CRM pipeline as the main Growth Audit funnel.
+ * endpoint. Reuses the same CRM pipeline as the main System-Diagnose funnel.
  *
  * @package Blocksy_Child
  */

--- a/blocksy-child/assets/js/audit.js
+++ b/blocksy-child/assets/js/audit.js
@@ -1,5 +1,5 @@
 /**
- * Growth Audit page logic.
+ * System-Diagnose page logic.
  *
  * Handles attribution capture, one-step form submission and FAQ schema.
  */

--- a/blocksy-child/assets/js/cja-audit.js
+++ b/blocksy-child/assets/js/cja-audit.js
@@ -551,7 +551,7 @@
     title.className = 'cja-score-title';
     subtitle.className = 'cja-score-sub';
 
-    kicker.textContent = 'Growth Audit Ergebnis';
+    kicker.textContent = 'System-Diagnose Ergebnis';
     title.textContent = displayUrl + ' im Überblick';
     subtitle.textContent = timestamp ? 'Stand: ' + timestamp + ' · priorisierte Hebel über alle Diagnose-Bereiche hinweg.' : 'Wo Ihre Website heute Nachfrage verliert und welche Bereiche zuerst Wirkung versprechen.';
 

--- a/blocksy-child/assets/js/contact.js
+++ b/blocksy-child/assets/js/contact.js
@@ -85,7 +85,7 @@
                 messageLabel: 'Kurzbeschreibung',
                 messageHelp: 'Welche URL ist relevant? Was ist unklar? Welches Ergebnis wünschen Sie sich?',
                 messagePlaceholder: '1. Seite: Welche URL ist relevant?\n2. Unklarheit: Was bremst gerade?\n3. Ziel: Was soll sich verbessern?',
-                submitLabel: 'Growth Audit anfragen',
+                submitLabel: 'System-Diagnose anfragen',
                 messageMinlength: 24,
                 timelineLabel: 'Zeitfenster',
                 showTimeline: false,
@@ -482,14 +482,14 @@
                 var statusValue = typeStatusBar.querySelector('.contact-type-status__value');
                 if (statusValue) {
                     var labels = {
-                        audit: 'Erstdiagnose / Growth Audit',
+                        audit: 'Erstdiagnose / System-Diagnose',
                         analysis: 'Fokussierte Folgeanalyse',
                         implementation: 'Umsetzung / Optimierung',
                         ongoing: 'Laufende Weiterentwicklung',
                         general: 'Allgemeine Anfrage',
                         client: 'Bestandskunde'
                     };
-                    statusValue.textContent = labels[requestType] || 'Erstdiagnose / Growth Audit';
+                    statusValue.textContent = labels[requestType] || 'Erstdiagnose / System-Diagnose';
                 }
             }
         }

--- a/blocksy-child/assets/js/cwv.js
+++ b/blocksy-child/assets/js/cwv.js
@@ -24,7 +24,7 @@
         '@type': 'Person',
         name: 'Haşim Üner',
         url: 'https://hasimuener.de',
-        jobTitle: 'Growth Architect',
+        jobTitle: 'Architekt für eigene Anfrage-Systeme',
         address: {
           '@type': 'PostalAddress',
           addressLocality: 'Hannover',

--- a/blocksy-child/assets/js/energy-intake.js
+++ b/blocksy-child/assets/js/energy-intake.js
@@ -417,7 +417,7 @@
 
     if (submitButton) {
       setDisplayed(submitButton, isLast, 'inline-flex');
-      submitButton.textContent = config.submitLabel || 'Growth Audit passend einordnen';
+      submitButton.textContent = config.submitLabel || 'System-Diagnose passend einordnen';
     }
   }
 
@@ -742,7 +742,7 @@
 
         if (submitButton) {
           submitButton.disabled = false;
-          submitButton.textContent = config.submitLabel || 'Growth Audit passend einordnen';
+          submitButton.textContent = config.submitLabel || 'System-Diagnose passend einordnen';
         }
       });
   }

--- a/blocksy-child/assets/js/performance.js
+++ b/blocksy-child/assets/js/performance.js
@@ -23,7 +23,7 @@
         '@type': 'Person',
         name: 'Haşim Üner',
         url: 'https://hasimuener.de',
-        jobTitle: 'Growth Architect',
+        jobTitle: 'Architekt für eigene Anfrage-Systeme',
         address: {
           '@type': 'PostalAddress',
           addressLocality: 'Hannover',

--- a/blocksy-child/assets/js/review-funnel.js
+++ b/blocksy-child/assets/js/review-funnel.js
@@ -7,7 +7,7 @@
   'use strict';
 
   var config = window.NexusReviewConfig || {};
-  var auditLabel = config.auditLabel || 'Growth Audit';
+  var auditLabel = config.auditLabel || 'System-Diagnose';
   var submitLabel = config.submitLabel || (auditLabel + ' anfragen');
   var AUTO_ADVANCE_DELAY = 500;
   var FEEDBACK_ID = 'review-form-feedback';

--- a/blocksy-child/category.php
+++ b/blocksy-child/category.php
@@ -68,7 +68,7 @@ $pillar = $pillar_map[$cat_slug] ?? [
     'icon'        => '📄',
     'badge'       => $cat_name,
     'subtitle'    => wp_strip_all_tags($cat_description) ?: 'Analysen und Insights zu ' . esc_html($cat_name) . '.',
-    'cta_label'   => 'Growth Audit',
+    'cta_label'   => 'System-Diagnose',
     'cta_url'     => $audit_url,
     'cta_text'    => 'Finden Sie heraus, wo Ihre Website Potenzial liegen lässt.',
 ];
@@ -255,12 +255,12 @@ if ($featured_query->have_posts()) {
                         </ul>
                     </div>
 
-                    <!-- Newsletter / Audit CTA -->
+                    <!-- Newsletter / Diagnose CTA -->
                     <div class="pillar-sidebar__audit">
                         <h4>Wo verbrennt Ihre Website Geld?</h4>
-                        <p>Der Growth Audit zeigt, wo Technik, SEO und Conversion im Zusammenspiel Reibung erzeugen.</p>
+                        <p>Die System-Diagnose zeigt, wo Technik, SEO und Conversion im Zusammenspiel Reibung erzeugen.</p>
                         <a href="<?php echo esc_url($audit_url); ?>" class="nx-btn nx-btn--ghost nx-btn--full nx-btn--sm">
-                            Audit starten →
+                            System-Diagnose starten →
                         </a>
                     </div>
                 </aside>

--- a/blocksy-child/front-page.php
+++ b/blocksy-child/front-page.php
@@ -36,15 +36,15 @@ $hero_metrics = function_exists( 'nexus_get_public_proof_metric_list' ) ? nexus_
 
 $faq_items = [
 	[
-		'question' => 'Was unterscheidet Sie von einer klassischen WordPress-Agentur?',
-		'answer'   => 'Ich ordne WordPress als B2B-Anfrage-System — Positionierung, Tracking, Conversion und kontrollierte Weiterentwicklung statt Seiten-Produktion.',
+		'question' => 'Bauen Sie nur eine Website oder kümmern Sie sich auch um den Traffic?',
+		'answer'   => 'Ich baue das komplette System. Die Website ist nur der Motor. Dazu gehören Tracking, Vorqualifizierung und die exakte Steuerung der Werbekanäle, um Sie von Portal-Leads unabhängig zu machen.',
 	],
 	[
-		'question' => 'Was passiert nach dem Growth Audit?',
-		'answer'   => 'Sie bekommen eine klare Einschätzung, wo Ihre Website Nachfrage verliert. Daraus kann eine fokussierte Korrektur oder laufende Weiterentwicklung entstehen — muss aber nicht.',
+		'question' => 'Was passiert nach der System-Diagnose?',
+		'answer'   => 'Sie bekommen eine klare Einschätzung, wo Ihr Anfrage-System Nachfrage verliert. Daraus kann eine fokussierte Korrektur oder laufende Weiterentwicklung entstehen — muss aber nicht.',
 	],
 	[
-		'question' => 'Arbeiten Sie auch mit bestehenden WordPress-Websites?',
+		'question' => 'Arbeiten Sie auch mit bestehenden Websites?',
 		'answer'   => 'Ja. In den meisten Fällen reichen gezielte Eingriffe statt eines Relaunches.',
 	],
 ];
@@ -66,9 +66,9 @@ get_header();
 
 						<div class="wp-home-hero__actions">
 							<a href="<?php echo esc_url( $request_url ); ?>" class="wp-btn wp-btn-primary wp-home-hero__primary" data-track-action="cta_home_hero_request" data-track-category="lead_gen"><?php echo esc_html( $request_cta_label ); ?></a>
-							<a href="<?php echo esc_url( $audit_url ); ?>" class="wp-home-text-link wp-home-text-link--quiet" data-track-action="cta_home_hero_audit" data-track-category="lead_gen">Audit starten</a>
+							<a href="<?php echo esc_url( $audit_url ); ?>" class="wp-home-text-link wp-home-text-link--quiet" data-track-action="cta_home_hero_audit" data-track-category="lead_gen">System-Diagnose starten</a>
 						</div>
-						<p class="nx-cta-microcopy">Wenn der Fit klar ist, direkt anfragen. Wenn zuerst die Hebel priorisiert werden sollen, Audit starten.</p>
+						<p class="nx-cta-microcopy">Wenn der Fit klar ist, direkt anfragen. Wenn zuerst die Hebel priorisiert werden sollen, System-Diagnose starten.</p>
 
 						<?php if ( ! empty( $hero_metrics ) ) : ?>
 							<div class="wp-home-kpi-row" role="list" aria-label="Zentrale Ergebniskennzahlen">
@@ -103,7 +103,7 @@ get_header();
 
 					<div class="homepage-track-record__actions">
 						<a href="<?php echo esc_url( $request_url ); ?>" class="nx-btn nx-btn--primary" data-track-action="cta_home_proof_request" data-track-category="lead_gen"><?php echo esc_html( $request_cta_label ); ?></a>
-						<a href="<?php echo esc_url( $audit_url ); ?>" class="wp-home-text-link" data-track-action="cta_home_proof_audit" data-track-category="lead_gen">Audit starten</a>
+						<a href="<?php echo esc_url( $audit_url ); ?>" class="wp-home-text-link" data-track-action="cta_home_proof_audit" data-track-category="lead_gen">System-Diagnose starten</a>
 					</div>
 				</article>
 			</div>
@@ -140,7 +140,7 @@ get_header();
 
 				<div class="homepage-problem-frame__cta">
 					<a href="<?php echo esc_url( $request_url ); ?>" class="nx-btn nx-btn--primary" data-track-action="cta_home_models_request" data-track-category="lead_gen"><?php echo esc_html( $request_cta_label ); ?></a>
-					<a href="<?php echo esc_url( $audit_url ); ?>" class="wp-home-text-link" data-track-action="cta_home_models_audit" data-track-category="lead_gen">Audit starten</a>
+					<a href="<?php echo esc_url( $audit_url ); ?>" class="wp-home-text-link" data-track-action="cta_home_models_audit" data-track-category="lead_gen">System-Diagnose starten</a>
 				</div>
 			</div>
 		</section>
@@ -154,10 +154,10 @@ get_header();
 
 				<div class="homepage-system-teaser__card">
 					<p class="homepage-system-teaser__lead">Die Logik dahinter ist immer gleich: erst Anfragepfad und Datenebene ordnen, dann skalieren.</p>
-					<p class="homepage-system-teaser__text">Sie müssen dafür nicht erst durch ein Framework klicken. Wenn der Fit passt, geht es direkt ins Formular. Wenn noch unklar ist, wo der größte Hebel liegt, zuerst ins Audit.</p>
+					<p class="homepage-system-teaser__text">Sie müssen dafür nicht erst durch ein Framework klicken. Wenn der Fit passt, geht es direkt ins Formular. Wenn noch unklar ist, wo der größte Hebel liegt, zuerst in die System-Diagnose.</p>
 					<div class="homepage-track-record__actions">
 						<a href="<?php echo esc_url( $request_url ); ?>" class="nx-btn nx-btn--primary" data-track-action="cta_home_system_request" data-track-category="lead_gen"><?php echo esc_html( $request_cta_label ); ?></a>
-						<a href="<?php echo esc_url( $audit_url ); ?>" class="wp-home-text-link" data-track-action="cta_home_system_audit" data-track-category="lead_gen">Audit starten</a>
+						<a href="<?php echo esc_url( $audit_url ); ?>" class="wp-home-text-link" data-track-action="cta_home_system_audit" data-track-category="lead_gen">System-Diagnose starten</a>
 					</div>
 				</div>
 			</div>
@@ -184,11 +184,11 @@ get_header();
 			<div class="wp-container wp-home-shell">
 				<div class="nx-cta-box homepage-conversion-cta__box">
 					<span class="nx-badge nx-badge--gold">Nächster Schritt</span>
-					<h2>Erst Anfrage. Oder zuerst Audit.</h2>
-					<p class="homepage-conversion-cta__lead">Wenn der Fit klar ist, gehen Sie direkt ins qualifizierte Formular. Wenn erst die Hebel priorisiert werden sollen, starten Sie das KI-Audit.</p>
+					<h2>Erst Anfrage. Oder zuerst System-Diagnose.</h2>
+					<p class="homepage-conversion-cta__lead">Wenn der Fit klar ist, gehen Sie direkt ins qualifizierte Formular. Wenn erst die Hebel priorisiert werden sollen, starten Sie die System-Diagnose.</p>
 					<div class="homepage-track-record__actions">
 						<a class="nx-btn nx-btn--primary homepage-conversion-cta__button" href="<?php echo esc_url( $request_url ); ?>" data-track-action="cta_home_final_request" data-track-category="lead_gen"><?php echo esc_html( $request_cta_label ); ?></a>
-						<a href="<?php echo esc_url( $audit_url ); ?>" class="wp-home-text-link" data-track-action="cta_home_final_audit" data-track-category="lead_gen">Audit starten</a>
+						<a href="<?php echo esc_url( $audit_url ); ?>" class="wp-home-text-link" data-track-action="cta_home_final_audit" data-track-category="lead_gen">System-Diagnose starten</a>
 					</div>
 					<p class="homepage-conversion-cta__microcopy"><?php echo esc_html( $audit_compact_microcopy ); ?></p>
 				</div>

--- a/blocksy-child/functions.php
+++ b/blocksy-child/functions.php
@@ -26,7 +26,7 @@ $modules = [
 	'glossary-autolink.php', // Auto-Linking: Glossar-Begriffe in Blog-Posts verlinken
 	'wgos-cluster-pages.php', // Versionierte Cluster-/Pillar-Pages und Blog-Asset-Bridges
 	'acf.php',            // ACF Feldgruppen-Registrierung (SEO, KPI, Comparison)
-	'cja-shortcode.php',  // Instant-Results Growth Audit als Shortcode
+	'cja-shortcode.php',  // Instant-Results System-Diagnose als Shortcode
 	'audit-page.php',     // Audit-Shell-Fallback für die Audit-Landing-Page
 	'tools-page.php',     // Versionierter Tools-Hub + Fallback für die Tools-Seite
 	'header.php',         // Eigener globaler Header + Navigation

--- a/blocksy-child/home.php
+++ b/blocksy-child/home.php
@@ -148,10 +148,10 @@ get_header();
 					</div>
 				<?php endif; ?>
 
-				<!-- Audit CTA am Ende aller Artikel -->
-				<div class="blog-archive-infeed-cta" aria-label="Kostenloser Growth Audit">
+				<!-- Diagnose CTA am Ende aller Artikel -->
+				<div class="blog-archive-infeed-cta" aria-label="Kostenlose System-Diagnose">
 					<div class="blog-archive-infeed-cta__inner">
-						<span class="blog-archive-infeed-cta__tag">Kostenloser Audit</span>
+						<span class="blog-archive-infeed-cta__tag">Kostenlose Diagnose</span>
 						<h2 class="blog-archive-infeed-cta__headline">Lassen Sie es uns konkret machen.</h2>
 						<p class="blog-archive-infeed-cta__sub">
 							Persönliche Analyse Ihrer Website. Schriftliche Rückmeldung mit den 3 stärksten Bremsen — in 48 Stunden.
@@ -162,7 +162,7 @@ get_header();
 							data-track-action="cta_blog_archive_end"
 							data-track-category="lead_gen"
 						>
-							Audit starten
+							System-Diagnose starten
 						</a>
 					</div>
 				</div>

--- a/blocksy-child/inc/cja-shortcode.php
+++ b/blocksy-child/inc/cja-shortcode.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Growth Audit shortcode for the instant analysis flow.
+ * System-Diagnose shortcode for the instant analysis flow.
  *
  * @package Blocksy_Child
  */
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Render the instant Growth Audit app.
+ * Render the instant System-Diagnose app.
  *
  * @return string
  */
@@ -70,9 +70,9 @@ function cja_audit_shortcode() {
 		<span id="form" class="cja-anchor" aria-hidden="true"></span>
 
 		<div class="cja-phase cja-hero" id="cja-input">
-			<span class="cja-overline">60-Sekunden-Diagnose für WordPress-B2B-Websites</span>
-			<h1 class="cja-headline">In 60 Sekunden sehen Sie, wo Ihre Website Leads verliert.</h1>
-			<p class="cja-subtitle">Der Audit zeigt direkt, wo Performance, Messbarkeit, SEO, Conversion und Inhalt Nachfrage bremsen und welche Hebel zuerst Wirkung versprechen.</p>
+			<span class="cja-overline">60-Sekunden-Diagnose für Solar- und Wärmepumpen-Anbieter</span>
+			<h1 class="cja-headline">In 60 Sekunden sehen Sie, wo Ihre Website Anfragen verliert.</h1>
+			<p class="cja-subtitle">Die Diagnose zeigt direkt, wo Performance, Messbarkeit, Vertrauen, Anfragepfad und Vorqualifizierung qualifizierte Anfragen bremsen — und welche Hebel zuerst Wirkung versprechen.</p>
 
 			<div class="cja-input-group">
 				<label class="screen-reader-text" for="cja-url-input">Website-URL</label>
@@ -81,9 +81,9 @@ function cja_audit_shortcode() {
 			</div>
 			<p class="cja-input-help">Starten Sie mit Ihrer Startseite oder der wichtigsten Angebotsseite. Sie sehen direkt die größten Reibungen und priorisierten Hebel.</p>
 
-			<div class="cja-trust-line" aria-label="Audit-Vertrauen">
+			<div class="cja-trust-line" aria-label="Diagnose-Vertrauen">
 				<span>Keine E-Mail nötig</span>
-				<span>WordPress- und B2B-Fokus</span>
+				<span>Fokus: Solar, Wärmepumpe, Speicher</span>
 				<span>Priorisierte Hebel statt Tool-Score</span>
 			</div>
 
@@ -131,15 +131,15 @@ function cja_audit_shortcode() {
 
 			<div class="cja-cta-section cja-reveal">
 				<p class="cja-cta-kicker">Nächster Schritt</p>
-				<h2>Wenn das nach Ihrem Setup klingt, ist jetzt die Einordnung dran.</h2>
-				<p>Der Audit war die Diagnose. Der nächste Schritt ist ein kurzes Formular — Sie erhalten eine persönliche Einschätzung per E-Mail, ohne Pitch.</p>
+				<h2>Wenn das nach Ihrer Situation klingt, folgt jetzt die persönliche Einordnung.</h2>
+				<p>Kurz beschreiben, wo Ihr Anfrageprozess heute steht — Sie erhalten eine persönliche Einschätzung per E-Mail, ohne Pitch.</p>
 				<div class="cja-cta-actions">
 					<a href="<?php echo esc_url( $request_url ); ?>" class="cja-cta-button" data-track-action="cja_results_request" data-track-category="lead_gen" data-track-section="growth_audit_results">Einordnung anfordern</a>
 				</div>
 				<div class="cja-cta-meta">2 Minuten · persönliche Rückmeldung · kein Pflicht-Call</div>
 			</div>
 
-			<div class="cja-footer-line">Diagnose für WordPress-B2B-Websites.</div>
+			<div class="cja-footer-line">System-Diagnose für Solar- und Wärmepumpen-Anbieter.</div>
 		</div>
 	</div>
 	<?php

--- a/blocksy-child/inc/contact-page.php
+++ b/blocksy-child/inc/contact-page.php
@@ -193,7 +193,7 @@ function nexus_maybe_ensure_contact_page() {
 						'post_title'   => 'Kontakt',
 						'post_name'    => 'kontakt',
 						'post_content' => '',
-						'post_excerpt' => 'Kontakt für Growth Audit, Folgeanalyse, Umsetzung und laufende Weiterentwicklung.',
+						'post_excerpt' => 'Kontakt für System-Diagnose, Folgeanalyse, Umsetzung und laufende Weiterentwicklung.',
 					]
 				),
 				true
@@ -217,7 +217,7 @@ function nexus_maybe_ensure_contact_page() {
 		wp_update_post(
 			[
 				'ID'           => $page_id,
-				'post_excerpt' => 'Kontakt für Growth Audit, Folgeanalyse, Umsetzung und laufende Weiterentwicklung.',
+				'post_excerpt' => 'Kontakt für System-Diagnose, Folgeanalyse, Umsetzung und laufende Weiterentwicklung.',
 			]
 		);
 	}
@@ -227,7 +227,7 @@ function nexus_maybe_ensure_contact_page() {
 	}
 
 	if ( '' === trim( (string) get_post_meta( $page_id, 'seo_description', true ) ) ) {
-		update_post_meta( $page_id, 'seo_description', 'Kontakt für Growth Audit, Folgeanalyse, Umsetzung und laufende Weiterentwicklung: direkter Einstieg ohne Sales-Team.' );
+		update_post_meta( $page_id, 'seo_description', 'Kontakt für System-Diagnose, Folgeanalyse, Umsetzung und laufende Weiterentwicklung: direkter Einstieg ohne Sales-Team.' );
 	}
 }
 add_action( 'init', 'nexus_maybe_ensure_contact_page', 28 );
@@ -240,7 +240,7 @@ add_action( 'init', 'nexus_maybe_ensure_contact_page', 28 );
 function nexus_get_contact_request_type_options() {
 	return [
 		'audit' => [
-			'label'       => 'Erstdiagnose / Growth Audit',
+			'label'       => 'Erstdiagnose / System-Diagnose',
 			'description' => 'Der saubere Diagnose-Einstieg, wenn zuerst Klarheit und Priorisierung gebraucht werden.',
 		],
 		'analysis' => [
@@ -289,7 +289,7 @@ function nexus_get_contact_request_type_labels() {
 function nexus_get_contact_focus_options() {
 	return [
 		'audit_scope'      => [
-			'label' => 'Erstdiagnose / Growth Audit',
+			'label' => 'Erstdiagnose / System-Diagnose',
 			'types' => [ 'audit' ],
 		],
 		'followup_scope'   => [
@@ -411,7 +411,7 @@ function nexus_get_contact_notification_email() {
  */
 function nexus_get_contact_request_response_label( $request_type ) {
 	$labels = [
-		'audit'          => 'Growth Audit Anfrage',
+		'audit'          => 'System-Diagnose Anfrage',
 		'analysis'       => 'Folgeanalyse',
 		'implementation' => 'Umsetzungsanfrage',
 		'ongoing'        => 'Weiterentwicklungsanfrage',

--- a/blocksy-child/inc/enqueue.php
+++ b/blocksy-child/inc/enqueue.php
@@ -332,7 +332,7 @@ function hu_enqueue_assets() {
 		);
 	}
 
-	// ── H) Template: Growth Audit Funnel ──────────────────────────
+	// ── H) Template: System-Diagnose Funnel ──────────────────────────
 	if ( nexus_is_audit_page() ) {
 		wp_add_inline_style(
 			'blocksy-child-style',

--- a/blocksy-child/inc/glossary-registry-data.php
+++ b/blocksy-child/inc/glossary-registry-data.php
@@ -339,7 +339,7 @@ return [
 			],
 			[
 				'key'    => 'audit',
-				'label'  => 'Growth Audit',
+				'label'  => 'System-Diagnose',
 				'reason' => 'Ist der richtige Einstieg, wenn Owned Leads gewünscht sind, das System aber noch keine saubere Reihenfolge hat.',
 			],
 		],

--- a/blocksy-child/inc/glossary-registry.php
+++ b/blocksy-child/inc/glossary-registry.php
@@ -684,7 +684,7 @@ function nexus_get_glossary_term_content_html( $term ) {
 			<div class="wgos-final-cta__inner">
 				<span class="wgos-principle-kicker">Nächster Schritt</span>
 				<h2 class="wgos-h2">Begriff verstanden. Jetzt die richtige Priorität für Ihre Website setzen.</h2>
-				<p class="wgos-prose">Wenn klar ist, was der Begriff bedeutet, bleibt die eigentliche Frage offen: Ist das Thema für Ihre Website gerade wirklich der Engpass oder nur ein Symptom? Der Growth Audit bringt die Reihenfolge zurück.</p>
+				<p class="wgos-prose">Wenn klar ist, was der Begriff bedeutet, bleibt die eigentliche Frage offen: Ist das Thema für Ihre Website gerade wirklich der Engpass oder nur ein Symptom? Die System-Diagnose bringt die Reihenfolge zurück.</p>
 				<div class="wgos-hero__actions">
 					<a href="<?php echo esc_url( $hub_url ); ?>" class="wgos-btn wgos-btn--outline">Zurück zum Glossar</a>
 					<a href="<?php echo esc_url( $audit_url ); ?>" class="wgos-btn wgos-btn--primary" data-track-action="cta_glossary_term_audit" data-track-category="lead_gen"><?php echo esc_html( nexus_get_audit_cta_label() ); ?></a>

--- a/blocksy-child/inc/helpers.php
+++ b/blocksy-child/inc/helpers.php
@@ -98,11 +98,11 @@ function nexus_get_public_proof_data() {
 			],
 		],
 		'ownership_sentence'  => 'Code, Inhalte, Zugänge und Setups bleiben bei Ihnen. Laufende Zusammenarbeit bedeutet Weiterentwicklung, nicht Abhängigkeit.',
-		'primary_term'        => 'WordPress als Nachfrage-System für B2B',
+		'primary_term'        => 'Eigenes Anfrage-System für Solar- und Wärmepumpen-Anbieter',
 		'framework_label'     => 'WGOS = WordPress Growth Operating System',
 		'framework_long'      => 'WordPress Growth Operating System',
 		'allowed_subterms'    => [
-			'Growth Audit',
+			'System-Diagnose',
 			'priorisierte Folgeanalyse',
 			'kontrollierte Weiterentwicklung',
 			'planbare Growth-Kapazität',
@@ -166,7 +166,7 @@ function nexus_get_public_framework_label() {
 }
 
 /**
- * Return the canonical entry CTA copy for the Growth Audit.
+ * Return the canonical entry CTA copy for the System-Diagnose.
  *
  * Keep purchase-intent copy in one place so the primary CTA label and its
  * supporting promise stay aligned across key surfaces.
@@ -181,31 +181,31 @@ function nexus_get_audit_cta_copy() {
 	}
 
 	$copy = [
-		'label'             => 'Growth Audit starten',
+		'label'             => 'System-Diagnose starten',
 		'compact_microcopy' => '60 Sek. · priorisierte Hebel · keine E-Mail',
 		'header_meta_items' => [
 			'60-Sekunden-Diagnose',
-			'WordPress- und B2B-Fokus',
+			'Fokus: Solar, Wärmepumpe, Speicher',
 		],
-		'footer_note'       => 'Growth Audit: In ca. 60 Sekunden sehen, wo Performance, Tracking, SEO und Content Nachfrage verlieren — mit priorisierten Hebeln statt generischem Score.',
+		'footer_note'       => 'System-Diagnose: In ca. 60 Sekunden sehen, wo Performance, Tracking, SEO und Content Anfragen verlieren — mit priorisierten Hebeln statt generischem Score.',
 	];
 
 	return $copy;
 }
 
 /**
- * Return the canonical primary CTA label for the Growth Audit.
+ * Return the canonical primary CTA label for the System-Diagnose.
  *
  * @return string
  */
 function nexus_get_audit_cta_label() {
 	$copy = nexus_get_audit_cta_copy();
 
-	return isset( $copy['label'] ) ? (string) $copy['label'] : 'Growth Audit starten';
+	return isset( $copy['label'] ) ? (string) $copy['label'] : 'System-Diagnose starten';
 }
 
 /**
- * Return the compact Growth Audit CTA microcopy.
+ * Return the compact System-Diagnose CTA microcopy.
  *
  * @return string
  */
@@ -216,7 +216,7 @@ function nexus_get_audit_compact_microcopy() {
 }
 
 /**
- * Return the compact metadata items used in the audit header.
+ * Return the compact metadata items used in the System-Diagnose header.
  *
  * @return array<int, string>
  */
@@ -237,7 +237,7 @@ function nexus_get_audit_header_meta_items() {
 }
 
 /**
- * Return the full Growth Audit footer note.
+ * Return the full System-Diagnose footer note.
  *
  * @return string
  */

--- a/blocksy-child/inc/llms-txt.php
+++ b/blocksy-child/inc/llms-txt.php
@@ -58,7 +58,7 @@ function nexus_get_llms_txt_sections() {
 					'description' => 'Überblick über Positionierung, Proof und primäre Einstiege.',
 				],
 				[
-					'label'       => 'Growth Audit',
+					'label'       => 'System-Diagnose',
 					'url'         => $urls['audit'] ?? home_url( '/growth-audit/' ),
 					'description' => 'Diagnose von SEO, Tracking, Performance und Conversion-Prioritäten.',
 				],
@@ -151,7 +151,7 @@ function nexus_get_llms_txt_content() {
 	$lines = [
 		'# Haşim Üner',
 		'',
-		'> Audit-first WordPress Growth Architect für B2B in Hannover. Schwerpunkte: Technical SEO, GA4/Tracking, Core Web Vitals und Conversion-Optimierung. Primärer Einstieg ist der Growth Audit.',
+		'> Architekt für eigene Anfrage-Systeme für Solar- und Wärmepumpen-Anbieter im DACH-Raum. Ablösung von Portal-Abhängigkeit durch Website, Tracking, Vorqualifizierung und Werbekanal-Steuerung als ein verbundenes System. Primärer Einstieg ist die System-Diagnose.',
 	];
 
 	foreach ( nexus_get_llms_txt_sections() as $section ) {

--- a/blocksy-child/inc/org-schema.php
+++ b/blocksy-child/inc/org-schema.php
@@ -14,10 +14,10 @@ function hu_output_schema()
         '@context' => 'https://schema.org',
         '@type'    => 'LocalBusiness',
         '@id'      => home_url('/#organization'),
-        'name'     => 'Haşim Üner – Growth Architect',
-        'alternateName' => 'Haşim Üner - WordPress Growth Architect',
+        'name'     => 'Haşim Üner – Architekt für eigene Anfrage-Systeme',
+        'alternateName' => 'Haşim Üner',
         'url'      => home_url(),
-        'description' => 'WordPress Growth Architect für B2B-Unternehmen: Positionierung, technische SEO, privacy-first Measurement und Conversion-Logik als Nachfrage-System.',
+        'description' => 'Architekt für eigene Anfrage-Systeme: Solar- und Wärmepumpen-Anbieter im DACH-Raum lösen Portal-Abhängigkeit ab und senken Leadkosten messbar — durch Website, Tracking, Vorqualifizierung und Kanal-Steuerung als ein verbundenes System.',
         'telephone'   => '+49 176 81407134',
         'email'       => 'info@hasimuener.de',
         'logo'        => function_exists( 'hu_get_brand_logo_url' ) ? hu_get_brand_logo_url() : content_url( '/uploads/2025/08/cropped-Logo-hasim-uener-1.webp' ),
@@ -92,7 +92,7 @@ function hu_output_schema()
             'itemListElement' => [
                 [
                     '@type'       => 'Offer',
-                    'name'        => 'Growth Audit',
+                    'name'        => 'System-Diagnose',
                     'description' => 'Kostenloser Ersteinstieg: persönliche Analyse der drei größten Anfragebremsen auf einer B2B-Website.',
                     'url'         => home_url('/growth-audit/'),
                 ],
@@ -142,50 +142,50 @@ function hu_output_schema()
         ],
 
         'customer-journey-audit' => [
-            'name'        => 'Growth Audit',
-            'description' => 'Persönlicher Growth Audit für B2B-Unternehmen mit WordPress: drei priorisierte Anfragebremsen, eine klare Priorität und der nächste sinnvolle Schritt.',
-            'serviceType' => 'Growth Audit',
+            'name'        => 'System-Diagnose',
+            'description' => 'Persönliche System-Diagnose für Solar- und Wärmepumpen-Anbieter: drei priorisierte Anfragebremsen, eine klare Priorität und der nächste sinnvolle Schritt.',
+            'serviceType' => 'System-Diagnose',
             'serviceOutput' => 'Persönliche Einschätzung der größten Anfragebremsen auf einer Startseite oder kaufnahen Angebotsseite',
             'offers'      => [
                 [
                     '@type'         => 'Offer',
-                    'name'          => 'Growth Audit',
+                    'name'          => 'System-Diagnose',
                     'price'         => 0,
                     'priceCurrency' => 'EUR',
                     'isAccessibleForFree' => true,
-                    'description'   => 'Kostenloser Ersteinstieg für B2B-WordPress-Seiten mit unklarer Lead-Performance'
+                    'description'   => 'Kostenloser Ersteinstieg für Solar- und Wärmepumpen-Anbieter mit unklarer Lead-Performance'
                 ]
             ]
         ],
 
         'growth-audit' => [
-            'name'        => 'Growth Audit',
-            'description' => 'Persönlicher Growth Audit für B2B-Unternehmen mit WordPress: drei priorisierte Anfragebremsen, eine klare Priorität und der nächste sinnvolle Schritt.',
-            'serviceType' => 'Growth Audit',
+            'name'        => 'System-Diagnose',
+            'description' => 'Persönliche System-Diagnose für Solar- und Wärmepumpen-Anbieter: drei priorisierte Anfragebremsen, eine klare Priorität und der nächste sinnvolle Schritt.',
+            'serviceType' => 'System-Diagnose',
             'serviceOutput' => 'Persönliche Einschätzung der größten Anfragebremsen auf einer Startseite oder kaufnahen Angebotsseite',
             'offers'      => [
                 [
                     '@type'         => 'Offer',
-                    'name'          => 'Growth Audit',
+                    'name'          => 'System-Diagnose',
                     'price'         => 0,
                     'priceCurrency' => 'EUR',
                     'isAccessibleForFree' => true,
-                    'description'   => 'Kostenloser Ersteinstieg für B2B-WordPress-Seiten mit unklarer Lead-Performance'
+                    'description'   => 'Kostenloser Ersteinstieg für Solar- und Wärmepumpen-Anbieter mit unklarer Lead-Performance'
                 ]
             ]
         ],
 
         'audit' => [
-            'name'        => 'Growth Audit',
-            'description' => 'Persönlicher Growth Audit für B2B-Unternehmen mit WordPress: drei priorisierte Anfragebremsen, eine klare Priorität und der nächste sinnvolle Schritt.',
-            'serviceType' => 'Growth Audit',
+            'name'        => 'System-Diagnose',
+            'description' => 'Persönliche System-Diagnose für Solar- und Wärmepumpen-Anbieter: drei priorisierte Anfragebremsen, eine klare Priorität und der nächste sinnvolle Schritt.',
+            'serviceType' => 'System-Diagnose',
             'serviceOutput' => 'Persönliche Einschätzung der größten Anfragebremsen auf einer Startseite oder kaufnahen Angebotsseite'
         ],
 
         '360-deep-dive' => [
-            'name'        => 'Vertiefte Folgeanalyse nach dem Growth Audit',
+            'name'        => 'Vertiefte Folgeanalyse nach der System-Diagnose',
             'description' => 'Persönliche Folgeanalyse nach dem Audit mit priorisierter Entscheidungsvorlage für Positionierung, IA, Measurement und Conversion.',
-            'serviceType' => 'Folgeanalyse nach dem Growth Audit',
+            'serviceType' => 'Folgeanalyse nach der System-Diagnose',
             'serviceOutput' => 'Priorisierte Entscheidungsvorlage für die nächsten sinnvollen Struktur- und Umsetzungsentscheidungen'
         ],
 
@@ -482,7 +482,7 @@ function hu_output_schema()
                 '@type'    => 'Person',
                 '@id'      => home_url('/uber-mich/#person'),
                 'name'     => 'Haşim Üner',
-                'jobTitle' => 'Growth Architect & Medienwissenschaftler',
+                'jobTitle' => 'Architekt für eigene Anfrage-Systeme',
                 'url'      => home_url('/uber-mich/'),
                 'image'    => hu_get_profile_image_url(),
                 'worksFor' => ['@id' => home_url('/#organization')],
@@ -490,7 +490,7 @@ function hu_output_schema()
                     'https://www.linkedin.com/in/hasim-%C3%BCner/',
                     'https://github.com/Hasim-hannover/'
                 ],
-                'description' => 'Growth Architect & Medienwissenschaftler mit Fokus auf WordPress-Systeme, technische SEO, privacy-first Measurement, Conversion-Logik und kontrollierte Weiterentwicklung für B2B-Unternehmen.'
+                'description' => 'Architekt für eigene Anfrage-Systeme mit Fokus auf Solar- und Wärmepumpen-Anbieter im DACH-Raum: Website, Tracking, Vorqualifizierung und Werbekanal-Steuerung als ein verbundenes System zur Ablösung von Portal-Abhängigkeit.'
             ];
 
             $profilePage = [
@@ -634,7 +634,7 @@ function hu_output_schema()
                 $toolParts = [
                     [
                         '@type' => 'WebPage',
-                        'name'  => 'Growth Audit',
+                        'name'  => 'System-Diagnose',
                         'description' => 'Persönlicher Diagnose-Einstieg für Nachfrage, Conversion, Tracking und Priorisierung.',
                         'url'   => home_url('/growth-audit/')
                     ],

--- a/blocksy-child/inc/review-crm.php
+++ b/blocksy-child/inc/review-crm.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Audit CRM and intake funnel for the Growth Audit.
+ * Audit CRM and intake funnel for the System-Diagnose.
  *
  * @package Blocksy_Child
  */
@@ -75,7 +75,7 @@ function nexus_get_review_primary_goal_options() {
  */
 function nexus_get_audit_request_type_options() {
 	return [
-		'growth_audit'     => 'Growth Audit',
+		'growth_audit'     => 'System-Diagnose',
 		'growth_blueprint' => 'Growth Blueprint',
 		'implementation'   => 'Umsetzung / Weiterentwicklung',
 	];
@@ -91,7 +91,7 @@ function nexus_get_energy_intake_variant_label() {
 }
 
 /**
- * Check whether the request comes from the simplified Growth Audit landing page.
+ * Check whether the request comes from the simplified System-Diagnose landing page.
  *
  * @param string $variant Intake variant slug.
  * @return bool
@@ -101,12 +101,12 @@ function nexus_is_growth_audit_simple_intake_variant( $variant ) {
 }
 
 /**
- * Return the public label for the simplified Growth Audit intake.
+ * Return the public label for the simplified System-Diagnose intake.
  *
  * @return string
  */
 function nexus_get_growth_audit_simple_intake_variant_label() {
-	return 'Growth Audit Landingpage';
+	return 'System-Diagnose Landingpage';
 }
 
 /**
@@ -766,7 +766,7 @@ function nexus_get_review_request_success_message( $payload ) {
 	$variant = isset( $payload['intake_variant'] ) ? sanitize_key( (string) $payload['intake_variant'] ) : '';
 
 	if ( 'energy_systems' === $variant ) {
-		return 'Danke. Ich prüfe Ihre Angaben als B2B-Energiesystem und melde mich mit einer priorisierten ersten Einordnung. Wenn ein Growth Audit der sinnvollste nächste Schritt ist, sehen Sie das direkt in der Rückmeldung.';
+		return 'Danke. Ich prüfe Ihre Angaben als B2B-Energiesystem und melde mich mit einer priorisierten ersten Einordnung. Wenn ein System-Diagnose der sinnvollste nächste Schritt ist, sehen Sie das direkt in der Rückmeldung.';
 	}
 
 	if ( nexus_is_growth_audit_simple_intake_variant( $variant ) ) {
@@ -1052,7 +1052,7 @@ function nexus_validate_review_request_payload( $payload ) {
 }
 
 /**
- * Validate and sanitize the simplified Growth Audit landing page payload.
+ * Validate and sanitize the simplified System-Diagnose landing page payload.
  *
  * @param array $payload Raw request payload.
  * @return array|WP_Error
@@ -1967,7 +1967,7 @@ function nexus_render_review_request_details_meta_box( $post ) {
 	<div class="nexus-review-meta">
 		<div class="nexus-review-meta-group">
 			<strong>Audit-Typ</strong>
-			<p><?php echo esc_html( $audit_type ?: 'Growth Audit' ); ?></p>
+			<p><?php echo esc_html( $audit_type ?: 'System-Diagnose' ); ?></p>
 		</div>
 		<div class="nexus-review-meta-group">
 			<strong>Unternehmen</strong>
@@ -2246,7 +2246,7 @@ function nexus_render_review_request_columns( $column, $post_id ) {
 
 	switch ( $column ) {
 		case 'audit_type':
-			echo esc_html( (string) get_post_meta( $post_id, '_nexus_review_audit_type_label', true ) ?: 'Growth Audit' );
+			echo esc_html( (string) get_post_meta( $post_id, '_nexus_review_audit_type_label', true ) ?: 'System-Diagnose' );
 			break;
 
 		case 'review_status':

--- a/blocksy-child/inc/seo-cockpit-leads.php
+++ b/blocksy-child/inc/seo-cockpit-leads.php
@@ -127,7 +127,7 @@ function nexus_get_seo_cockpit_empty_lead_metrics() {
  */
 function nexus_get_seo_cockpit_lead_source_label( $source ) {
 	$labels = [
-		'growth_audit_funnel'   => 'Growth Audit',
+		'growth_audit_funnel'   => 'System-Diagnose',
 		'energy_systems_landing' => 'Energie-Landing',
 	];
 

--- a/blocksy-child/inc/seo-meta.php
+++ b/blocksy-child/inc/seo-meta.php
@@ -109,19 +109,19 @@ function hu_get_forced_singular_seo_map() {
 			],
 			'wordpress-agentur-hannover' => [
 				'title'       => 'WordPress Agentur Hannover für B2B | Haşim Üner',
-				'description' => 'WordPress Agentur Hannover für B2B: Angebotsseiten, SEO, GA4-Tracking und Conversion-Optimierung als System. Growth Audit als Einstieg – 60 Sek., keine E-Mail.',
+				'description' => 'WordPress Agentur Hannover für B2B: Angebotsseiten, SEO, GA4-Tracking und Conversion-Optimierung als System. System-Diagnose als Einstieg – 60 Sek., keine E-Mail.',
 			],
 			'wordpress-agentur' => [
 				'title'       => 'WordPress Agentur Hannover für B2B | Haşim Üner',
-				'description' => 'WordPress Agentur Hannover für B2B: Angebotsseiten, SEO, GA4-Tracking und Conversion-Optimierung als System. Growth Audit als Einstieg – 60 Sek., keine E-Mail.',
+				'description' => 'WordPress Agentur Hannover für B2B: Angebotsseiten, SEO, GA4-Tracking und Conversion-Optimierung als System. System-Diagnose als Einstieg – 60 Sek., keine E-Mail.',
 			],
 			'ergebnisse' => [
 				'title'       => 'Ergebnisse & Case Studies | WordPress, SEO, CRO',
 				'description' => 'Ergebnisse aus WordPress-, SEO-, Tracking- und CRO-Projekten: E3, DOMDAR und Whitelabel-Proof mit klarem naechsten Schritt.',
 			],
 			'growth-audit' => [
-				'title'       => 'Growth Audit für WordPress-B2B | Haşim Üner',
-				'description' => 'In 60 Sekunden sehen Sie, wo Ihre WordPress-Website Nachfrage verliert. Diagnose für Performance, Tracking, SEO und Content mit priorisierten Hebeln statt Tool-Score.',
+				'title'       => 'System-Diagnose für Solar- und Wärmepumpen-Anbieter | Haşim Üner',
+				'description' => 'In 60 Sekunden sehen Sie, wo Ihre Website Anfragen verliert. Diagnose für Performance, Tracking, SEO und Content mit priorisierten Hebeln statt Tool-Score.',
 			],
 			'case-studies-e-commerce' => [
 				'title'       => 'Ergebnisse & Case Studies | WordPress, SEO, CRO',
@@ -141,7 +141,7 @@ function hu_get_forced_singular_seo_map() {
 			],
 			'wordpress-seo-hannover' => [
 				'title'       => 'WordPress SEO Hannover für B2B | Technisches SEO & Audit',
-				'description' => 'WordPress SEO in Hannover fuer B2B: technisches SEO, Crawlability und interne Verlinkung fuer kaufnahe Seiten. Growth Audit als 60-Sekunden-Diagnose fuer priorisierte Hebel.',
+				'description' => 'WordPress SEO in Hannover fuer B2B: technisches SEO, Crawlability und interne Verlinkung fuer kaufnahe Seiten. System-Diagnose als 60-Sekunden-Diagnose fuer priorisierte Hebel.',
 			],
 			'ki-integration-wordpress' => [
 				'title'       => 'KI-Integration für WordPress – DSGVO-konform | Haşim Üner',
@@ -492,7 +492,7 @@ function hu_document_title_overrides( $parts ) {
 	}
 
 	if ( hu_is_audit_offer_page() ) {
-		$parts['title'] = 'Kostenloser Growth Audit | Hasim Üner — WordPress Growth Architect';
+		$parts['title'] = 'Kostenlose System-Diagnose | Haşim Üner';
 		return $parts;
 	}
 
@@ -781,8 +781,8 @@ function hu_get_seo_meta() {
 		}
 
 		if ( hu_is_audit_offer_page() ) {
-			$meta['og_title']    = 'Growth Audit für WordPress-B2B | Haşim Üner';
-			$meta['description'] = 'In 60 Sekunden sehen Sie, wo Ihre WordPress-Website Nachfrage verliert. Diagnose für Performance, Tracking, SEO und Content mit priorisierten Hebeln statt Tool-Score.';
+			$meta['og_title']    = 'System-Diagnose für Solar- und Wärmepumpen-Anbieter | Haşim Üner';
+			$meta['description'] = 'In 60 Sekunden sehen Sie, wo Ihre Website Anfragen verliert. Diagnose für Performance, Tracking, SEO und Content mit priorisierten Hebeln statt Tool-Score.';
 		}
 
 		if ( hu_is_domdar_case_study_page() ) {

--- a/blocksy-child/inc/shortcodes.php
+++ b/blocksy-child/inc/shortcodes.php
@@ -256,7 +256,7 @@ function hu_hero_section_shortcode() {
 			<div class="wp-container">
 				<div class="wp-hero-grid">
 					<div class="wp-hero-copy">
-						<span class="wp-badge nx-reveal">WordPress Growth Architect für B2B</span>
+						<span class="wp-badge nx-reveal">Architekt für eigene Anfrage-Systeme</span>
 						<h1 class="wp-hero-title nx-reveal">
 							Ich mache aus Ihrer<br><span>WordPress-Website ein planbares Nachfrage-System.</span>
 						</h1>
@@ -289,7 +289,7 @@ function hu_hero_section_shortcode() {
 					<div class="wp-hero-panel nx-reveal">
 						<div class="audit-card-premium" id="audit">
 							<div class="audit-card-premium__intro">
-								<span class="audit-card-premium__eyebrow">Growth Audit</span>
+								<span class="audit-card-premium__eyebrow">System-Diagnose</span>
 							</div>
 							<h2 class="audit-card-premium__title">Erster Schritt: Diagnose statt Pitch</h2>
 							<p class="audit-card-premium__copy">
@@ -512,7 +512,7 @@ function hu_wgos_block_shortcode() {
 			<div class="wp-process">
 				<div class="wp-step nx-reveal">
 					<div class="wp-step-num">1</div>
-					<h3>Growth Audit</h3>
+					<h3>System-Diagnose</h3>
 					<p>Der niedrigschwellige Einstieg. Wir machen sichtbar, wo Sichtbarkeit, Vertrauen, Datenqualität oder Lead-Capture wegbrechen und ob sich ein tieferer Eingriff lohnt.</p>
 				</div>
 				<div class="wp-step highlight-step nx-reveal">
@@ -705,7 +705,7 @@ function hu_faq_section_shortcode() {
 				</details>
 				<details class="nx-faq__item nx-reveal">
 					<summary>Wie startet die Zusammenarbeit?</summary>
-					<div class="nx-faq__content">Mit dem Growth Audit. Danach gibt es eine klare Priorität und den nächsten sinnvollen Schritt. Größere Folgeprojekte ergeben sich erst nach der Rückmeldung und persönlichem Kontakt.</div>
+					<div class="nx-faq__content">Mit der System-Diagnose. Danach gibt es eine klare Priorität und den nächsten sinnvollen Schritt. Größere Folgeprojekte ergeben sich erst nach der Rückmeldung und persönlichem Kontakt.</div>
 				</details>
 			</div>
 		</div>
@@ -808,7 +808,7 @@ function hu_cta_section_shortcode() {
 			<div class="nx-cta-box nx-reveal">
 				<span class="nx-badge nx-badge--gold" style="display:inline-block; margin-bottom:1.5rem;">Nächster Schritt</span>
 				<h2 id="cta-heading" style="font-size:clamp(1.8rem,3vw,2.4rem); margin-bottom:1rem; color:#fff;">Prüfen wir, wo Ihre WordPress-Seite Anfragen verliert.</h2>
-				<p>Im Growth Audit sehen Sie, wo Sichtbarkeit, Vertrauen, Datensignale oder Conversion wegbrechen und ob Ihre Website heute schon als Plattform trägt.</p>
+				<p>Im System-Diagnose sehen Sie, wo Sichtbarkeit, Vertrauen, Datensignale oder Conversion wegbrechen und ob Ihre Website heute schon als Plattform trägt.</p>
 
 				<div role="group" aria-label="Audit-Merkmale" style="display:flex; flex-wrap:wrap; justify-content:center; gap:0.75rem 1.5rem; margin-bottom:2rem;">
 					<span style="font-size:0.85rem; color:var(--nx-text-muted);">✓ klare Einschätzung statt Bauchgefühl</span>

--- a/blocksy-child/inc/tools-page.php
+++ b/blocksy-child/inc/tools-page.php
@@ -26,7 +26,7 @@ function nexus_get_tools_hub_items() {
 	return [
 		[
 			'eyebrow'      => 'Diagnose',
-			'title'        => 'Growth Audit',
+			'title'        => 'System-Diagnose',
 			'description'  => 'Wenn zuerst klar werden soll, wo Positionierung, Proof, CTA oder Tracking auf einer konkreten Seite Nachfrage verlieren.',
 			'use_case'     => 'Eine Seite wirtschaftlich priorisieren statt mehrere Symptome parallel zu behandeln.',
 			'outcome'      => 'Schriftliche Rückmeldung in 48 Stunden mit stärkster Bremse, Priorität und nächstem sinnvollen Schritt.',

--- a/blocksy-child/inc/wgos-asset-registry-data.php
+++ b/blocksy-child/inc/wgos-asset-registry-data.php
@@ -2,21 +2,21 @@
 
 return [
 	'growth-audit' => [
-		'title'           => 'Growth Audit',
+		'title'           => 'System-Diagnose',
 		'slug'            => 'growth-audit',
 		'status'          => 'publish',
 		'core_area'       => 'Strategie',
 		'credits'         => '10',
-		'keyword'         => 'Growth Audit',
-		'excerpt'         => 'Der Growth Audit zeigt, welche Bremsen Ihre WordPress-Seite zuerst lösen muss.',
+		'keyword'         => 'System-Diagnose',
+		'excerpt'         => 'Die System-Diagnose zeigt, welche Bremsen Ihre WordPress-Seite zuerst lösen muss.',
 		'goal'            => 'Prioritäten für Wachstum, Technik, Messbarkeit und Conversion sauber festlegen.',
 		'result'          => 'Sie erhalten eine priorisierte Einschätzung mit klaren nächsten Schritten.',
 		'prerequisite'    => 'Keine - Einstiegs-Asset',
-		'seo_title'       => 'Growth Audit - WGOS Asset | Haşim Üner',
-		'seo_description' => 'Growth Audit für B2B-WordPress-Seiten: Engpässe priorisieren, Reihenfolge klären und den richtigen nächsten Schritt wählen.',
+		'seo_title'       => 'System-Diagnose - WGOS Asset | Haşim Üner',
+		'seo_description' => 'System-Diagnose für B2B-WordPress-Seiten: Engpässe priorisieren, Reihenfolge klären und den richtigen nächsten Schritt wählen.',
 		'problem'         => [
 			'Viele Teams spüren, dass die Website nicht sauber liefert, können die Ursache aber nicht priorisieren. Dann laufen Technik, Tracking, Inhalte und Conversion nebeneinander her.',
-			'Der Growth Audit schafft zuerst Ordnung. Sie sehen, welcher Engpass heute Leads, Datenqualität oder Sichtbarkeit am stärksten bremst.',
+			'Die System-Diagnose schafft zuerst Ordnung. Sie sehen, welcher Engpass heute Leads, Datenqualität oder Sichtbarkeit am stärksten bremst.',
 		],
 		'deliverables'    => [
 			[
@@ -37,7 +37,7 @@ return [
 			],
 		],
 		'system_context'  => [
-			'Der Growth Audit steht ganz am Anfang der WGOS-Reihenfolge. Er schafft die gemeinsame Diagnose, auf der Positionierungs-Check, CWV Speed Audit oder Tracking Audit sinnvoll priorisiert werden können.',
+			'Die System-Diagnose steht ganz am Anfang der WGOS-Reihenfolge. Er schafft die gemeinsame Diagnose, auf der Positionierungs-Check, CWV Speed Audit oder Tracking Audit sinnvoll priorisiert werden können.',
 			'Ohne diese Vorarbeit werden Maßnahmen schnell politisch statt systemisch entschieden. Mit dem Audit wird aus einer losen Aufgabenliste eine belastbare Reihenfolge.',
 		],
 		'priority'        => [
@@ -62,7 +62,7 @@ return [
 		'excerpt'         => 'Der Positionierungs-Check prüft, ob Angebot, Zielgruppe und Nutzenversprechen auf der Website klar genug sind.',
 		'goal'            => 'Angebot, Nutzenversprechen und Zielgruppe so schärfen, dass die Website nicht beliebig wirkt.',
 		'result'          => 'Sie erhalten eine klare Positionierungsdiagnose mit konkreter Korrekturrichtung.',
-		'prerequisite'    => 'Growth Audit ist sinnvoll, aber nicht zwingend',
+		'prerequisite'    => 'System-Diagnose ist sinnvoll, aber nicht zwingend',
 		'seo_title'       => 'Positionierungs-Check - WGOS Asset | Haşim Üner',
 		'seo_description' => 'Positionierungs-Check für B2B-WordPress-Seiten: Angebot schärfen, Missverständnisse abbauen und Message-Match verbessern.',
 		'problem'         => [
@@ -88,7 +88,7 @@ return [
 			],
 		],
 		'system_context'  => [
-			'Der Positionierungs-Check gehört in der Strategiephase früh nach vorne, weil unklare Botschaften spätere SEO-, Landing-Page- und CRO-Arbeit ausbremsen. Er setzt nicht zwingend andere Assets voraus, ist aber nach dem Growth Audit deutlich zielgerichteter.',
+			'Der Positionierungs-Check gehört in der Strategiephase früh nach vorne, weil unklare Botschaften spätere SEO-, Landing-Page- und CRO-Arbeit ausbremsen. Er setzt nicht zwingend andere Assets voraus, ist aber nach der System-Diagnose deutlich zielgerichteter.',
 			'Wenn die Positionierung steht, werden Seitenrollen-Mapping, Wettbewerbs-Analyse und Keyword-Strategie erheblich präziser. Erst dann greifen Inhalte, Proof und Conversion sauber ineinander.',
 		],
 		'priority'        => [
@@ -215,7 +215,7 @@ return [
 		'excerpt'         => 'Roadmap & Priorisierung bringt WGOS-Assets in eine Reihenfolge, die wirklich wirkt.',
 		'goal'            => 'Die richtigen Bausteine nach Impact, Abhängigkeit und Umsetzbarkeit staffeln.',
 		'result'          => 'Sie erhalten eine abgestimmte Umsetzungsroadmap statt einer losen Wunschliste.',
-		'prerequisite'    => 'Growth Audit oder klare Discovery sollte abgeschlossen sein',
+		'prerequisite'    => 'System-Diagnose oder klare Discovery sollte abgeschlossen sein',
 		'seo_title'       => 'Roadmap Priorisierung - WGOS Asset | Haşim Üner',
 		'seo_description' => 'Roadmap & Priorisierung für WGOS: Maßnahmen nach Impact, Abhängigkeiten und Teamkapazität sauber staffeln.',
 		'problem'         => [
@@ -241,7 +241,7 @@ return [
 			],
 		],
 		'system_context'  => [
-			'Roadmap & Priorisierung steht in WGOS zwischen Diagnose und Umsetzung. Sie setzt meist auf Growth Audit, Positionierungs-Check oder Discovery-Ergebnissen auf und übersetzt diese in einen belastbaren Arbeitsplan.',
+			'Roadmap & Priorisierung steht in WGOS zwischen Diagnose und Umsetzung. Sie setzt meist auf System-Diagnose, Positionierungs-Check oder Discovery-Ergebnissen auf und übersetzt diese in einen belastbaren Arbeitsplan.',
 			'Danach können einzelne Assets wie CWV Speed Audit, Tracking Audit oder Landing Page Neu ohne Richtungsverlust umgesetzt werden. Die Roadmap ist damit das Bindeglied zwischen Einsicht und Ausführung.',
 		],
 		'priority'        => [
@@ -266,7 +266,7 @@ return [
 		'excerpt'         => 'Der CWV Speed Audit zeigt, was Ihre WordPress-Seite langsam macht und wo der Hebel wirklich liegt.',
 		'goal'            => 'Performance-Bremsen sichtbar machen, die Ladezeit, Rankings und Nutzererlebnis schädigen.',
 		'result'          => 'Sie erhalten eine priorisierte Performance-Diagnose mit klaren Optimierungsfeldern.',
-		'prerequisite'    => 'Growth Audit oder klare Priorisierung liegt vor',
+		'prerequisite'    => 'System-Diagnose oder klare Priorisierung liegt vor',
 		'seo_title'       => 'CWV Speed Audit - WGOS Asset | Haşim Üner',
 		'seo_description' => 'CWV Speed Audit für WordPress: Ladezeitbremsen finden, Prioritäten setzen und die Basis für Rankings und Conversion stärken.',
 		'problem'         => [
@@ -292,7 +292,7 @@ return [
 			],
 		],
 		'system_context'  => [
-			'Der CWV Speed Audit gehört früh ins technische Fundament und kommt oft direkt nach Growth Audit oder Roadmap. Er schafft die Diagnose, auf der CWV Optimierung und Server-Tuning sauber aufsetzen.',
+			'Der CWV Speed Audit gehört früh ins technische Fundament und kommt oft direkt nach System-Diagnose oder Roadmap. Er schafft die Diagnose, auf der CWV Optimierung und Server-Tuning sauber aufsetzen.',
 			'Wenn die Performance-Basis steht, profitieren danach auch Technical SEO Audit, Landing Pages und Conversion-Arbeit. Langsame Seiten bremsen sonst jede spätere Investition aus.',
 		],
 		'priority'        => [
@@ -573,7 +573,7 @@ return [
 		'excerpt'         => 'Der Tracking Audit zeigt, ob Ihre Datenbasis für Entscheidungen überhaupt belastbar ist.',
 		'goal'            => 'Fehler in Tracking, Events, Attribution und Consent sichtbar machen, bevor falsche Entscheidungen darauf aufbauen.',
 		'result'          => 'Sie erhalten eine priorisierte Tracking-Diagnose mit konkreten Fixes und Folgeempfehlungen.',
-		'prerequisite'    => 'Growth Audit oder klare Priorisierung liegt vor',
+		'prerequisite'    => 'System-Diagnose oder klare Priorisierung liegt vor',
 		'seo_title'       => 'Tracking Audit - WGOS Asset | Haşim Üner',
 		'seo_description' => 'Tracking Audit für B2B-Websites: Messfehler finden, Datenqualität absichern und die Basis für Reporting und Optimierung legen.',
 		'problem'         => [

--- a/blocksy-child/inc/wgos-asset-registry.php
+++ b/blocksy-child/inc/wgos-asset-registry.php
@@ -466,7 +466,7 @@ function nexus_get_wgos_asset_content_html( $asset ) {
 			<div class="wgos-asset-cta-card">
 				<span class="wgos-principle-kicker">Nächster Schritt</span>
 				<h2 class="wgos-h2">Prüfen, ob dieses Asset jetzt Priorität hat.</h2>
-				<p class="wgos-section-intro">Der Growth Audit zeigt, ob dieses Asset jetzt Priorität hat - oder ob ein anderer Baustein zuerst dran ist.</p>
+				<p class="wgos-section-intro">Die System-Diagnose zeigt, ob dieses Asset jetzt Priorität hat - oder ob ein anderer Baustein zuerst dran ist.</p>
 				<div class="wgos-hero__actions">
 					<a href="<?php echo esc_url( $audit_url ); ?>" class="wgos-btn wgos-btn--primary" data-track-action="cta_wgos_asset_content_audit" data-track-category="lead_gen"><?php echo esc_html( nexus_get_audit_cta_label() ); ?></a>
 					<a href="<?php echo esc_url( $calendar_url ); ?>" class="wgos-btn wgos-btn--outline" data-track-action="cta_wgos_asset_content_calendar" data-track-category="lead_gen">Strategiegespräch vereinbaren</a>

--- a/blocksy-child/inc/wgos-cluster-pages.php
+++ b/blocksy-child/inc/wgos-cluster-pages.php
@@ -79,7 +79,7 @@ function nexus_get_wgos_cluster_page_data() {
 				],
 			],
 			'meta_title'       => 'WordPress SEO Hannover für B2B | Technisches SEO & Audit',
-			'meta_description' => 'WordPress SEO in Hannover fuer B2B: technisches SEO, Crawlability und interne Verlinkung fuer kaufnahe Seiten. Growth Audit als 60-Sekunden-Diagnose fuer priorisierte Hebel.',
+			'meta_description' => 'WordPress SEO in Hannover fuer B2B: technisches SEO, Crawlability und interne Verlinkung fuer kaufnahe Seiten. System-Diagnose als 60-Sekunden-Diagnose fuer priorisierte Hebel.',
 			'schema_name'      => 'WordPress SEO Hannover – technisch sauber, messbar, B2B-ready',
 			'schema_description' => 'WGOS-Cluster für technisches SEO auf WordPress in Hannover: technische Basis, Seitenstruktur und conversion-nahe Sichtbarkeit für B2B-Websites.',
 		],
@@ -500,7 +500,7 @@ function nexus_get_wgos_cluster_page_proof_metrics() {
 		],
 		[
 			'value' => '60 Sek.',
-			'label' => 'Diagnose-Einstieg mit priorisierten Hebeln im Growth Audit',
+			'label' => 'Diagnose-Einstieg mit priorisierten Hebeln in der System-Diagnose',
 		],
 		[
 			'value' => '3 Proof-Routen',
@@ -549,7 +549,7 @@ function nexus_render_wgos_cluster_page( $page ) {
 	$method_steps  = nexus_get_wgos_cluster_page_method_steps();
 	$proof_note    = isset( $page['proof_note'] ) ? (string) $page['proof_note'] : '';
 	$proof_links   = isset( $page['proof_links'] ) && is_array( $page['proof_links'] ) ? $page['proof_links'] : [];
-	$audit_cta_label         = function_exists( 'nexus_get_audit_cta_label' ) ? nexus_get_audit_cta_label() : 'Growth Audit starten';
+	$audit_cta_label         = function_exists( 'nexus_get_audit_cta_label' ) ? nexus_get_audit_cta_label() : 'System-Diagnose starten';
 	$audit_compact_microcopy = function_exists( 'nexus_get_audit_compact_microcopy' ) ? nexus_get_audit_compact_microcopy() : '60 Sek. · priorisierte Hebel · keine E-Mail';
 
 	ob_start();
@@ -650,7 +650,7 @@ function nexus_render_wgos_cluster_page( $page ) {
 						echo esc_html(
 							'' !== $proof_note
 								? $proof_note
-								: 'Wenn Sie die öffentlichen Beispiele und die Herleitung dazu sehen wollen, gehen Sie zuerst in die Ergebnisse. Der Growth Audit klärt danach, welche dieser Hebel in Ihrer Lage wirklich zuerst zählen.'
+								: 'Wenn Sie die öffentlichen Beispiele und die Herleitung dazu sehen wollen, gehen Sie zuerst in die Ergebnisse. Die System-Diagnose klärt danach, welche dieser Hebel in Ihrer Lage wirklich zuerst zählen.'
 						);
 						?>
 					</p>
@@ -751,7 +751,7 @@ function nexus_render_wgos_cluster_page( $page ) {
 				<div class="nx-card nx-card--flat nx-cluster-cta">
 					<span class="nx-cluster-cta__kicker">Nächster Schritt</span>
 					<h2 class="nx-headline-section">Erst die Lage klären. Dann den richtigen Baustein priorisieren.</h2>
-					<p>Der Growth Audit zeigt, ob dieses Cluster jetzt dran ist oder ob Fundament, Messbarkeit oder Angebotslogik zuerst korrigiert werden müssen.</p>
+					<p>Die System-Diagnose zeigt, ob dieses Cluster jetzt dran ist oder ob Fundament, Messbarkeit oder Angebotslogik zuerst korrigiert werden müssen.</p>
 					<div class="nx-cluster-hero__actions">
 						<a href="<?php echo esc_url( $audit_url ); ?>" class="nx-btn nx-btn--primary" data-track-action="cta_cluster_footer_audit" data-track-category="lead_gen"><?php echo esc_html( $audit_cta_label ); ?></a>
 						<a href="<?php echo esc_url( $asset_hub_url ); ?>" class="nx-btn nx-btn--ghost">Alle WGOS-Assets ansehen</a>

--- a/blocksy-child/page-360-deep-dive.php
+++ b/blocksy-child/page-360-deep-dive.php
@@ -17,10 +17,10 @@ $audit_url = nexus_get_audit_url();
 
 	<!-- 1. HERO SECTION -->
 	<section class="deepdive-hero">
-		<span class="deepdive-pill">Nur nach Audit und Kontakt</span>
-		<h1 class="deepdive-hero-title">Vertiefte Folgeanalyse nach dem Growth Audit</h1>
+		<span class="deepdive-pill">Nur nach System-Diagnose und Kontakt</span>
+		<h1 class="deepdive-hero-title">Vertiefte Folgeanalyse nach der System-Diagnose</h1>
 		<p class="deepdive-hero-sub">
-			Sie kennen die groben Engpässe aus dem Growth Audit.<br>
+			Sie kennen die groben Engpässe aus der System-Diagnose.<br>
 			Mit wenigen gezielten Angaben verdichte ich das Bild zu einer persönlichen Analyse<br>
 			mit klarer Reihenfolge statt losem Maßnahmenstapel.
 		</p>
@@ -79,13 +79,13 @@ $audit_url = nexus_get_audit_url();
 	<section class="deepdive-alt-cta">
 			<p class="deepdive-alt-label">Wenn der Kontext doch noch sortiert werden soll:</p>
 			<a href="<?php echo esc_url( $audit_url ); ?>" class="deepdive-alt-link">
-			-> Erst den Growth Audit starten
+			-> Erst die System-Diagnose starten
 			</a>
 		</section>
 
 	<!-- 6. RÜCKLINK ZUM CJA -->
 	<section class="deepdive-cja-link">
-			<p class="deepdive-cja-label">Noch keinen Growth Audit gemacht?</p>
+			<p class="deepdive-cja-label">Noch keine System-Diagnose gemacht?</p>
 			<a href="<?php echo esc_url( $audit_url ); ?>" class="deepdive-cja-btn">
 			-> Erst mit dem Audit starten
 			</a>

--- a/blocksy-child/page-audit.php
+++ b/blocksy-child/page-audit.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Template Name: Growth Audit
- * Description: Landing Page für den instantanen Growth Audit mit Sofort-Ergebnis
+ * Template Name: System-Diagnose
+ * Description: Landing Page für den instantanen System-Diagnose mit Sofort-Ergebnis
  *
  * SEO-Meta: zentral in inc/seo-meta.php (ACF-Felder: seo_title, seo_description, og_image)
  *

--- a/blocksy-child/page-case-e3.php
+++ b/blocksy-child/page-case-e3.php
@@ -575,7 +575,7 @@ $energy_url  = function_exists( 'nexus_get_energy_systems_url' ) ? nexus_get_ene
                     Die Ergebnisse entstanden in einem Setup für KMU + B2C mit
                     klarer Leistungsfähigkeit und belastbaren internen Prozessen.
                     Besonders relevant wird das Modell ab etwa &gt;5 Mio.&nbsp;€ Jahresumsatz.
-                    Ob ähnliche Hebel bei Ihnen vorhanden sind, zeigt der Growth Audit
+                    Ob ähnliche Hebel bei Ihnen vorhanden sind, zeigt die System-Diagnose
                     klar priorisiert und ohne Pitch.
                 </div>
             </details>
@@ -652,7 +652,7 @@ $energy_url  = function_exists( 'nexus_get_energy_systems_url' ) ? nexus_get_ene
                 Welche Hebel liegen bei Ihnen brach?
             </h2>
             <p style="color:var(--nx-text-muted);max-width:560px;margin:0 auto 2rem;line-height:1.6;">
-                Im Growth Audit analysieren wir Ihre WordPress-Präsenz
+                In der System-Diagnose analysieren wir Ihre Website
                 auf die größten Wachstumspotenziale&nbsp;— klar priorisiert und ohne Pitch.
             </p>
 

--- a/blocksy-child/page-case-study-domdar.php
+++ b/blocksy-child/page-case-study-domdar.php
@@ -202,7 +202,7 @@ $faq_items = [
 $author_points = [
 	'Ich optimiere keine hübschen Oberflächen, sondern Nachfrage-Systeme mit klarer wirtschaftlicher Funktion.',
 	'WordPress, CRO, Performance und Prozesse greifen bei mir als ein Verbund statt als getrennte Disziplinen.',
-	'Der Einstieg bleibt bewusst diagnosegetrieben: erst der Growth Audit, dann Prioritäten und erst danach Umsetzung.',
+	'Der Einstieg bleibt bewusst diagnosegetrieben: erst die System-Diagnose, dann Prioritäten und erst danach Umsetzung.',
 ];
 
 get_header();
@@ -469,7 +469,7 @@ get_header();
 				</div>
 				<div class="cs-domdar-portrait-meta">
 					<span class="cs-domdar-portrait-label">Haşim Üner</span>
-					<span class="cs-domdar-portrait-text">Growth Architect für WordPress, CRO, Performance und systemische Nachfrage-Logik</span>
+					<span class="cs-domdar-portrait-text">Architekt für eigene Anfrage-Systeme: Solar, Wärmepumpe und systemische Nachfrage-Logik</span>
 				</div>
 			</div>
 
@@ -539,7 +539,7 @@ get_header();
 				Welche Reibung kostet Sie gerade Marge?
 			</h2>
 			<p style="color:var(--nx-text-muted);max-width:560px;margin:0 auto 2rem;line-height:1.6;">
-				Im Growth Audit sehen Sie, wo Warenkorb, Conversion oder operative
+				Im System-Diagnose sehen Sie, wo Warenkorb, Conversion oder operative
 				Prozesse aktuell Ertrag kosten und welche Reihenfolge für Ihr Setup
 				wirklich Sinn ergibt.
 			</p>
@@ -558,7 +558,7 @@ get_header();
 			<div class="cs-internal-links">
 				<a href="<?php echo esc_url( $cases_url ); ?>" class="cs-internal-link">Weitere Ergebnisse</a>
 				<a href="<?php echo esc_url( $wgos_url ); ?>" class="cs-internal-link">WGOS: Das System dahinter</a>
-				<a href="<?php echo esc_url( $local_wp_url ); ?>" class="cs-internal-link">WordPress Growth Architect</a>
+				<a href="<?php echo esc_url( $local_wp_url ); ?>" class="cs-internal-link">WordPress Agentur Hannover</a>
 			</div>
 		</div>
 

--- a/blocksy-child/page-datenschutz.php
+++ b/blocksy-child/page-datenschutz.php
@@ -418,7 +418,7 @@ while ( have_posts() ) :
 
 						<h3>Growth-Audit-Anfrage</h3>
 						<p>
-							Auf der Seite zum Growth Audit können Sie eine Anfrage stellen. Dabei werden
+							Auf der Seite zur System-Diagnose können Sie eine Anfrage stellen. Dabei werden
 							insbesondere Name, geschäftliche E-Mail-Adresse, Unternehmen, URL der zu
 							prüfenden Seite sowie Ihre inhaltlichen Angaben zur Anfrage verarbeitet.
 						</p>

--- a/blocksy-child/page-glossar.php
+++ b/blocksy-child/page-glossar.php
@@ -36,7 +36,7 @@ $hub_sections = function_exists( 'nexus_get_glossary_hub_sections' ) ? nexus_get
 
 						<div class="wgos-hero__actions">
 							<a href="<?php echo esc_url( $wgos_url ); ?>" class="wgos-btn wgos-btn--outline">Zum WGOS-System</a>
-							<a href="<?php echo esc_url( $audit_url ); ?>" class="wgos-btn wgos-btn--primary" data-track-action="cta_glossary_hub_audit" data-track-category="lead_gen">Mit dem Growth Audit starten</a>
+							<a href="<?php echo esc_url( $audit_url ); ?>" class="wgos-btn wgos-btn--primary" data-track-action="cta_glossary_hub_audit" data-track-category="lead_gen">Mit der System-Diagnose starten</a>
 						</div>
 
 						<p class="wgos-hero__microcopy">Glossar bedeutet hier nicht „zweites Lexikon neben dem Angebot“, sondern ein kontrollierter Begriffs-Layer mit klarer Rückführung auf die richtige Seite.</p>

--- a/blocksy-child/page-ki-integration.php
+++ b/blocksy-child/page-ki-integration.php
@@ -131,7 +131,7 @@ $faq_items = [
 	],
 	[
 		'question' => 'Welcher KI-Baustein ist der richtige für mich?',
-		'answer'   => 'Das klärt der Growth Audit. Die Empfehlung hängt davon ab, wo Ihre Website heute steht und welches Problem zuerst gelöst werden soll.',
+		'answer'   => 'Das klärt die System-Diagnose. Die Empfehlung hängt davon ab, wo Ihre Website heute steht und welches Problem zuerst gelöst werden soll.',
 	],
 ];
 
@@ -384,7 +384,7 @@ foreach ( $faq_items as $faq_item ) {
 				<div class="wgos-asset-hub-bridge">
 					<div class="wgos-note-card">
 						<h3>WGOS verstehen</h3>
-						<p>Die KI-Bausteine sind Teil eines größeren Systems mit sechs Modulen und drei Phasen. Der Growth Audit klärt, welcher Baustein zuerst Sinn macht.</p>
+						<p>Die KI-Bausteine sind Teil eines größeren Systems mit sechs Modulen und drei Phasen. Die System-Diagnose klärt, welcher Baustein zuerst Sinn macht.</p>
 						<a href="<?php echo esc_url( $wgos_url ); ?>" class="wgos-link--arrow">WordPress Growth Operating System ansehen</a>
 					</div>
 				</div>
@@ -424,7 +424,7 @@ foreach ( $faq_items as $faq_item ) {
 						<span class="wgos-principle-kicker">Nächster Schritt</span>
 						<h2 class="wgos-h2">Prüfen wir, ob KI auf Ihrer WordPress-Seite heute Sinn macht.</h2>
 						<div class="wgos-prose">
-							<p>Der Growth Audit zeigt, wo Ihre Website steht, welcher Engpass zuerst gelöst werden muss und ob KI dabei eine Rolle spielt. Persönliche Rückmeldung in 48 Stunden.</p>
+							<p>Die System-Diagnose zeigt, wo Ihre Website steht, welcher Engpass zuerst gelöst werden muss und ob KI dabei eine Rolle spielt. Persönliche Rückmeldung in 48 Stunden.</p>
 						</div>
 
 						<div class="wgos-hero__actions">

--- a/blocksy-child/page-kontakt.php
+++ b/blocksy-child/page-kontakt.php
@@ -61,7 +61,7 @@ $type_copy_map         = [
 		'message_label'       => 'Kurzbeschreibung',
 		'message_help'        => 'Welche URL ist relevant? Was ist unklar? Welches Ergebnis wünschen Sie sich?',
 		'message_placeholder' => "1. Seite: Welche URL ist relevant?\n2. Unklarheit: Was bremst gerade?\n3. Ziel: Was soll sich verbessern?",
-		'submit_label'        => 'Growth Audit anfragen',
+		'submit_label'        => 'System-Diagnose anfragen',
 		'timeline_label'      => 'Zeitfenster',
 	],
 	'analysis'       => [
@@ -124,10 +124,10 @@ $is_scoped_landing     = $has_explicit_type && ! $is_general_type && ! $is_clien
 $current_type_label    = isset( $request_type_options[ $selected_type ]['label'] ) ? (string) $request_type_options[ $selected_type ]['label'] : 'Kontakt';
 
 $hero_eyebrow = $is_scoped_landing ? $current_type_label : 'Kontakt';
-$hero_title   = $is_scoped_landing ? $current_type_label : 'Growth Audit, Folgeanalyse oder Weiterentwicklung.';
+$hero_title   = $is_scoped_landing ? $current_type_label : 'System-Diagnose, Folgeanalyse oder Weiterentwicklung.';
 $hero_lead    = $is_scoped_landing
 	? 'Beschreiben Sie Ihr Anliegen in wenigen Feldern. Sie erhalten eine persönliche Einschätzung und eine saubere Einordnung ohne Sales-Nebel.'
-	: 'Ein zentraler Einstieg für Growth Audit, fokussierte Folgeanalyse, Umsetzung / Optimierung, laufende Weiterentwicklung, allgemeine Anfragen und Bestandskunden.';
+	: 'Ein zentraler Einstieg für System-Diagnose, fokussierte Folgeanalyse, Umsetzung / Optimierung, laufende Weiterentwicklung, allgemeine Anfragen und Bestandskunden.';
 $hero_cta     = $is_scoped_landing ? 'Anfrage ausfüllen' : 'Anfrage starten';
 
 $auto_scroll  = $has_explicit_type || '' !== $selected_focus;

--- a/blocksy-child/page-loesungen.php
+++ b/blocksy-child/page-loesungen.php
@@ -24,7 +24,7 @@ get_header();
 			<h1 style="margin:1rem 0 1rem;">Drei Schritte. Ein klarer Einstieg.</h1>
 			<p style="font-size:1.12rem; color:#64748b; line-height:1.7;">
 				Diese Seite ist keine Leistungsbibliothek. Sie zeigt den sinnvollen Weg,
-				mit dem aus einer WordPress-Präsenz ein planbares Anfrage- und Wachstumssystem wird. Der öffentliche Fokus bleibt bewusst auf dem Growth Audit.
+				mit dem aus Ihrer Website ein planbares Anfrage-System wird. Der öffentliche Fokus bleibt bewusst auf der System-Diagnose.
 			</p>
 		</div>
 
@@ -32,22 +32,22 @@ get_header();
 			<ul style="display:grid; grid-template-columns:repeat(auto-fit,minmax(280px,1fr)); gap:1.5rem; list-style:none; padding:0; margin:0;">
 				<li class="solution-item">
 					<a href="<?php echo esc_url( $audit_url ); ?>">
-						<h2>1. Growth Audit</h2>
-						<p>Diagnose-Einstieg für B2B-Unternehmen mit bestehender WordPress-Seite. Wir machen sichtbar, wo Sichtbarkeit, Vertrauen oder Conversion wegbrechen.</p>
-						<span class="cta-btn">Audit starten</span>
+						<h2>1. System-Diagnose</h2>
+						<p>Diagnose-Einstieg für Solar- und Wärmepumpen-Anbieter mit bestehender Website. Wir machen sichtbar, wo Sichtbarkeit, Vertrauen oder Conversion wegbrechen.</p>
+						<span class="cta-btn">System-Diagnose starten</span>
 					</a>
 				</li>
 				<li class="solution-item">
 					<a href="<?php echo esc_url( $audit_url ); ?>">
 						<h2>2. Priorisierte Folgeentscheidung</h2>
-						<p>Kein öffentlicher Einstieg. Wenn der Fall tiefer geht, ergibt sich der nächste vertiefte Schritt erst nach Growth Audit, Rückmeldung und persönlichem Kontakt.</p>
-						<span class="cta-btn">Ergibt sich nach dem Audit</span>
+						<p>Kein öffentlicher Einstieg. Wenn der Fall tiefer geht, ergibt sich der nächste vertiefte Schritt erst nach System-Diagnose, Rückmeldung und persönlichem Kontakt.</p>
+						<span class="cta-btn">Ergibt sich nach der Diagnose</span>
 					</a>
 				</li>
 				<li class="solution-item">
 					<a href="<?php echo esc_url( $wgos_url ); ?>">
 						<h2>3. Kontrollierte Umsetzung &amp; laufende Weiterentwicklung</h2>
-						<p>Umsetzung und laufende Optimierung in der richtigen Reihenfolge: Technik, SEO, Tracking, Content und Conversion auf WordPress-Basis.</p>
+						<p>Umsetzung und laufende Optimierung in der richtigen Reihenfolge: Technik, SEO, Tracking, Content und Conversion.</p>
 						<span class="cta-btn">System ansehen</span>
 					</a>
 				</li>

--- a/blocksy-child/page-seo-cornerstone.php
+++ b/blocksy-child/page-seo-cornerstone.php
@@ -365,7 +365,7 @@ get_header();
 					<p>Wenn Sie wissen wollen, wie belastbar Ihr technisches Fundament heute ist, starten Sie mit einer strukturierten Analyse von Technik, Tracking, Conversion-Logik und Lead-Übergabe.</p>
 					<div class="seo-cornerstone__cta-buttons">
 						<a class="nx-btn nx-btn--primary" href="<?php echo esc_url( $seo_url ); ?>" data-track-action="cta_seo_cornerstone_audit" data-track-category="lead_gen">Technisches SEO Audit anfragen</a>
-						<a class="nx-btn nx-btn--ghost" href="<?php echo esc_url( nexus_get_audit_url() ); ?>" data-track-action="cta_seo_cornerstone_journey" data-track-category="lead_gen">Growth Audit</a>
+						<a class="nx-btn nx-btn--ghost" href="<?php echo esc_url( nexus_get_audit_url() ); ?>" data-track-action="cta_seo_cornerstone_journey" data-track-category="lead_gen">System-Diagnose</a>
 					</div>
 				</div>
 

--- a/blocksy-child/page-solar-waermepumpen-leadgenerierung.php
+++ b/blocksy-child/page-solar-waermepumpen-leadgenerierung.php
@@ -94,7 +94,7 @@ $service_schema = [
 	'@type'       => 'Service',
 	'@id'         => trailingslashit( $page_url ) . '#service',
 	'name'        => 'Website als Vertriebssystem für Solar- und Wärmepumpen-Anbieter',
-	'serviceType' => 'B2B Website-, Tracking- und Conversion-System für Solar-, Wärmepumpen-, Speicher- und Energie-Anbieter',
+	'serviceType' => 'Aufbau eigener Anfrage-Systeme zur Ablösung von Portal-Leads für Solar-, Wärmepumpen-, Speicher- und Energie-Anbieter',
 	'url'         => $page_url,
 	'description' => 'Eigenes Anfrage-System für Solar- und Wärmepumpen-Betriebe: Schluss mit teuren Portal-Leads. Referenz E3 New Energy — 83 % weniger Kosten pro Anfrage in 9 Monaten.',
 	'provider'    => [
@@ -104,7 +104,7 @@ $service_schema = [
 	],
 	'audience'    => [
 		'@type'        => 'Audience',
-		'audienceType' => 'B2B-Unternehmen aus Solar, Wärmepumpe, Speicher und Energielösungen',
+		'audienceType' => 'Solar-, Wärmepumpen-, Speicher- und Energie-Anbieter im DACH-Raum',
 	],
 	'areaServed'  => [
 		[
@@ -116,7 +116,7 @@ $service_schema = [
 		'@type'         => 'Offer',
 		'price'         => '0',
 		'priceCurrency' => 'EUR',
-		'description'   => 'Growth Audit als diagnostischer Einstieg in Website-, Tracking- und Conversion-Optimierung.',
+		'description'   => 'Diagnostische System-Einordnung für Ihre Anfrage-Prozesse.',
 	],
 ];
 

--- a/blocksy-child/page-tools.php
+++ b/blocksy-child/page-tools.php
@@ -242,10 +242,10 @@ get_header();
 				<div class="tools-card tools-cta-card">
 					<div class="tools-section-head">
 						<h2>Bereit für tiefere Einblicke?</h2>
-						<p>Unsere Tools zeigen erste Ansätze. Ein vollständiger Audit liefert Ihnen detaillierte Empfehlungen für messbare Verbesserungen.</p>
+						<p>Unsere Tools zeigen erste Ansätze. Eine vollständige System-Diagnose liefert Ihnen detaillierte Empfehlungen für messbare Verbesserungen.</p>
 					</div>
 					<div class="tools-cta-actions">
-						<a class="tool-btn tool-btn--primary" href="<?php echo esc_url(home_url('/growth-audit/')); ?>" data-track-action="cta_tools_page_audit" data-track-category="lead_gen" data-track-section="tools_cta">Growth Audit anfragen</a>
+						<a class="tool-btn tool-btn--primary" href="<?php echo esc_url(home_url('/growth-audit/')); ?>" data-track-action="cta_tools_page_audit" data-track-category="lead_gen" data-track-section="tools_cta">System-Diagnose anfragen</a>
 					</div>
 				</div>
 			</section>

--- a/blocksy-child/page-wgos-assets.php
+++ b/blocksy-child/page-wgos-assets.php
@@ -25,7 +25,7 @@ $asset_count     = isset( $summary['totalAssets'] ) ? (int) $summary['totalAsset
 $phase_count     = isset( $payload['wgosAssetPhases'] ) && is_array( $payload['wgosAssetPhases'] ) ? count( $payload['wgosAssetPhases'] ) : 0;
 $module_count    = isset( $payload['wgosAssetModules'] ) && is_array( $payload['wgosAssetModules'] ) ? count( $payload['wgosAssetModules'] ) : 0;
 $hub_sections    = function_exists( 'nexus_get_wgos_asset_hub_sections' ) ? nexus_get_wgos_asset_hub_sections() : [];
-$audit_cta_label = function_exists( 'nexus_get_audit_cta_label' ) ? nexus_get_audit_cta_label() : 'Growth Audit starten';
+$audit_cta_label = function_exists( 'nexus_get_audit_cta_label' ) ? nexus_get_audit_cta_label() : 'System-Diagnose starten';
 $hero_subtitle   = sprintf(
 	'%1$d Assets in %2$d Modulen, nach Phasen geordnet. Jedes Asset direkt klickbar.',
 	$asset_count,
@@ -164,7 +164,7 @@ $hero_subtitle   = sprintf(
 				<div class="wgos-final-cta__inner">
 					<span class="wgos-principle-kicker">Audit</span>
 					<h2 class="wgos-h2">Welches Asset zuerst?</h2>
-					<p class="wgos-prose">Der Growth Audit klärt die Reihenfolge für Ihre Situation.</p>
+					<p class="wgos-prose">Die System-Diagnose klärt die Reihenfolge für Ihre Situation.</p>
 
 					<div class="wgos-hero__actions">
 						<a href="<?php echo esc_url( $audit_url ); ?>" class="wgos-btn wgos-btn--primary" data-track="cta_click_audit" data-track-action="cta_click_audit" data-track-category="lead_gen" data-track-section="asset_hub_cta"><?php echo esc_html( $audit_cta_label ); ?></a>

--- a/blocksy-child/page-wgos.php
+++ b/blocksy-child/page-wgos.php
@@ -22,7 +22,7 @@ $page_url                     = get_permalink( get_queried_object_id() );
 $public_proof                 = function_exists( 'nexus_get_public_proof_data' ) ? nexus_get_public_proof_data() : [];
 $canonical_ownership_sentence = function_exists( 'nexus_get_public_ownership_sentence' ) ? nexus_get_public_ownership_sentence() : 'Code, Inhalte, Zugänge und Setups bleiben bei Ihnen. Laufende Zusammenarbeit bedeutet Weiterentwicklung, nicht Abhängigkeit.';
 $framework_label              = function_exists( 'nexus_get_public_framework_label' ) ? nexus_get_public_framework_label() : 'WGOS = WordPress Growth Operating System';
-$audit_cta_label              = function_exists( 'nexus_get_audit_cta_label' ) ? nexus_get_audit_cta_label() : 'Growth Audit starten';
+$audit_cta_label              = function_exists( 'nexus_get_audit_cta_label' ) ? nexus_get_audit_cta_label() : 'System-Diagnose starten';
 $audit_compact_microcopy      = function_exists( 'nexus_get_audit_compact_microcopy' ) ? nexus_get_audit_compact_microcopy() : '60 Sek. · priorisierte Hebel · keine E-Mail';
 $diagram_svg_markup           = '';
 $diagram_svg_path             = get_stylesheet_directory() . '/assets/brand/wgos-system-diagram.svg';
@@ -250,7 +250,7 @@ $faq_items = [
 	],
 	[
 		'question' => 'Was kostet die Zusammenarbeit?',
-		'answer'   => 'Der Einstieg beginnt ab 1.500 €/Monat. Die passende Tiefe ergibt sich aus dem Growth Audit. Details stehen in der Paket-Übersicht oben.',
+		'answer'   => 'Der Einstieg beginnt ab 1.500 €/Monat. Die passende Tiefe ergibt sich aus der System-Diagnose. Details stehen in der Paket-Übersicht oben.',
 	],
 ];
 
@@ -372,7 +372,7 @@ foreach ( $faq_items as $faq_item ) {
 				</div>
 
 				<div class="wgos-mid-cta">
-					<p>Sie sehen das System. Der Growth Audit zeigt, welcher Bereich bei Ihnen zuerst den größten Hebel hat.</p>
+					<p>Sie sehen das System. Die System-Diagnose zeigt, welcher Bereich bei Ihnen zuerst den größten Hebel hat.</p>
 					<a href="<?php echo esc_url( $audit_url ); ?>" class="wgos-btn wgos-btn--primary" data-track="cta_click_audit" data-track-action="cta_click_audit" data-track-category="lead_gen" data-track-section="mid_cta"><?php echo esc_html( $audit_cta_label ); ?></a>
 					<p class="nx-cta-microcopy"><?php echo esc_html( $audit_compact_microcopy ); ?></p>
 				</div>

--- a/blocksy-child/page-wordpress-agentur.php
+++ b/blocksy-child/page-wordpress-agentur.php
@@ -31,7 +31,7 @@ $tools_url = nexus_get_primary_public_url( 'tools', home_url( '/kostenlose-tools
 $proof_metrics = function_exists( 'nexus_get_public_proof_metric_list' ) ? nexus_get_public_proof_metric_list( [ 'lead_count', 'sales_conversion', 'cpl_reduction' ] ) : [];
 $canonical_ownership_sentence = function_exists( 'nexus_get_public_ownership_sentence' ) ? nexus_get_public_ownership_sentence() : 'Code, Inhalte, Zugänge und Setups bleiben bei Ihnen. Laufende Zusammenarbeit bedeutet Weiterentwicklung, nicht Abhängigkeit.';
 $primary_term                = function_exists( 'nexus_get_public_primary_term' ) ? nexus_get_public_primary_term() : 'WordPress als Nachfrage-System für B2B';
-$audit_cta_label             = function_exists( 'nexus_get_audit_cta_label' ) ? nexus_get_audit_cta_label() : 'Growth Audit starten';
+$audit_cta_label             = function_exists( 'nexus_get_audit_cta_label' ) ? nexus_get_audit_cta_label() : 'System-Diagnose starten';
 $audit_compact_microcopy     = function_exists( 'nexus_get_audit_compact_microcopy' ) ? nexus_get_audit_compact_microcopy() : '60 Sek. · priorisierte Hebel · keine E-Mail';
 
 $pain_cards = [
@@ -94,8 +94,8 @@ $faq_items = [
 		'answer'   => 'Ja. Die Arbeit umfasst nicht nur WordPress-Entwicklung, sondern auch technische SEO, GA4- und Tracking-Setups, Conversion Rate Optimierung und die Priorisierung kaufnaher Seiten. Genau diese Kombination ist für Leadgenerierung im B2B meist entscheidend.',
 	],
 	[
-		'question' => 'Wann ist die Agentur-Seite der richtige Einstieg und wann der Growth Audit?',
-		'answer'   => 'Die Agentur-Seite ist richtig, wenn Sie den Gesamtkontext verstehen wollen. Der Growth Audit ist der bessere nächste Schritt, wenn klar werden soll, ob zuerst SEO, Tracking, Performance oder Conversion den größten Hebel hat.',
+		'question' => 'Wann ist die Agentur-Seite der richtige Einstieg und wann die System-Diagnose?',
+		'answer'   => 'Die Agentur-Seite ist richtig, wenn Sie den Gesamtkontext verstehen wollen. Die System-Diagnose ist der bessere nächste Schritt, wenn klar werden soll, ob zuerst SEO, Tracking, Performance oder Conversion den größten Hebel hat.',
 	],
 	[
 		'question' => 'Warum rankt eine WordPress-Seite, liefert aber keine Anfragen?',
@@ -385,7 +385,7 @@ get_header();
 			<div class="nx-container">
 				<div class="nx-cta-box wp-agentur-cta-box">
 					<h2>Prüfen wir, an welcher Stelle Ihr WordPress-System heute Nachfrage verliert.</h2>
-					<p>Der Growth Audit zeigt, ob Angebotsseiten, Datenlage, CTA-Führung oder technische Reibung zuerst angegangen werden sollten und ob ein tieferer Umbau überhaupt sinnvoll ist.</p>
+					<p>Die System-Diagnose zeigt, ob Angebotsseiten, Datenlage, CTA-Führung oder technische Reibung zuerst angegangen werden sollten und ob ein tieferer Umbau überhaupt sinnvoll ist.</p>
 					<a href="<?php echo esc_url( $audit_url ); ?>" class="nx-btn nx-btn--primary" data-track-action="cta_agentur_final_audit" data-track-category="lead_gen"><?php echo esc_html( $audit_cta_label ); ?></a>
 					<p class="wp-cta-desc mt-1">Kein Pitch. Klare Priorisierung. Wenn fachlich sinnvoll, kann daraus als nächster Schritt eine vertiefte Analyse, eine fokussierte Korrektur oder eine laufende Weiterentwicklung entstehen.</p>
 					<p class="wp-cta-desc mb-0">

--- a/blocksy-child/single.php
+++ b/blocksy-child/single.php
@@ -73,14 +73,14 @@ get_template_part( 'template-parts/blog-header' );
 
 				   <div class="nexus-inline-cta" id="nexus-inline-cta" hidden aria-hidden="true">
 					   <div class="nexus-inline-cta__inner">
-						   <span class="nexus-inline-cta__tag">Kostenloser Audit</span>
+						   <span class="nexus-inline-cta__tag">Kostenlose Diagnose</span>
 						   <h3 class="nexus-inline-cta__headline">Was bremst Ihr Wachstum?</h3>
 						   <p class="nexus-inline-cta__sub">Persönliche Analyse Ihrer Website — schriftliche Rückmeldung in 48 Stunden.</p>
 						   <a href="<?php echo esc_url( home_url( '/growth-audit/' ) ); ?>"
 							  class="nexus-btn nexus-btn--primary nexus-inline-cta__btn"
 							  data-track-action="cta_blog_inline"
 							  data-track-category="lead_gen">
-							  Audit starten
+							  System-Diagnose starten
 						   </a>
 					   </div>
 				   </div>

--- a/blocksy-child/template-about.php
+++ b/blocksy-child/template-about.php
@@ -115,7 +115,7 @@ $project_phases = [
 
 $background_paragraphs = [
 	'Mein Zugang ist Medienwissenschaften, nicht Design. Deshalb schaue ich zuerst auf Sprache, Entscheidung und Signalqualität.',
-	'Über Jahre habe ich B2B-WordPress-Systeme für Maschinenbau und Dienstleistung gebaut. Technisch sauber war selten das eigentliche Problem.',
+	'Über Jahre habe ich B2B-Anfrage-Systeme für Maschinenbau und Dienstleistung gebaut. Technisch sauber war selten das eigentliche Problem.',
 	'Das Solar-Mandat hat die Richtung festgezogen. 120 € CPL, frustrierter Inhaber, Tracking ohne belastbare Rückmeldung.',
 	'Als der CPL auf 20 € fiel, war klar, wo die Methode am stärksten greift. Seitdem konzentriere ich mich auf Solar- und Wärmepumpen-Anbieter im DACH-Raum.',
 ];
@@ -338,7 +338,7 @@ get_header();
 			<div class="nx-container">
 				<div class="about-close__inner">
 					<h2 class="nx-headline-section">Prüfen wir Ihren Status quo.</h2>
-					<p>Der Growth Audit zeigt in 30–45 Minuten, wo Ihr Anfrage-System konkret klemmt – von der Landingpage bis zur Attribution. Kein Verkaufsgespräch, keine Präsentation. Entweder der Fit passt, oder ich sage Ihnen, welcher Partner besser wäre.</p>
+					<p>Die System-Diagnose zeigt in 30–45 Minuten, wo Ihr Anfrage-System konkret klemmt – von der Landingpage bis zur Attribution. Kein Verkaufsgespräch, keine Präsentation. Entweder der Fit passt, oder ich sage Ihnen, welcher Partner besser wäre.</p>
 					<p class="about-close__actions">
 						<a
 							href="<?php echo esc_url( $request_url ); ?>"

--- a/blocksy-child/template-parts/audit-page-shell.php
+++ b/blocksy-child/template-parts/audit-page-shell.php
@@ -19,7 +19,7 @@ $audit_cta_label = 'Audit starten';
 		<main class="audit-content">
 			<section id="start" class="audit-section ga-hero nx-reveal" aria-labelledby="ga-hero-title">
 				<div class="ga-hero__inner">
-					<p class="ga-kicker">Growth Audit für B2B-WordPress-Seiten</p>
+					<p class="ga-kicker">System-Diagnose für Solar- und Wärmepumpen-Anbieter</p>
 					<h1 id="ga-hero-title">Wo Ihre Seite gerade Anfragen ausbremst.</h1>
 					<p class="ga-hero__sub">
 						Ich prüfe Ihre Startseite oder Angebotsseite manuell und KI-unterstützt.
@@ -27,7 +27,7 @@ $audit_cta_label = 'Audit starten';
 						und einen klaren nächsten Schritt.
 					</p>
 
-					<div class="ga-trust-badges" aria-label="Audit im Überblick">
+					<div class="ga-trust-badges" aria-label="System-Diagnose im Überblick">
 						<span>0 € Einstieg</span>
 						<span>manuell geprüft</span>
 						<span>Rückmeldung in 48h</span>
@@ -66,7 +66,7 @@ $audit_cta_label = 'Audit starten';
 				<div class="ga-form-shell">
 					<div class="ga-form-intro">
 						<div class="ga-section-head ga-section-head--compact">
-							<p class="ga-section-kicker">Growth Audit anfragen</p>
+							<p class="ga-section-kicker">System-Diagnose anfragen</p>
 							<h2 id="ga-form-title">Seite einreichen.</h2>
 							<p>Startseite oder Angebotsseite genügt. Ich melde mich schriftlich zurück.</p>
 						</div>
@@ -112,7 +112,7 @@ $audit_cta_label = 'Audit starten';
 								<label class="ga-form__consent">
 									<input id="ga-consent-privacy" name="consent_privacy" type="checkbox" value="accepted" required>
 									<span>
-										Ich stimme zu, dass meine Angaben zur Bearbeitung des Growth Audits verarbeitet werden.
+										Ich stimme zu, dass meine Angaben zur Bearbeitung der System-Diagnose verarbeitet werden.
 										Details stehen in der <a href="<?php echo esc_url( $privacy_url ); ?>">Datenschutzerklärung</a>.
 									</span>
 								</label>
@@ -123,7 +123,7 @@ $audit_cta_label = 'Audit starten';
 
 							<div class="ga-form__actions">
 								<button type="submit" class="ga-btn ga-btn--primary ga-btn--full" data-track-action="cta_form_growth_audit" data-track-category="lead_gen" data-track-section="form">
-									<span class="ga-btn__label">Audit starten</span>
+									<span class="ga-btn__label">System-Diagnose starten</span>
 									<span class="ga-btn__spinner" aria-hidden="true"></span>
 								</button>
 								<p class="ga-form__microcopy">Schriftliche Rückmeldung in 48h. Kein Pflicht-Call.</p>

--- a/blocksy-child/template-parts/service-system-map.php
+++ b/blocksy-child/template-parts/service-system-map.php
@@ -30,7 +30,7 @@
  *         'actions' => [
  *           [
  *             'url'      => home_url( '/growth-audit/' ),
- *             'label'    => 'Growth Audit starten',
+ *             'label'    => 'System-Diagnose starten',
  *             'class'    => 'nx-btn nx-btn--primary',
  *             'action'   => 'cta_service_system_audit',
  *             'category' => 'lead_gen',

--- a/blocksy-child/template-parts/site-footer.php
+++ b/blocksy-child/template-parts/site-footer.php
@@ -37,8 +37,8 @@ $imprint_url      = $primary_urls['impressum'] ?? home_url( '/impressum/' );
 $privacy_url      = $primary_urls['datenschutz'] ?? home_url( '/datenschutz/' );
 $hide_primary_cta = function_exists( 'nexus_should_hide_footer_primary_cta' ) && nexus_should_hide_footer_primary_cta();
 $footer_class     = $hide_primary_cta ? 'ft ft--no-primary-cta ft--mobile-cta' : 'ft';
-$audit_cta_label  = function_exists( 'nexus_get_audit_cta_label' ) ? nexus_get_audit_cta_label() : 'Growth Audit starten';
-$audit_footer_note = function_exists( 'nexus_get_audit_footer_note' ) ? nexus_get_audit_footer_note() : 'Growth Audit: persönliche Ersteinschätzung, schriftliche Rückmeldung in 48 Stunden, kein Pflicht-Call.';
+$audit_cta_label  = function_exists( 'nexus_get_audit_cta_label' ) ? nexus_get_audit_cta_label() : 'System-Diagnose starten';
+$audit_footer_note = function_exists( 'nexus_get_audit_footer_note' ) ? nexus_get_audit_footer_note() : 'System-Diagnose: persönliche Ersteinschätzung, schriftliche Rückmeldung in 48 Stunden, kein Pflicht-Call.';
 ?>
 
 <?php if ( function_exists( 'nexus_is_audit_linkedin_page' ) && nexus_is_audit_linkedin_page() ) : ?>
@@ -50,7 +50,7 @@ $audit_footer_note = function_exists( 'nexus_get_audit_footer_note' ) ? nexus_ge
 	<h2 id="ft-heading" class="ft__sr">Footer-Navigation</h2>
 	<div class="ft__audit-shell">
 		<p class="ft__audit-note"><?php echo esc_html( $audit_footer_note ); ?></p>
-		<nav class="ft__audit-links" aria-label="Audit-Footer-Navigation">
+		<nav class="ft__audit-links" aria-label="System-Diagnose-Footer-Navigation">
 			<a href="<?php echo esc_url( $request_url ); ?>" data-track-action="cta_audit_footer_request" data-track-category="lead_gen">Anfrage stellen</a>
 			<a href="<?php echo esc_url( $imprint_url ); ?>" rel="nofollow">Impressum</a>
 			<a href="<?php echo esc_url( $privacy_url ); ?>" rel="nofollow">Datenschutz</a>
@@ -89,7 +89,7 @@ $audit_footer_note = function_exists( 'nexus_get_audit_footer_note' ) ? nexus_ge
 	<div class="ft__top">
 		<div class="ft__brand">
 			<a class="ft__logo site-logo site-logo--accent" href="<?php echo esc_url( $home_url ); ?>" aria-label="Startseite - HAŞIM ÜNER">HAŞIM ÜNER</a>
-			<p class="ft__tag">WordPress als Nachfrage-System für B2B.</p>
+			<p class="ft__tag">Eigenes Anfrage-System für Solar- und Wärmepumpen-Anbieter.</p>
 			<?php if ( ! $hide_primary_cta ) : ?>
 			<a class="ft__cta" href="<?php echo esc_url( $audit_url ); ?>" data-track-action="cta_footer_audit" data-track-category="lead_gen"><?php echo esc_html( $audit_cta_label ); ?></a>
 			<?php else : ?>
@@ -112,7 +112,7 @@ $audit_footer_note = function_exists( 'nexus_get_audit_footer_note' ) ? nexus_ge
 			<section class="ft__col" aria-labelledby="ft-einstieg">
 				<h3 id="ft-einstieg">Einstieg</h3>
 				<ul class="ft__list">
-					<li><a class="ft__link-strong" href="<?php echo esc_url( $audit_url ); ?>" data-track-action="cta_footer_nav_audit" data-track-category="lead_gen">Growth Audit</a></li>
+					<li><a class="ft__link-strong" href="<?php echo esc_url( $audit_url ); ?>" data-track-action="cta_footer_nav_audit" data-track-category="lead_gen">System-Diagnose</a></li>
 					<li><a class="ft__link-strong" href="<?php echo esc_url( $agentur_url ); ?>" data-track-action="cta_footer_nav_agentur" data-track-category="navigation">WordPress Agentur Hannover</a></li>
 					<li><a href="<?php echo esc_url( $wgos_url ); ?>" data-track-action="cta_footer_nav_wgos" data-track-category="navigation">Systemlogik (WGOS)</a></li>
 					<li><a href="<?php echo esc_url( $whitelabel_url ); ?>" data-track-action="cta_footer_nav_whitelabel" data-track-category="navigation">Whitelabel &amp; Weiterentwicklung</a></li>

--- a/blocksy-child/template-parts/site-header.php
+++ b/blocksy-child/template-parts/site-header.php
@@ -42,7 +42,7 @@ if ( empty( $audit_header_meta_items ) ) {
 	<div class="nx-container">
 		<div class="nx-site-header__shell nx-site-header__shell--audit">
 			<div class="nx-site-header__brand-block">
-				<span class="nx-site-header__eyebrow">Growth Audit</span>
+				<span class="nx-site-header__eyebrow">System-Diagnose</span>
 				<a
 					class="site-logo nx-site-header__brand"
 					href="<?php echo esc_url( home_url( '/' ) ); ?>"

--- a/blocksy-child/template-parts/tools-page-shell.php
+++ b/blocksy-child/template-parts/tools-page-shell.php
@@ -91,13 +91,13 @@ $tools_cards   = function_exists( 'nexus_get_tools_hub_items' ) ? nexus_get_tool
 			<span class="tools-kicker">Wenn Sie nicht raten wollen</span>
 			<h2 id="tools-bridge-title" class="tools-section__title">Nicht sicher, welcher Einstieg zuerst Sinn ergibt?</h2>
 			<p class="tools-section__intro">
-				Dann starten Sie nicht mit dem falschen Tool. Der Growth Audit ordnet zuerst ein, ob das Problem eher in Botschaft,
+				Dann starten Sie nicht mit dem falschen Tool. Die System-Diagnose ordnet zuerst ein, ob das Problem eher in Botschaft,
 				Proof, Performance, Tracking oder im nächsten Schritt liegt.
 			</p>
 		</div>
 
 		<div class="tools-bridge__actions">
-			<a href="<?php echo esc_url( $audit_url ); ?>" class="tools-btn tools-btn--primary" data-track-action="cta_tools_footer_audit" data-track-category="lead_gen">Zum Growth Audit</a>
+			<a href="<?php echo esc_url( $audit_url ); ?>" class="tools-btn tools-btn--primary" data-track-action="cta_tools_footer_audit" data-track-category="lead_gen">Zur System-Diagnose</a>
 			<a href="<?php echo esc_url( $wgos_url ); ?>" class="tools-btn tools-btn--secondary" data-track-action="cta_tools_footer_wgos" data-track-category="navigation">Erst das System verstehen</a>
 		</div>
 	</section>

--- a/docs/standards/BRAND_AND_COPY.md
+++ b/docs/standards/BRAND_AND_COPY.md
@@ -5,50 +5,58 @@ Skills reference this file instead of duplicating brand rules.
 
 ## Identity
 
-- Role: **WordPress Growth Architect fuer B2B**
-- Entity: Hasim Uener, hasimuener.de
-- Not: Agentur, WordPress Specialist, Webdesign-Dienstleister
+- Role: **Architekt für eigene Anfrage-Systeme**
+- Entity: Haşim Üner, hasimuener.de
+- Not: WordPress-Agentur, B2B-Generalist, Performance-Marketing-Agentur, Webdesign-Dienstleister
 
 ## Positioning
 
-- WordPress, B2B, Leads, Conversion, Tracking, SEO, Nachfrage-Systeme
-- SEO, Tracking, Privacy/Consent, CRO, and WordPress implementation are one connected system
-- Owned-first before paid scaling
-- Diagnose before pitch
-- Clarity before feature count
+**Ich baue Solar- und Wärmepumpen-Anbietern im DACH-Raum eigene Anfrage-Systeme, die Portal-Abhängigkeit ablösen und Leadkosten messbar senken.**
+
+- Zielgruppe: Solar-, Wärmepumpen-, Speicher- und Energie-Anbieter mit eigenem Vertrieb (typ. 10–25 Mitarbeiter)
+- Wettbewerb: Lead-Portale (Aroundhome, Check24, DAA) — nicht Webdesign-Agenturen
+- Website, Tracking, Vorqualifizierung und Werbekanal-Steuerung sind ein verbundenes System
+- Eigene Nachfrage-Infrastruktur vor Portal-Zukauf
+- Diagnose vor Pitch
+- Klarheit vor Feature-Count
 
 ## Offer Ladder
 
 ```
-Audit -> Blueprint -> Implementation/Retainer
+System-Diagnose -> Blueprint -> Umsetzung / Retainer
 ```
 
-- Primary CTA: `/growth-audit/`
-- Secondary paths: `/wordpress-growth-operating-system/`, `/ergebnisse/`, `/blog/`
-- Frame the audit as a strategic diagnosis entry point, not a gimmicky free tool
+- Primary CTA: Anfrage stellen (`/solar-waermepumpen-leadgenerierung/#energie-anfrage`)
+- Sekundärer Pfad: System-Diagnose (URL-Slug `/growth-audit/` bleibt aus SEO-Gründen; Label ist "System-Diagnose")
+- Die System-Diagnose ist diagnostischer Einstieg, kein gimmicky Gratis-Tool
 
 ## Tone
 
-- Clear, premium, direct, strategic
-- Decision-maker copy over generic agency language
-- Technical fixes before cosmetic polish
+- Klar, direkt, handwerklich, entscheidungssicher
+- Sprache für Geschäftsführer und Vertriebsleiter, nicht für Marketing-Abteilungen
+- Technische Klarheit vor kosmetischer Politur
 
 ## Preferred Terms
 
-`Website`, `Nachfrage`, `Leads`, `Anfragen`, `Wachstumspotenzial`,
-`priorisierte Hebel`, `Diagnose`, `Klarheit`, `Conversion`, `Tracking`,
-`SEO`, `WordPress`, `B2B`, `Nachfrage-Systeme`
+`Anfrage-System`, `eigene Anfragen`, `Portal-Abhängigkeit`, `Leadkosten`,
+`Kosten pro Anfrage`, `qualifizierte Anfragen`, `Abschlussquote`,
+`Vorqualifizierung`, `Tracking`, `Nachfrage-Infrastruktur`,
+`System-Diagnose`, `Potenzial-Check`, `priorisierte Hebel`,
+`Solar`, `Wärmepumpe`, `Speicher`, `Energie-Anbieter`, `Handwerk`
 
 ## Anti-Patterns (Hard Bans)
 
-- Shopify as live positioning
-- Generic buzzwords without specifics
-- `kostenlos` as the only value proposition
-- Tool-like framing for the audit
-- Inflated revenue promises
-- Broad agency wording: `Leistungen`, `WordPress Specialist`, `Webdesign`
-- Equal-weight service catalog instead of diagnosis-first funnel
-- Copy that sells tactics before diagnosis
+- `Growth Audit` als user-facing Label (interne URL/IDs dürfen bleiben)
+- `WordPress` als Angebot oder Rolle (nur als Technologie im Nebensatz erlaubt)
+- `B2B` als Positionierung (zu generisch — wir sprechen Solar/Wärmepumpe)
+- `WordPress Specialist`, `WordPress-Agentur`, `Webdesign`, `Leistungen`
+- `Growth Architect`, generische Growth-/Marketing-Blasen-Begriffe
+- Shopify als Live-Positionierung
+- `kostenlos` als alleiniges Wertversprechen
+- Tool-artige Rahmung der Diagnose
+- Überhöhte Umsatzversprechen
+- Gleichgewichtiger Leistungskatalog statt Diagnose-first-Funnel
+- Copy, die Taktik vor Diagnose verkauft
 
 ## Brand Colors (Project Override)
 


### PR DESCRIPTION
Normalize user-facing copy across theme to the new canonical positioning ("Architekt für eigene Anfrage-Systeme" für Solar- und Wärmepumpen-Anbieter im DACH-Raum) so that prospects from the landing page no longer hit WordPress-B2B/Growth-Architect language downstream.

- BRAND_AND_COPY.md rewritten: new identity, positioning sentence, anti-patterns (Growth Audit, WordPress als Angebot, B2B, Growth Architect)
- helpers.php: canonical CTA label "Growth Audit starten" → "System-Diagnose starten", footer note, header meta items, primary_term, allowed_subterms
- cja-shortcode.php: Solar-gerechte Overline, Trust-Line, neutralisierter Funnel-Übergang zum Anfrage-Formular
- front-page.php: FAQ ("klassische WordPress-Agentur" → "Traffic/System-Frage"), alle CTAs + Microcopy "Audit starten" → "System-Diagnose starten"
- page-solar-waermepumpen-leadgenerierung.php: Schema.org serviceType, audienceType und Offer-description auf neue Positionierung
- Alle weiteren Seiten (home, about, ki, loesungen, case-e3, kontakt, tools, wp-agentur, wgos, category, 404, single, 360-deep-dive, glossar, case-study-domdar, seo-cornerstone, datenschutz, audit) sowie template-parts (site-header, site-footer, audit-page-shell, tools-page-shell, service-system-map) sprachlich auf System-Diagnose normalisiert
- SEO/Schema: org-schema.php LocalBusiness + Person, seo-meta.php titles, llms-txt.php
- JS Schema (cwv.js, performance.js) jobTitle aktualisiert
- review-crm, contact-page, shortcodes, wgos-cluster-pages etc. mitgezogen

Bewusst NICHT geändert (Rationale im Commit-Body):
- URL /growth-audit/ bleibt (SEO-Backlinks, Analytics-Kontinuität)
- Tracking-Event-IDs (growth_audit_instant, cta_*_audit etc.) bleiben als interne GA4-Identifier
- Hidden field audit_type="growth_audit" bleibt (n8n/CRM-Identifier, kein user-facing Text)
- page-wordpress-agentur.php behält Titel/SEO-Fokus (sekundäre SEO-Landing für "WordPress Agentur Hannover"-Suchintent)
- Interne Code-Kommentare (functions.php header, audit.css, README.md) bleiben als Doku des ursprünglichen Modulnamens

Deutsche Grammatik: "der Growth Audit" (maskulin) → "die System-Diagnose" (feminin) systematisch via Python-Pass mit geordneten Artikel-Varianten (dem/des/den/einen/einem/Der/der/im/zum/vom/als/mit dem → passende Feminin-Form), anschließend manuell verifiziert.

https://claude.ai/code/session_017WJBaq4T73pyogCEdzMJvQ