### PR TITLE
cro: finalize audit-funnel — header CTA, tracking schema, form microc…

### DIFF
--- a/blocksy-child/inc/cja-shortcode.php
+++ b/blocksy-child/inc/cja-shortcode.php
@@ -66,7 +66,7 @@ function cja_audit_shortcode() {
 
 	ob_start();
 	?>
-	<div class="cja-wrapper" id="cja-app" data-track-section="growth_audit_instant">
+	<div class="cja-wrapper" id="cja-app" data-track-section="growth_audit_instant" data-track-funnel-stage="audit_input">
 		<span id="form" class="cja-anchor" aria-hidden="true"></span>
 
 		<div class="cja-phase cja-hero" id="cja-input">
@@ -77,7 +77,7 @@ function cja_audit_shortcode() {
 			<div class="cja-input-group">
 				<label class="screen-reader-text" for="cja-url-input">Website-URL</label>
 				<input type="text" id="cja-url-input" placeholder="ihre-domain.de" autocomplete="off" inputmode="url" autocapitalize="off" spellcheck="false" aria-describedby="cja-error">
-				<button id="cja-submit" type="button" data-track-action="cja_start_analysis" data-track-category="lead_gen" data-track-section="growth_audit_input">Diagnose starten</button>
+				<button id="cja-submit" type="button" data-track-action="cja_start_analysis" data-track-category="lead_gen" data-track-section="growth_audit_input" data-track-funnel-stage="audit_input">Diagnose starten</button>
 			</div>
 			<p class="cja-input-help">Starten Sie mit Ihrer Startseite oder der wichtigsten Angebotsseite. Sie sehen direkt die größten Reibungen und priorisierten Hebel.</p>
 
@@ -134,7 +134,7 @@ function cja_audit_shortcode() {
 				<h2>Wenn das nach Ihrer Situation klingt, folgt jetzt die persönliche Einordnung.</h2>
 				<p>Kurz beschreiben, wo Ihr Anfrageprozess heute steht — Sie erhalten eine persönliche Einschätzung per E-Mail, ohne Pitch.</p>
 				<div class="cja-cta-actions">
-					<a href="<?php echo esc_url( $request_url ); ?>" class="cja-cta-button" data-track-action="cja_results_request" data-track-category="lead_gen" data-track-section="growth_audit_results">Einordnung anfordern</a>
+					<a href="<?php echo esc_url( $request_url ); ?>" class="cja-cta-button" data-track-action="cja_results_request" data-track-category="lead_gen" data-track-section="growth_audit_results" data-track-funnel-stage="audit_results">Einordnung anfordern</a>
 				</div>
 				<div class="cja-cta-meta">2 Minuten · persönliche Rückmeldung · kein Pflicht-Call</div>
 			</div>

--- a/blocksy-child/inc/enqueue.php
+++ b/blocksy-child/inc/enqueue.php
@@ -232,12 +232,12 @@ function hu_enqueue_assets() {
 				'submittingLabel' => 'Wird gesendet …',
 				'errorMessage'    => 'Die Anfrage konnte gerade nicht gesendet werden. Bitte versuchen Sie es erneut.',
 				'progressMessages' => [
-					'solution'     => 'Gleich wird klar, wo der größte Hebel liegt.',
-					'audience'     => 'Zielmarkt bestimmt die Formular-Logik.',
-					'challenge'    => 'Fast da — noch wenige kurze Fragen.',
-					'site-state'   => 'Noch 3 Schritte bis zur Einordnung.',
-					'timing'       => 'Gleich geschafft — dann folgen Ihre Kontaktdaten.',
-					'contact-pref' => 'Letzter Schritt: Wohin soll die Einordnung?',
+					'solution'     => 'Ihre Leistung — ca. 60 Sekunden bis zur Einordnung.',
+					'audience'     => 'Ihr Zielmarkt — kurz einsortieren.',
+					'challenge'    => 'Ihr Hauptengpass — wo klemmt es aktuell?',
+					'site-state'   => 'Ihr Status — noch 3 Schritte bis zur Einordnung.',
+					'timing'       => 'Ihr Timing — gleich folgen die Kontaktdaten.',
+					'contact-pref' => 'Rückmeldung — letzter Schritt vor Kontakt.',
 					'contact'      => 'Ihre Kontaktdaten — dann wird eingeordnet.',
 				],
 			]

--- a/blocksy-child/page-solar-waermepumpen-leadgenerierung.php
+++ b/blocksy-child/page-solar-waermepumpen-leadgenerierung.php
@@ -215,7 +215,7 @@ $get_summary_value = static function( $field_name ) use ( $get_value, $option_la
 get_header();
 ?>
 <main id="main" class="site-main">
-	<div class="energy-page-wrapper" data-track-section="energy_service_landing">
+	<div class="energy-page-wrapper" data-track-section="energy_service_landing" data-track-funnel-stage="energy_landing">
 		<section class="nx-section nx-hero energy-hero" id="hero">
 			<div class="nx-container">
 				<div class="energy-hero__grid">
@@ -225,7 +225,7 @@ get_header();
 						<p class="nx-hero__subtitle">Ich baue Solar- und Wärmepumpen-Anbietern ein eigenes Anfrage-System &mdash; damit Ihr Vertrieb nur noch mit Interessenten spricht, die wirklich kaufen wollen.</p>
 						<p class="nx-cta-microcopy">Referenz E3 New Energy: –83 % Kosten pro Anfrage &middot; 1.750+ qualifizierte Anfragen in 9 Monaten &middot; 12 % Abschlussquote</p>
 						<div class="energy-hero__actions">
-							<a href="<?php echo esc_url( $request_url ); ?>" class="nx-btn nx-btn--primary" data-track-action="cta_energy_hero_request" data-track-category="lead_gen"><?php echo esc_html( $request_cta ); ?></a>
+							<a href="<?php echo esc_url( $request_url ); ?>" class="nx-btn nx-btn--primary" data-track-action="cta_energy_hero_request" data-track-category="lead_gen" data-track-section="energy_hero" data-track-funnel-stage="energy_hero"><?php echo esc_html( $request_cta ); ?></a>
 						</div>
 					</div>
 
@@ -241,7 +241,7 @@ get_header();
 						<h2>E3 New Energy.</h2>
 						<p>E3 New Energy ist ein regionaler Energieanbieter für Photovoltaik, Wärmepumpen und Speicherlösungen. Ausgangslage: Hohe Kosten pro Anfrage durch Portal-Zukauf, keine eigene digitale Anfrage-Infrastruktur. In 9 Monaten: eigenes System aufgebaut, Kosten pro Anfrage um 83 % gesenkt, Vertrieb arbeitet nur noch mit vorqualifizierten Anfragen.</p>
 						<div class="energy-proof__actions">
-							<a href="<?php echo esc_url( $request_url ); ?>" class="nx-btn nx-btn--primary" data-track-action="cta_energy_proof_request" data-track-category="lead_gen"><?php echo esc_html( $request_cta ); ?></a>
+							<a href="<?php echo esc_url( $request_url ); ?>" class="nx-btn nx-btn--primary" data-track-action="cta_energy_proof_request" data-track-category="lead_gen" data-track-section="energy_proof" data-track-funnel-stage="energy_proof"><?php echo esc_html( $request_cta ); ?></a>
 						</div>
 					</div>
 
@@ -302,7 +302,7 @@ get_header();
 					<h2>Nicht sicher, ob das für Sie passt?</h2>
 					<p>2 Minuten. Kein Pitch. Sie beschreiben Ihre Situation — ich melde mich innerhalb von 48 Stunden mit einer konkreten Einordnung per E-Mail.</p>
 					<div class="energy-cta-box__actions">
-						<a href="#energie-anfrage" class="nx-btn nx-btn--primary" data-track-action="cta_energy_erstgespraech" data-track-category="lead_gen"><?php echo esc_html( $request_cta ); ?></a>
+						<a href="#energie-anfrage" class="nx-btn nx-btn--primary" data-track-action="cta_energy_erstgespraech" data-track-category="lead_gen" data-track-section="energy_midpage" data-track-funnel-stage="energy_midpage"><?php echo esc_html( $request_cta ); ?></a>
 					</div>
 				</div>
 			</div>
@@ -345,7 +345,7 @@ get_header();
 									<div class="review-progress energy-progress" aria-label="Fortschritt im Branchen-Flow">
 										<div class="review-progress-head">
 											<div class="review-progress-copy">
-												<strong id="energy-progress-current" aria-live="polite" aria-atomic="true">Schritt 1 von <?php echo esc_html( (string) count( $flow_steps ) ); ?> — Gleich wird klar, wo der größte Hebel liegt.</strong>
+												<strong id="energy-progress-current" aria-live="polite" aria-atomic="true">Schritt 1 von <?php echo esc_html( (string) count( $flow_steps ) ); ?> — Ihre Leistung, ca. 60 Sekunden bis zur Einordnung.</strong>
 											</div>
 										</div>
 										<div
@@ -582,8 +582,9 @@ get_header();
 				<div class="nx-cta-box energy-cta-box">
 					<span class="nx-badge nx-badge--gold">Nächster Schritt</span>
 					<h2>Eigene Anfragen statt Portal-Abhängigkeit. In 2 Minuten Situation einordnen — Ergebnis per E-Mail.</h2>
+					<p class="nx-cta-microcopy">Referenz E3 New Energy: –83 % Kosten pro Anfrage &middot; 1.750+ qualifizierte Anfragen in 9 Monaten &middot; 12 % Abschlussquote</p>
 					<div class="energy-cta-box__actions">
-						<a href="<?php echo esc_url( $request_url ); ?>" class="nx-btn nx-btn--primary" data-track-action="cta_energy_footer_request" data-track-category="lead_gen"><?php echo esc_html( $request_cta ); ?></a>
+						<a href="<?php echo esc_url( $request_url ); ?>" class="nx-btn nx-btn--primary" data-track-action="cta_energy_footer_request" data-track-category="lead_gen" data-track-section="energy_footer" data-track-funnel-stage="energy_footer"><?php echo esc_html( $request_cta ); ?></a>
 					</div>
 				</div>
 			</div>

--- a/blocksy-child/template-parts/site-header.php
+++ b/blocksy-child/template-parts/site-header.php
@@ -60,7 +60,7 @@ if ( empty( $audit_header_meta_items ) ) {
 			</div>
 
 			<div class="nx-site-header__audit-actions">
-				<a class="nx-site-header__audit-link" href="<?php echo esc_url( $request_url ); ?>">Anfrage stellen</a>
+				<a class="nx-site-header__audit-link" href="<?php echo esc_url( $request_url ); ?>" data-track-action="cta_audit_header_results" data-track-category="lead_gen" data-track-section="audit_header" data-track-funnel-stage="audit_header">Ergebnisse ansehen</a>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
…opy, footer trust

Audit-Header (site-header.php):
- CTA "Anfrage stellen" -> "Ergebnisse ansehen" — weniger Druck vor Audit-Ergebnis
- Tracking-Attribute ergaenzt (funnel-stage=audit_header)

Tracking-Schema vereinheitlicht:
- data-track-funnel-stage eingefuehrt als Single Source of Truth fuer Funnel-Messung
- Stages: audit_input, audit_results, audit_header, energy_landing, energy_hero, energy_proof, energy_midpage, energy_footer
- Fehlende data-track-section auf Solar-Seite-CTAs nachgezogen

Formular-Microcopy (Schritt-Fortschritt):
- enqueue.php progressMessages: von generischem Reassurance-Text zu konkreter Step-Identitaet ("Ihre Leistung", "Ihr Zielmarkt", "Ihr Hauptengpass", ...)
- PHP initial render: "Schritt 1 von 7 — Gleich wird klar..." ->
  "Schritt 1 von 7 — Ihre Leistung, ca. 60 Sekunden bis zur Einordnung."

Footer-CTA-Box Trust-Element:
- Proof-Microcopy unter Footer-CTA ergaenzt (Referenz E3 New Energy — 83 % Kosten pro Anfrage, 1.750+ Anfragen, 12 % Abschlussquote), analog zur Hero-CTA. Ersetzt den entfernten sekundaeren "Audit starten"-CTA durch Trust statt Decision-Paralyse.

Damit sind alle Items aus plans/cro-funnel-fix-plan.md und den MITTEL/GERING Empfehlungen aus plans/cro-audit-funnel-analysis.md abgeschlossen.

https://claude.ai/code/session_017WJBaq4T73pyogCEdzMJvQ