### PR TITLE
seo: schema + sitemap cleanup — no more mixed signals for noindex/301…

### DIFF
--- a/blocksy-child/inc/org-schema.php
+++ b/blocksy-child/inc/org-schema.php
@@ -88,25 +88,25 @@ function hu_output_schema()
         ],
         'hasOfferCatalog' => [
             '@type'           => 'OfferCatalog',
-            'name'            => 'Leistungen für B2B-Unternehmen',
+            'name'            => 'Leistungen für Solar-, Wärmepumpen- und B2B-Anbieter',
             'itemListElement' => [
                 [
                     '@type'       => 'Offer',
                     'name'        => 'System-Diagnose',
-                    'description' => 'Kostenloser Ersteinstieg: persönliche Analyse der drei größten Anfragebremsen auf einer B2B-Website.',
+                    'description' => 'Kostenloser Ersteinstieg: persönliche Analyse der drei größten Anfragebremsen für Solar-, Wärmepumpen- und B2B-Websites.',
                     'url'         => home_url('/growth-audit/'),
                 ],
                 [
                     '@type'       => 'Offer',
-                    'name'        => 'WordPress Growth Operating System (WGOS)',
-                    'description' => 'Strukturiertes Nachfrage-System: Strategie, Fundament, Messbarkeit, Sichtbarkeit und Conversion auf WordPress-Basis.',
-                    'url'         => home_url('/wordpress-growth-operating-system/'),
+                    'name'        => 'Eigenes Anfrage-System für Solar- und Wärmepumpen-Anbieter',
+                    'description' => 'Aufbau eigener Anfrage-Systeme zur Ablösung von Portal-Leads: Website, Tracking, Vorqualifizierung und Kanal-Steuerung als verbundenes System.',
+                    'url'         => home_url('/solar-waermepumpen-leadgenerierung/'),
                 ],
                 [
                     '@type'       => 'Offer',
-                    'name'        => 'Technische SEO',
-                    'description' => 'Technische Suchmaschinenoptimierung: Core Web Vitals, Crawlability, Schema-Markup und Seitenarchitektur.',
-                    'url'         => home_url('/seo-fuer-b2b-unternehmen/'),
+                    'name'        => 'WordPress Agentur Hannover',
+                    'description' => 'WordPress-Entwicklung für B2B in Hannover: technisches SEO, Wartungsvertrag, Tracking und Conversion als verbundenes System.',
+                    'url'         => home_url('/wordpress-agentur-hannover/'),
                 ],
                 [
                     '@type'       => 'Offer',
@@ -117,14 +117,8 @@ function hu_output_schema()
                 [
                     '@type'       => 'Offer',
                     'name'        => 'Conversion-Optimierung',
-                    'description' => 'Systematische Optimierung von Angebotsseiten und Nutzerpfaden für mehr qualifizierte B2B-Anfragen.',
+                    'description' => 'Systematische Optimierung von Angebotsseiten und Nutzerpfaden für mehr qualifizierte Anfragen.',
                     'url'         => home_url('/conversion-optimierung/'),
-                ],
-                [
-                    '@type'       => 'Offer',
-                    'name'        => 'WordPress Agentur Hannover',
-                    'description' => 'WordPress-Entwicklung und Weiterentwicklung als Nachfragesystem für B2B-Unternehmen in Hannover und der Region.',
-                    'url'         => home_url('/wordpress-agentur-hannover/'),
                 ],
             ],
         ],
@@ -136,9 +130,9 @@ function hu_output_schema()
     $service_definitions = [
         'wordpress-agentur-hannover' => [
             'name'        => 'WordPress Agentur Hannover',
-            'description' => 'WordPress Agentur in Hannover für B2B-Unternehmen: Angebotsseiten, technische SEO, privacy-first Measurement, Conversion-Logik und kontrollierte Weiterentwicklung als Nachfrage-System.',
+            'description' => 'WordPress Agentur in Hannover für B2B-Unternehmen: technisches SEO, Wartungsvertrag, Tracking, Conversion und Angebotsseiten als ein verbundenes System mit kontrollierter Weiterentwicklung.',
             'serviceType' => 'WordPress Agentur',
-            'serviceOutput' => 'Steuerbares WordPress-System mit Angebotsseiten, Datenebene, KPI-Klarheit und vollen Zugängen'
+            'serviceOutput' => 'Steuerbares WordPress-System mit Angebotsseiten, technischem SEO, Wartung, Datenebene, KPI-Klarheit und vollen Zugängen'
         ],
 
         'customer-journey-audit' => [
@@ -189,26 +183,9 @@ function hu_output_schema()
             'serviceOutput' => 'Priorisierte Entscheidungsvorlage für die nächsten sinnvollen Struktur- und Umsetzungsentscheidungen'
         ],
 
-        'wordpress-wartung-hannover' => [
-            'name'        => 'WordPress Wartung Hannover',
-            'description' => 'WGOS-Cluster für WordPress-Wartung in Hannover: Updates, Sicherheit, Backups, Performance und kontrollierbare Betriebsroutinen für B2B-Websites.',
-            'serviceType' => 'WordPress Betrieb & Wartung',
-            'serviceOutput' => 'Stabiler, abgesicherter und kontrollierbarer WordPress-Betrieb als Fundament für Sichtbarkeit und Conversion'
-        ],
-
-        'wordpress-seo' => [
-            'name'        => 'WordPress SEO',
-            'description' => 'SEO-Optimierung für WordPress-Websites – von technischer SEO bis Content-Strategie.',
-            'serviceType' => 'SEO-Dienstleistung',
-            'serviceOutput' => 'Verbesserte Rankings & Conversion Rates'
-        ],
-
-        'wordpress-seo-hannover' => [
-            'name'        => 'Technisches SEO für WordPress in Hannover',
-            'description' => 'WGOS-Cluster für technisches SEO auf WordPress in Hannover: technische Basis, Seitenstruktur und conversion-nahe Sichtbarkeit für B2B-Websites.',
-            'serviceType' => 'Technisches SEO für WordPress',
-            'serviceOutput' => 'Priorisierte SEO-Bausteine aus Technical SEO, Keyword-Strategie, Pillar Pages und interner Verlinkung'
-        ],
+        // Legacy-Services wordpress-wartung-hannover, wordpress-seo, wordpress-seo-hannover entfernt:
+        // Seiten sind 301 auf /wordpress-agentur-hannover/#wordpress-wartung bzw. #technisches-seo konsolidiert,
+        // daher keine eigenständigen Service-Schemas mehr — gehören jetzt in die Agentur-Service-Beschreibung.
 
         'core-web-vitals-optimierung' => [
             'name'        => 'Speed & Core Web Vitals Optimierung',
@@ -285,42 +262,9 @@ function hu_output_schema()
             'serviceOutput' => 'Kampagnenfähige Zielseiten und belastbare Tracking-Signale für effiziente Paid-Aktivierung'
         ],
 
-        'wordpress-growth-operating-system' => [
-            'name'        => 'WordPress Growth Operating System (WGOS)',
-            'description' => 'Strukturiertes Nachfrage-System für Unternehmen: Strategie, Fundament, Messbarkeit, Sichtbarkeit und Conversion in einer klaren WordPress-Logik.',
-            'serviceType' => 'Growth Operating System',
-            'serviceOutput' => 'Strukturiertes Nachfrage-System auf WordPress-Basis mit klarer Reihenfolge, voller Ownership und planbarer Weiterentwicklung.',
-            'offers'      => [
-                [
-                    '@type'         => 'Offer',
-                    'name'          => 'Fundament',
-                    'price'         => 1500,
-                    'priceCurrency' => 'EUR',
-                    'description'   => '30 Credits/Monat. Fundament, Messbarkeit und technische Stabilität ordnen.'
-                ],
-                [
-                    '@type'         => 'Offer',
-                    'name'          => 'Systemaufbau',
-                    'price'         => 2800,
-                    'priceCurrency' => 'EUR',
-                    'description'   => '60 Credits/Monat. Sichtbarkeit und Conversion auf saubere Basis setzen.'
-                ],
-                [
-                    '@type'         => 'Offer',
-                    'name'          => 'Weiterentwicklung',
-                    'price'         => 4500,
-                    'priceCurrency' => 'EUR',
-                    'description'   => '100+ Credits/Monat. Das System kontrolliert ausbauen und weiter nachschärfen.'
-                ]
-            ]
-        ],
-
-        'wgos' => [
-            'name'        => 'WordPress Growth Operating System (WGOS)',
-            'description' => 'Strukturiertes Nachfrage-System für Unternehmen: WordPress als verbindende Architektur für Strategie, Fundament, Messbarkeit, Sichtbarkeit und Conversion.',
-            'serviceType' => 'Growth Operating System',
-            'serviceOutput' => 'Strukturiertes Nachfrage-System mit klarer Priorisierung, messbarer Entwicklung und voller Kontrolle'
-        ],
+        // Legacy-Services wordpress-growth-operating-system + wgos entfernt:
+        // WGOS ist in der neuen Positionierung Hard-Ban, Seite ist noindex,
+        // daher keine Service-Schema-Signale mehr zur WGOS-URL.
     ];
 
     /**
@@ -427,7 +371,8 @@ function hu_output_schema()
                     'serviceType'   => 'WGOS Asset',
                     'serviceOutput' => (string) ($asset['result'] ?? ''),
                     'areaServed'    => ['@type' => 'AdministrativeArea', 'name' => 'DACH'],
-                    'isPartOf'      => ['@id' => home_url('/wordpress-growth-operating-system/#service')],
+                    // isPartOf-Referenz auf WGOS-Hub entfernt (noindex);
+                    // Asset wird via provider an Organization gebunden.
                 ];
 
                 $schemas[] = $service;
@@ -640,9 +585,9 @@ function hu_output_schema()
                     ],
                     [
                         '@type' => 'WebPage',
-                        'name'  => 'WordPress Growth Operating System',
-                        'description' => 'Systemlogik für Sichtbarkeit, Tracking, Conversion und kontrollierte Weiterentwicklung.',
-                        'url'   => home_url('/wordpress-growth-operating-system/')
+                        'name'  => 'Eigenes Anfrage-System für Solar- und Wärmepumpen-Anbieter',
+                        'description' => 'Aufbau eigener Anfrage-Systeme zur Ablösung von Portal-Leads für Solar-, Wärmepumpen- und Energie-Anbieter im DACH-Raum.',
+                        'url'   => home_url('/solar-waermepumpen-leadgenerierung/')
                     ],
                 ];
             }
@@ -824,15 +769,15 @@ function hu_output_schema()
             ];
 
         } elseif ( is_singular( 'wgos_asset' ) ) {
-            // WGOS > Asset
-            $wgos_url = function_exists( 'nexus_get_primary_public_url' )
-                ? nexus_get_primary_public_url( 'wgos', home_url( '/wordpress-growth-operating-system/' ) )
-                : home_url( '/wordpress-growth-operating-system/' );
+            // Agentur > Asset — WGOS-Hub-Crumb entfernt (noindex).
+            $agentur_url = function_exists( 'nexus_get_primary_public_url' )
+                ? nexus_get_primary_public_url( 'agentur', home_url( '/wordpress-agentur-hannover/' ) )
+                : home_url( '/wordpress-agentur-hannover/' );
             $breadcrumb_items[] = [
                 '@type'    => 'ListItem',
                 'position' => $bc_position++,
-                'name'     => 'WGOS',
-                'item'     => $wgos_url,
+                'name'     => 'WordPress Agentur Hannover',
+                'item'     => $agentur_url,
             ];
             $breadcrumb_items[] = [
                 '@type'    => 'ListItem',

--- a/blocksy-child/inc/seo-meta.php
+++ b/blocksy-child/inc/seo-meta.php
@@ -91,14 +91,8 @@ function hu_get_forced_singular_seo_map() {
 				'title'       => 'Über Haşim Üner | WordPress, SEO und klare Systeme',
 				'description' => 'Über Haşim Üner: WordPress, technische SEO, privacy-first Messbarkeit und klare Nutzerführung für B2B-Websites mit Diagnose vor Aktion.',
 			],
-			'wgos' => [
-				'title'       => 'WordPress Growth Operating System | Haşim Üner',
-				'description' => 'Das WordPress Growth Operating System verbindet SEO, Tracking, Conversion und Angebotslogik zu einem strukturierten Nachfrage-System für B2B-Websites.',
-			],
-			'wordpress-growth-operating-system' => [
-				'title'       => 'WordPress Growth Operating System | Haşim Üner',
-				'description' => 'Das WordPress Growth Operating System verbindet SEO, Tracking, Conversion und Angebotslogik zu einem strukturierten Nachfrage-System für B2B-Websites.',
-			],
+			// 'wgos' / 'wordpress-growth-operating-system' Meta-Einträge entfernt:
+			// Seiten sind noindex, daher keine öffentlichen Meta-Signale mehr.
 			'tools' => [
 				'title'       => 'Kostenlose Website- und ROI-Tools | Haşim Üner',
 				'description' => 'Kostenlose Tools für ROI, Website-Analyse und Performance: schnelle Checks für Marketing-, Website- und WordPress-Entscheidungen.',
@@ -135,18 +129,9 @@ function hu_get_forced_singular_seo_map() {
 				'title'       => 'Kostenloses Website Audit für mehr Anfragen | Haşim Üner',
 				'description' => 'Ich analysiere, wo Klarheit, Vertrauen, Struktur und Conversion-Logik auf deiner Website bremsen – mit fundierter Ersteinschätzung ohne Pflicht-Call.',
 			],
-			'wordpress-wartung-hannover' => [
-				'title'       => 'WordPress Wartung Hannover – B2B Wartungsvertrag',
-				'description' => 'Sicherheits-Updates, Backups und Performance für B2B WordPress-Websites. Kein Ticket-System – direkter Ansprechpartner. Wartungspaket anfragen.',
-			],
-			'wordpress-seo-hannover' => [
-				'title'       => 'WordPress SEO Hannover für B2B | Technisches SEO & Audit',
-				'description' => 'WordPress SEO in Hannover fuer B2B: technisches SEO, Crawlability und interne Verlinkung fuer kaufnahe Seiten. System-Diagnose als 60-Sekunden-Diagnose fuer priorisierte Hebel.',
-			],
-			'ki-integration-wordpress' => [
-				'title'       => 'KI-Integration für WordPress – DSGVO-konform | Haşim Üner',
-				'description' => 'KI-Features direkt in WordPress: Chatbots, Lead-Qualifizierung, Wissenssuche, Automatisierung – auf eigener Infrastruktur, ohne Datenabfluss.',
-			],
+			// 'wordpress-wartung-hannover' + 'wordpress-seo-hannover' + 'ki-integration-wordpress' entfernt:
+			// /wordpress-seo-hannover/ und /wordpress-wartung-hannover/ sind 301 auf die Agentur-Page (Anker-Sektionen);
+			// /ki-integration-wordpress/ ist noindex. Keine eigenständigen SEO-Signale mehr nötig.
 			'solar-waermepumpen-leadgenerierung' => [
 				'title'       => 'Leadgenerierung für Solar & Wärmepumpen | Weniger Kosten, bessere Anfragen',
 				'description' => 'Schluss mit teuren Portal-Leads. Eigenes Anfrage-System für Solarteure und Wärmepumpen-Installateure. Referenz: –83 % Kosten pro Anfrage. Kostenloses Erstgespräch.',
@@ -881,4 +866,84 @@ add_action( 'template_redirect', function () {
 	if ( ! defined( 'WPSEO_VERSION' ) && ! defined( 'SEOPRESS_VERSION' ) ) {
 		remove_action( 'wp_head', 'rel_canonical' );
 	}
+} );
+
+/**
+ * Slugs deprecated in der neuen Positionierung:
+ * - wgos / wordpress-growth-operating-system: noindex (Legacy-Hub)
+ * - ki-integration-wordpress / ki-integration: noindex (Legacy-Thema)
+ * - loesungen: noindex (interne Angebotsübersicht, nicht mehr beworben)
+ * - wordpress-seo-hannover / wordpress-wartung-hannover: 301 auf Agentur-Page-Anker
+ *
+ * @return array<int, string>
+ */
+function nexus_get_sitemap_excluded_slugs() {
+	return [
+		'wordpress-growth-operating-system',
+		'wgos',
+		'ki-integration-wordpress',
+		'ki-integration',
+		'loesungen',
+		'wordpress-seo-hannover',
+		'wordpress-wartung-hannover',
+	];
+}
+
+/**
+ * Resolve excluded slugs to page IDs once per request.
+ *
+ * @return array<int, int>
+ */
+function nexus_get_sitemap_excluded_ids() {
+	static $ids = null;
+
+	if ( null !== $ids ) {
+		return $ids;
+	}
+
+	$ids = [];
+	foreach ( nexus_get_sitemap_excluded_slugs() as $slug ) {
+		$page = get_page_by_path( $slug );
+		if ( $page instanceof WP_Post ) {
+			$ids[] = (int) $page->ID;
+		}
+	}
+
+	$ids = array_values( array_unique( $ids ) );
+	return $ids;
+}
+
+/**
+ * Exclude deprecated/noindex pages from WordPress core sitemap (wp-sitemap.xml).
+ *
+ * Verhindert Mischsignale: Sitemap-Eintrag ("crawl mich") vs. noindex-Header
+ * oder 301-Redirect. Google würde sonst Crawl-Budget auf Dead-End-URLs verschwenden.
+ */
+add_filter( 'wp_sitemaps_posts_query_args', function ( $args, $post_type ) {
+	if ( 'page' !== $post_type ) {
+		return $args;
+	}
+
+	$excluded_ids = nexus_get_sitemap_excluded_ids();
+	if ( empty( $excluded_ids ) ) {
+		return $args;
+	}
+
+	$existing               = $args['post__not_in'] ?? [];
+	$args['post__not_in']   = array_values( array_unique( array_merge( (array) $existing, $excluded_ids ) ) );
+
+	return $args;
+}, 10, 2 );
+
+/**
+ * Exclude deprecated/noindex pages from Rank Math sitemap (sitemap_index.xml).
+ *
+ * Rank Math erkennt noindex-Meta in der eigenen Settings-Oberfläche automatisch,
+ * unser noindex wird aber per HTTP-Header + wp_head gesetzt — daher explizite
+ * ID-basierte Exclusion als Safety-Net.
+ */
+add_filter( 'rank_math/sitemap/exclude_posts', function ( $excluded ) {
+	$excluded = is_array( $excluded ) ? $excluded : [];
+	$excluded = array_values( array_unique( array_merge( $excluded, nexus_get_sitemap_excluded_ids() ) ) );
+	return $excluded;
 } );


### PR DESCRIPTION
… pages

Nach dem Legacy-Pages-Lockdown (WGOS, KI-Integration, Lösungen auf noindex) und der SEO/Wartung-Konsolidierung auf die Agentur-Money-Page (301-Redirect) blieben widersprüchliche Signale: Schema.org listete diese Seiten noch als hasPart/Service, Sitemap enthielt sie noch als "crawl mich". Dieser Commit räumt beides auf.

inc/org-schema.php:
- hasOfferCatalog (LocalBusiness): WGOS-Offer entfernt; stattdessen Solar/Wärmepumpen- Anfrage-System als primärer Offer. Agentur-Offer-Beschreibung reflektiert jetzt die neue Breite (SEO + Wartung + Tracking + Conversion auf einer Seite). "Leistungen für B2B-Unternehmen" → "Leistungen für Solar-, Wärmepumpen- und B2B-Anbieter".
- service_definitions: Deprecated Entries entfernt:
  * wordpress-growth-operating-system + wgos (Seite noindex)
  * wordpress-seo-hannover + wordpress-seo (301 auf Agentur-Anker)
  * wordpress-wartung-hannover (301 auf Agentur-Anker)
- wordpress-agentur-hannover Service description/serviceOutput reflektiert konsolidierte Scope (SEO + Wartung + Conversion).
- wgos_asset-Single Service-Schema: isPartOf-Referenz auf /wordpress-growth-operating-system/ entfernt (Provider-Binding an Organization reicht, keine noindex-URL-Referenz).
- wgos_asset-Breadcrumb: "WGOS > Asset" → "WordPress Agentur Hannover > Asset" (saubere Breadcrumb-Kette ohne noindex-Crumb).
- CollectionPage fallback toolParts: WGOS-WebPage-Entry durch Solar-Anfrage-System ersetzt.

inc/seo-meta.php:
- Meta-Entries für 'wgos', 'wordpress-growth-operating-system', 'wordpress-seo-hannover', 'wordpress-wartung-hannover', 'ki-integration-wordpress' entfernt (Seiten sind noindex oder 301, daher keine öffentlichen Meta-Signale).
- Fallback-Title-Setter für direkte Browser-Aufrufe der WGOS-Slugs bleiben (kosmetisch, irrelevant für Index).
- Neue Filter:
  * wp_sitemaps_posts_query_args — schließt Deprecated-Slugs aus WP-Core-Sitemap (wp-sitemap.xml) via post__not_in aus.
  * rank_math/sitemap/exclude_posts — schließt dieselben IDs aus Rank Math Sitemap (sitemap_index.xml) aus.
  * nexus_get_sitemap_excluded_slugs() + nexus_get_sitemap_excluded_ids() als zentrale Liste (Single Source of Truth für beide Filter).

Ausgeschlossene Slugs:
- wordpress-growth-operating-system, wgos (noindex, Hub deprecated)
- ki-integration-wordpress, ki-integration (noindex, Legacy-Thema)
- loesungen (noindex, interne Übersicht)
- wordpress-seo-hannover, wordpress-wartung-hannover (301 auf Agentur-Anker)

Bewusst NICHT geändert:
- inc/wgos-cluster-pages.php Cluster-Config bleibt (reversibel).
- Fallback-Titel in seo-meta.php für direkte Browser-Aufrufe bleiben (kosmetisch).
- wgos_asset-Post-Type selbst wird nicht noindexed — separater Scope, falls Asset-Singles jemals aufgeräumt werden sollen.

Erwartete Wirkung:
- Google Search Console sollte in den nächsten Crawls keine Sitemap-Submissions mehr für die 6 Deprecated-Slugs bringen.
- Structured-Data-Testing zeigt konsistente Services-Liste ohne WGOS/KI-Integration.
- Keine "Submitted URL marked noindex"-Warnungen mehr in GSC Coverage Report.

https://claude.ai/code/session_017WJBaq4T73pyogCEdzMJvQ