### PR TITLE
seo: consolidate /wordpress-seo-hannover/ + /wordpress-wartung-hannov…

### DIFF
--- a/blocksy-child/inc/helpers.php
+++ b/blocksy-child/inc/helpers.php
@@ -877,12 +877,18 @@ add_action( 'init', 'nexus_maybe_ensure_energy_systems_page', 27 );
  * @return array<string, string>
  */
 function nexus_get_legacy_offer_redirect_map() {
+	$agentur_url = nexus_get_primary_public_url( 'agentur', home_url( '/wordpress-agentur-hannover/' ) );
+
 	return [
 		// /meta-ads/ ehemals WGOS-Landung. WGOS ist deprecated in der neuen Positionierung;
 		// Redirect zur System-Diagnose, damit Handwerker nicht im alten Systemlogik-Hub landen.
 		'/meta-ads/'                   => nexus_get_audit_url(),
-		'/seo/'                        => nexus_get_primary_public_url( 'seo', home_url( '/wordpress-seo-hannover/' ) ),
-		'/wordpress-agentur/'          => nexus_get_primary_public_url( 'agentur', home_url( '/wordpress-agentur-hannover/' ) ),
+		// SEO- und Wartungs-Seiten konsolidiert auf die Agentur-Money-Page (Anker-Sektionen).
+		// Löst Kannibalisierung für "wordpress agentur hannover" + transferiert SEO-Equity.
+		'/wordpress-seo-hannover/'     => trailingslashit( $agentur_url ) . '#technisches-seo',
+		'/wordpress-wartung-hannover/' => trailingslashit( $agentur_url ) . '#wordpress-wartung',
+		'/seo/'                        => trailingslashit( $agentur_url ) . '#technisches-seo',
+		'/wordpress-agentur/'          => $agentur_url,
 		'/roi-rechner/'                => nexus_get_primary_public_url( 'tools', home_url( '/kostenlose-tools/' ) ),
 	];
 }

--- a/blocksy-child/inc/seo-meta.php
+++ b/blocksy-child/inc/seo-meta.php
@@ -108,12 +108,12 @@ function hu_get_forced_singular_seo_map() {
 				'description' => 'Kostenlose Tools für ROI, Website-Analyse und Performance: schnelle Checks für Marketing-, Website- und WordPress-Entscheidungen.',
 			],
 			'wordpress-agentur-hannover' => [
-				'title'       => 'WordPress Agentur Hannover für B2B | Haşim Üner',
-				'description' => 'WordPress Agentur Hannover für B2B: Angebotsseiten, SEO, GA4-Tracking und Conversion-Optimierung als System. System-Diagnose als Einstieg – 60 Sek., keine E-Mail.',
+				'title'       => 'WordPress Agentur Hannover – SEO, Wartung & Conversion',
+				'description' => 'WordPress Agentur in Hannover: technisches SEO, Wartungsvertrag, Tracking und Conversion für B2B-Websites als verbundenes System. Referenz E3 — -83 % Leadkosten.',
 			],
 			'wordpress-agentur' => [
-				'title'       => 'WordPress Agentur Hannover für B2B | Haşim Üner',
-				'description' => 'WordPress Agentur Hannover für B2B: Angebotsseiten, SEO, GA4-Tracking und Conversion-Optimierung als System. System-Diagnose als Einstieg – 60 Sek., keine E-Mail.',
+				'title'       => 'WordPress Agentur Hannover – SEO, Wartung & Conversion',
+				'description' => 'WordPress Agentur in Hannover: technisches SEO, Wartungsvertrag, Tracking und Conversion für B2B-Websites als verbundenes System. Referenz E3 — -83 % Leadkosten.',
 			],
 			'ergebnisse' => [
 				'title'       => 'Ergebnisse & Case Studies | WordPress, SEO, CRO',

--- a/blocksy-child/page-wordpress-agentur.php
+++ b/blocksy-child/page-wordpress-agentur.php
@@ -38,7 +38,7 @@ $pain_cards = [
 	[
 		'icon'  => '01',
 		'title' => 'Sichtbarkeit ohne Richtung',
-		'text'  => 'Es gibt Inhalte, aber keine saubere Verbindung zwischen Suchintention, Angebotsseite und nächstem Schritt. Genau dort greifen <a href="' . esc_url( $seo_url ) . '">technische SEO</a> und Angebotslogik ineinander.',
+		'text'  => 'Es gibt Inhalte, aber keine saubere Verbindung zwischen Suchintention, Angebotsseite und nächstem Schritt. Genau dort greifen <a href="#technisches-seo">technisches SEO</a> und Angebotslogik ineinander.',
 	],
 	[
 		'icon'  => '02',
@@ -292,8 +292,8 @@ get_header();
 					<h2 class="nx-headline-section">Spezialisierte Leistungen</h2>
 				</div>
 				<div class="wp-agentur-spoke-grid">
-					<a href="<?php echo esc_url( $seo_url ); ?>" class="wp-agentur-spoke-card" data-track-action="cta_agentur_spoke_seo" data-track-category="navigation">
-						<span class="wp-agentur-spoke-card__title">WordPress SEO Hannover</span>
+					<a href="#technisches-seo" class="wp-agentur-spoke-card" data-track-action="cta_agentur_spoke_seo" data-track-category="navigation">
+						<span class="wp-agentur-spoke-card__title">Technisches SEO</span>
 						<span class="wp-agentur-spoke-card__desc">Crawlability, Seitenstruktur, interne Verlinkung und technische Fixes für kaufnahe Rankings.</span>
 					</a>
 					<a href="<?php echo esc_url( $tracking_url ); ?>" class="wp-agentur-spoke-card" data-track-action="cta_agentur_spoke_tracking" data-track-category="navigation">
@@ -304,10 +304,73 @@ get_header();
 						<span class="wp-agentur-spoke-card__title">Conversion Rate Optimierung für WordPress</span>
 						<span class="wp-agentur-spoke-card__desc">Angebotsseiten, Proof, CTA-Führung und Formulare so ordnen, dass aus Besuchern Anfragen werden.</span>
 					</a>
-					<a href="<?php echo esc_url( $wartung_url ); ?>" class="wp-agentur-spoke-card" data-track-action="cta_agentur_spoke_wartung" data-track-category="navigation">
+					<a href="#wordpress-wartung" class="wp-agentur-spoke-card" data-track-action="cta_agentur_spoke_wartung" data-track-category="navigation">
 						<span class="wp-agentur-spoke-card__title">WordPress Wartung Hannover</span>
-						<span class="wp-agentur-spoke-card__desc">Updates, Sicherheit, Backups und stabile Betriebsroutinen als WGOS-Fundament.</span>
+						<span class="wp-agentur-spoke-card__desc">Updates, Sicherheit, Backups und stabile Betriebsroutinen als Fundament für alles andere.</span>
 					</a>
+				</div>
+			</div>
+		</section>
+
+		<section id="technisches-seo" class="nx-section">
+			<div class="nx-container">
+				<div class="nx-section-header">
+					<h2 class="nx-headline-section">Technisches WordPress-SEO für Hannover und DACH</h2>
+					<p class="wp-agentur-section-intro">
+						Technisches SEO ist hier kein Meta-Feintuning, sondern Arbeit an Crawlability, Seitenstruktur und interner Verlinkung — priorisiert für kaufnahe Seitentypen wie Angebotsseiten, Audit-Einstiege und zentrale Proof-Seiten.
+					</p>
+				</div>
+				<div class="nx-prose wp-agentur-prose">
+					<h3>Was typischerweise klemmt</h3>
+					<ul class="premium-list">
+						<li><span class="check-icon">→</span><div>Kaufnahe Seiten indexieren schlecht, weil Crawlability und interne Verlinkung unklar sind.</div></li>
+						<li><span class="check-icon">→</span><div>Meta-Titel und Beschreibungen treffen die Suchintention nicht — Impressionen ohne Klicks.</div></li>
+						<li><span class="check-icon">→</span><div>Pillar- und Cluster-Logik fehlt: Inhalte bleiben Einzelseiten ohne Themen-Rückgrat.</div></li>
+						<li><span class="check-icon">→</span><div>Schema-Markup, Core Web Vitals und Server-Tuning sind isoliert statt als ein System verzahnt.</div></li>
+					</ul>
+
+					<h3>Wie ich das als WordPress-Agentur löse</h3>
+					<ul class="premium-list">
+						<li><span class="check-icon">✓</span><div>Technical SEO Audit mit priorisierter Hebel-Liste statt generischer Checkliste.</div></li>
+						<li><span class="check-icon">✓</span><div>Keyword-Strategie nach Suchintention und Seitentypen, nicht nach Suchvolumen.</div></li>
+						<li><span class="check-icon">✓</span><div>Pillar Pages und Content Hubs mit stringenter interner Verlinkung.</div></li>
+						<li><span class="check-icon">✓</span><div>On-Page-SEO: Snippets, Seitentitel und Headlines gegen die Suchintention geschärft.</div></li>
+						<li><span class="check-icon">✓</span><div>Local SEO für Hannover, wenn regionale Nachfrage relevant ist.</div></li>
+					</ul>
+					<p class="wp-agentur-section-intro">
+						Ob technisches SEO bei Ihrer Website heute den größten Hebel hat, zeigt die <a href="<?php echo esc_url( $audit_url ); ?>" data-track-action="cta_agentur_seo_audit" data-track-category="lead_gen">System-Diagnose</a> in ca. 60 Sekunden.
+					</p>
+				</div>
+			</div>
+		</section>
+
+		<section id="wordpress-wartung" class="nx-section">
+			<div class="nx-container">
+				<div class="nx-section-header">
+					<h2 class="nx-headline-section">WordPress Wartung und Wartungsvertrag in Hannover</h2>
+					<p class="wp-agentur-section-intro">
+						Wartung ist hier kein Ticket-System, sondern der Betriebsblock aus Updates, Sicherheit, Backups, Performance und klaren Rollback-Prozessen — Fundament für alles, was darauf an SEO, Conversion und bezahlter Nachfrage aufbaut.
+					</p>
+				</div>
+				<div class="nx-prose wp-agentur-prose">
+					<h3>Was ein belastbarer WordPress-Wartungsvertrag abdeckt</h3>
+					<ul class="premium-list">
+						<li><span class="check-icon">✓</span><div>Security Hardening: Zugriffe, Rechte und Wiederherstellungswege abgesichert.</div></li>
+						<li><span class="check-icon">✓</span><div>Update-Management: planbar, testbar, rollback-fähig — kein Ad-hoc-Risiko.</div></li>
+						<li><span class="check-icon">✓</span><div>Backups und Monitoring mit verifizierter Wiederherstellung, nicht nur Dump-Dateien.</div></li>
+						<li><span class="check-icon">✓</span><div>Plugin-Audit: Reduktion von Wartungslast und Konflikten.</div></li>
+						<li><span class="check-icon">✓</span><div>Performance-Diagnose und bei Bedarf Server-Tuning.</div></li>
+					</ul>
+
+					<h3>Warum das kein generischer Wartungsvertrag ist</h3>
+					<ul class="premium-list">
+						<li><span class="check-icon">→</span><div>Direkter Ansprechpartner statt Support-Pipeline.</div></li>
+						<li><span class="check-icon">→</span><div>Wartung als Fundament — erst stabiler Betrieb, dann SEO, Conversion und Ads.</div></li>
+						<li><span class="check-icon">→</span><div>Für Unternehmen mit relevanter Website und regelmäßigem Traffic, nicht für Low-Traffic-Projekte.</div></li>
+					</ul>
+					<p class="wp-agentur-section-intro">
+						Wartungsvertrag anfragen: über den <a href="<?php echo esc_url( $contact_url ); ?>" data-track-action="cta_agentur_wartung_contact" data-track-category="lead_gen">Kontaktpfad</a> oder direkt in der <a href="<?php echo esc_url( $audit_url ); ?>" data-track-action="cta_agentur_wartung_audit" data-track-category="lead_gen">System-Diagnose</a> einordnen.
+					</p>
 				</div>
 			</div>
 		</section>

--- a/blocksy-child/template-parts/site-footer.php
+++ b/blocksy-child/template-parts/site-footer.php
@@ -122,7 +122,6 @@ $audit_footer_note = function_exists( 'nexus_get_audit_footer_note' ) ? nexus_ge
 				<ul class="ft__list">
 					<li><a class="ft__link-strong" href="<?php echo esc_url( $cases_url ); ?>" data-track-action="cta_footer_nav_results" data-track-category="trust">Ergebnisse</a></li>
 					<li><a href="<?php echo esc_url( $blog_url ); ?>" data-track-action="cta_footer_nav_insights" data-track-category="navigation">Insights</a></li>
-					<li><a href="<?php echo esc_url( $seo_url ); ?>" data-track-action="cta_footer_nav_seo" data-track-category="navigation">WordPress SEO</a></li>
 					<li><a href="<?php echo esc_url( $cwv_url ); ?>" data-track-action="cta_footer_nav_cwv" data-track-category="navigation">Core Web Vitals</a></li>
 					<li><a href="<?php echo esc_url( $tools_url ); ?>" data-track-action="cta_footer_nav_tools" data-track-category="navigation">Kostenlose Tools</a></li>
 				</ul>


### PR DESCRIPTION
…er/ into agentur money page

SEOCobit-Analyse zeigt: /wordpress-agentur-hannover/ (86 Impressionen, Pos 37) kannibalisiert mit /wordpress-seo-hannover/ (42 Impressionen, Pos 56) für die Query "wordpress agentur hannover" und beide Seiten haben Snippet-Schwäche (0% CTR). /wordpress-wartung-hannover/ hat kaum Datengrundlage (5 Impressionen). Konsolidierung auf die Money Page.

page-wordpress-agentur.php:
- Zwei neue Deep-Dive-Sektionen nach #leistungen:
  * #technisches-seo — condensed Content aus der Cluster-Definition, fokussiert auf "wordpress seo hannover"-Intent (Crawlability, interne Verlinkung, Pillar/Cluster, Local SEO) mit CTA zur System-Diagnose
  * #wordpress-wartung — condensed Content zu Wartungsvertrag, Security Hardening, Update-Management, Plugin-Audit, mit CTAs zu Kontakt + System-Diagnose
- Spoke-Card-Links für "Technisches SEO" und "WordPress Wartung Hannover" zeigen jetzt auf In-Page-Anker statt auf externe URLs — kein Redirect-Bounce auf der Seite
- Pain-Card-Inline-Link "technische SEO" zeigt auf #technisches-seo statt $seo_url

inc/helpers.php nexus_get_legacy_offer_redirect_map():
- /wordpress-seo-hannover/ → /wordpress-agentur-hannover/#technisches-seo (301)
- /wordpress-wartung-hannover/ → /wordpress-agentur-hannover/#wordpress-wartung (301)
- /seo/ ebenfalls auf #technisches-seo statt auf separate SEO-Seite umgelenkt
- Redirect fires via template_redirect priority 2, BEVOR die alten Cluster-Seiten überhaupt rendern → SEO-Equity transferiert, Kannibalisierung aufgelöst

inc/seo-meta.php:
- Title + Description für /wordpress-agentur-hannover/ geschärft: Title neu: "WordPress Agentur Hannover – SEO, Wartung & Conversion" (~56 Zeichen) Description neu: enthält Intent-Keywords (technisches SEO, Wartungsvertrag, Tracking, Conversion) + Proof (Referenz E3, -83% Leadkosten), ~150 Zeichen

template-parts/site-footer.php:
- "WordPress SEO" aus Footer-Navigation raus. Thema wird jetzt über die Agentur-Seite abgedeckt, nicht mehr als separater Menüpunkt.

Bewusst NICHT geändert:
- inc/wgos-cluster-pages.php: Cluster-Definitionen für seo + wartung bleiben. Redirect fires first (template_redirect prio 2), Cluster-Rendering nie erreicht. Vorteil: reversibel, falls Seiten wieder aktiviert werden sollen.
- page-seo.php + page-wordpress-wartung-hannover.php Template-Files bleiben physisch im Repo — 301-Redirect springt bevor die Templates geladen werden.
- $seo_url + $wartung_url Variablen in div. Templates bleiben (verwendet für interne Fallback-Logik, resolvieren jetzt zu URLs die weiterleiten).
- /wordpress-wartung-hannover/ rankt Pos 3 für "wordpress wartungsvertrag hannover" (aber nur 1 Impression). 301 transferiert die Ranking-Power auf Agentur-Seite; Wartung-Sektion hat eigenen Wartungsvertrag-CTA, damit die kaufnahe Intent bedient wird.

Erwartete Wirkung:
- Kannibalisierung für "wordpress agentur hannover" weg (eine URL für alle Intent-Varianten)
- Agentur-Money-Page wird inhaltstiefer → Topical Authority steigt → realistisch Position 37 → Top 20 für Primary Query
- CTR-Upside durch geschärftes Snippet
- Wartungs-Intent + SEO-Intent werden auf der Agentur-Seite bedient statt dünn verstreut

Risiko:
- Google braucht typisch 4-8 Wochen bis 301 vollständig verarbeitet
- Kurzzeitig Ranking-Wackler möglich
- Backlinks auf /wordpress-seo-hannover/ transferieren via 301 (sofern vorhanden)

https://claude.ai/code/session_017WJBaq4T73pyogCEdzMJvQ