### PR TITLE
cro: solar/wp v1 — infrastructure positioning, TCO block, 5-step funnel

### DIFF
--- a/blocksy-child/assets/css/energy-systems.css
+++ b/blocksy-child/assets/css/energy-systems.css
@@ -1105,3 +1105,189 @@
     grid-template-columns: minmax(0, 1fr);
   }
 }
+
+/* ── TCO comparison block ─────────────────────────────────── */
+.energy-tco {
+  padding-top: 0;
+}
+
+.energy-tco__table-wrap {
+  margin-top: 1.75rem;
+  overflow-x: auto;
+  border-radius: var(--nx-radius-xl);
+  border: 1px solid var(--audit-border-strong);
+  background: var(--audit-surface-strong);
+  box-shadow: var(--audit-shadow-card, var(--nx-shadow-sm));
+}
+
+.energy-tco__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+  color: var(--nx-text);
+}
+
+.energy-tco__table thead th {
+  padding: 1rem 1.1rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  text-align: left;
+  color: var(--nx-text-secondary);
+  background: hsl(30 10% 100% / 0.04);
+  border-bottom: 1px solid var(--audit-border-strong);
+  vertical-align: bottom;
+}
+
+.energy-tco__table thead th small {
+  display: block;
+  margin-top: 0.25rem;
+  font-size: 0.72rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: none;
+  color: var(--nx-text-dim);
+}
+
+.energy-tco__table tbody th {
+  width: 36%;
+  padding: 1rem 1.1rem;
+  font-weight: 600;
+  font-size: 0.92rem;
+  text-align: left;
+  color: var(--nx-text-secondary);
+  border-bottom: 1px solid var(--audit-border-strong);
+  background: hsl(30 10% 100% / 0.015);
+}
+
+.energy-tco__table tbody td {
+  padding: 1rem 1.1rem;
+  border-bottom: 1px solid var(--audit-border-strong);
+  vertical-align: top;
+  font-size: 0.95rem;
+  line-height: 1.45;
+}
+
+.energy-tco__table tbody tr:last-child th,
+.energy-tco__table tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.energy-tco__col--rental {
+  color: var(--red);
+  background: var(--audit-danger-bg);
+  border-left: 1px solid var(--audit-danger-border);
+}
+
+.energy-tco__col--ownership {
+  color: var(--audit-success-text);
+  background: var(--audit-success-bg);
+  border-left: 1px solid var(--audit-success-border);
+}
+
+.energy-tco__table thead .energy-tco__col--rental,
+.energy-tco__table thead .energy-tco__col--ownership {
+  color: var(--nx-text);
+}
+
+.energy-tco__table tbody tr.is-highlight th,
+.energy-tco__table tbody tr.is-highlight td {
+  font-weight: 700;
+  background: hsl(30 10% 100% / 0.05);
+}
+
+.energy-tco__table tbody tr.is-highlight .energy-tco__col--rental {
+  background: hsl(8 82% 64% / 0.16);
+}
+
+.energy-tco__table tbody tr.is-highlight .energy-tco__col--ownership {
+  background: hsl(145 43% 58% / 0.18);
+}
+
+.energy-tco__pointe {
+  margin: 1.5rem 0 0;
+  max-width: 56rem;
+  color: var(--nx-text-secondary);
+  font-size: 1rem;
+  line-height: 1.55;
+}
+
+.energy-tco__cta {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.85rem 1.25rem;
+}
+
+.energy-tco__cta-microcopy {
+  color: var(--nx-text-dim);
+  font-size: 0.85rem;
+  max-width: 32rem;
+}
+
+@media (max-width: 720px) {
+  .energy-tco__table {
+    font-size: 0.88rem;
+  }
+
+  .energy-tco__table thead th,
+  .energy-tco__table tbody th,
+  .energy-tco__table tbody td {
+    padding: 0.85rem 0.8rem;
+  }
+
+  .energy-tco__table tbody th {
+    width: 38%;
+  }
+}
+
+/* ── Hero CTA microcopy + final CTA microcopy ─────────────── */
+.energy-hero__cta-microcopy,
+.energy-final-cta__microcopy {
+  margin: 0.5rem 0 0;
+  color: var(--nx-text-dim);
+  font-size: 0.88rem;
+  line-height: 1.5;
+  max-width: 36rem;
+}
+
+.energy-final-cta__microcopy {
+  margin-top: 0.75rem;
+}
+
+/* ── Funnel: text_input step (PLZ) ────────────────────────── */
+.energy-text-input-step {
+  display: grid;
+  gap: 1rem;
+}
+
+.energy-text-input-step__field {
+  max-width: 14rem;
+}
+
+.energy-text-input-step__field input {
+  font-size: 1.15rem;
+  letter-spacing: 0.12em;
+  text-align: left;
+}
+
+/* ── Success block: bullet list (replaces meta tags) ──────── */
+.review-success-list {
+  margin: 1rem 0 0;
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 0.45rem;
+  color: var(--nx-text-secondary);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.review-success-list li {
+  list-style: disc;
+}
+
+.review-success-list li::marker {
+  color: var(--nx-accent-text);
+}

--- a/blocksy-child/assets/js/energy-intake.js
+++ b/blocksy-child/assets/js/energy-intake.js
@@ -417,7 +417,7 @@
 
     if (submitButton) {
       setDisplayed(submitButton, isLast, 'inline-flex');
-      submitButton.textContent = config.submitLabel || 'System-Diagnose passend einordnen';
+      submitButton.textContent = config.submitLabel || 'Standortbestimmung absenden';
     }
   }
 
@@ -525,10 +525,11 @@
 
   function getFieldMessage(name, field) {
     var messages = {
-      name: 'Bitte Ihren Namen angeben.',
+      name: 'Bitte Vor- und Nachname angeben.',
       company: 'Bitte Ihr Unternehmen angeben.',
       email: 'Bitte eine gültige geschäftliche E-Mail-Adresse angeben.',
       page_url: 'Bitte eine gültige URL angeben oder das Feld leer lassen.',
+      postal_code: 'Bitte eine gültige fünfstellige deutsche Postleitzahl angeben.',
       consent_privacy: 'Bitte bestätigen Sie den Datenschutzhinweis.'
     };
 
@@ -742,7 +743,7 @@
 
         if (submitButton) {
           submitButton.disabled = false;
-          submitButton.textContent = config.submitLabel || 'System-Diagnose passend einordnen';
+          submitButton.textContent = config.submitLabel || 'Standortbestimmung absenden';
         }
       });
   }

--- a/blocksy-child/inc/review-crm.php
+++ b/blocksy-child/inc/review-crm.php
@@ -116,6 +116,60 @@ function nexus_get_growth_audit_simple_intake_variant_label() {
  */
 function nexus_get_energy_intake_field_options() {
 	return [
+		'lead_volume' => [
+			'unter_20'    => [
+				'label'       => 'Unter 20 pro Monat',
+				'description' => 'Vertrieb hat freie Kapazität, aber zu wenige qualifizierte Anfragen kommen rein.',
+			],
+			'20_bis_50'   => [
+				'label'       => '20–50 pro Monat',
+				'description' => 'Volumen vorhanden, aber unklar, welcher Anteil tragend ist und welcher verpufft.',
+			],
+			'51_bis_120'  => [
+				'label'       => '51–120 pro Monat',
+				'description' => 'Stabiler Anfrage-Korridor — der Hebel liegt bei Qualität, Zuordnung und Eigentum.',
+			],
+			'ueber_120'   => [
+				'label'       => 'Über 120 pro Monat',
+				'description' => 'Hohes Volumen — Skalierung greift nur, wenn Tracking, Datenebene und Vertriebsfluss sauber sind.',
+			],
+		],
+		'cpl_range' => [
+			'unter_80'    => [
+				'label'       => 'Unter 80 €',
+				'description' => 'Niedriger CPL — meist organisch, Empfehlungen oder bestehende Eigenkanäle.',
+			],
+			'80_bis_150'  => [
+				'label'       => '80–150 €',
+				'description' => 'Typischer Korridor für Portal-Zukauf oder ungeöffnete Performance-Kampagnen.',
+			],
+			'151_bis_300' => [
+				'label'       => '151–300 €',
+				'description' => 'Spürbar hoher CPL — meist Mischung aus Portal-Leads, Streuverlust und schwacher Conversion.',
+			],
+			'ueber_300'   => [
+				'label'       => 'Über 300 €',
+				'description' => 'Akut unwirtschaftlich — Skalierung ist ohne strukturellen Eingriff nicht tragfähig.',
+			],
+		],
+		'primary_bottleneck' => [
+			'lead_menge'           => [
+				'label'       => 'Lead-Menge',
+				'description' => 'Vertrieb hat freie Kapazität, aber zu wenige Anfragen.',
+			],
+			'lead_qualitaet'       => [
+				'label'       => 'Lead-Qualität',
+				'description' => 'Anfragen kommen rein, aber zu viele unpassende Kontakte landen beim Vertrieb.',
+			],
+			'tracking_klarheit'    => [
+				'label'       => 'Tracking-Klarheit',
+				'description' => 'Unklar, welcher Kanal welche Abschlüsse bringt — Entscheidungen im Nebel.',
+			],
+			'eigentum_abhaengigkeit' => [
+				'label'       => 'Eigentum / Abhängigkeit',
+				'description' => 'System läuft, aber liegt bei Portal oder Agentur — Sie mieten den Hebel.',
+			],
+		],
 		'solution_focus' => [
 			'photovoltaik' => [
 				'label'       => 'Photovoltaik',
@@ -313,92 +367,70 @@ function nexus_get_energy_intake_flow_definition() {
 
 	return [
 		[
-			'id'           => 'solution',
-			'name'         => 'solution_focus',
-			'kind'         => 'single_choice',
-			'title_short'  => 'Leistung',
-			'question'     => 'Welche Leistungen verkaufen Sie hauptsächlich?',
-			'description'  => 'So wird direkt klar, wie kaufnah, erklärungsbedürftig und segmentiert Ihr Anfrageprozess sein muss.',
-			'summary_label'=> 'Leistung',
-			'auto_advance' => true,
-			'next'         => 'audience',
-			'options'      => $options['solution_focus'],
+			'id'            => 'region',
+			'name'          => 'postal_code',
+			'kind'          => 'text_input',
+			'title_short'   => 'Region',
+			'question'      => 'In welcher Region arbeitet Ihr Betrieb?',
+			'description'   => 'Wir prüfen, ob Ihr Einzugsgebiet im aktuellen Kapazitätsfenster liegt. Eine PLZ reicht — Filialstandorte besprechen wir im Erstgespräch.',
+			'summary_label' => 'Region (PLZ)',
+			'next'          => 'lead-volume',
+			'field'         => [
+				'name'         => 'postal_code',
+				'label'        => 'Postleitzahl',
+				'type'         => 'text',
+				'inputmode'    => 'numeric',
+				'autocomplete' => 'postal-code',
+				'pattern'      => '[0-9]{5}',
+				'maxlength'    => 5,
+				'placeholder'  => 'z. B. 30159',
+				'required'     => true,
+			],
 		],
 		[
-			'id'           => 'audience',
-			'name'         => 'sales_audience',
-			'kind'         => 'single_choice',
-			'title_short'  => 'Zielmarkt',
-			'question'     => 'An wen verkaufen Sie hauptsächlich?',
-			'description'  => 'B2C und B2B ticken auf Landingpages, im Proof und in Formularen oft komplett unterschiedlich.',
-			'summary_label'=> 'Zielmarkt',
-			'auto_advance' => true,
-			'next'         => 'challenge',
-			'options'      => $options['sales_audience'],
-		],
-		[
-			'id'            => 'challenge',
-			'name'          => 'primary_challenge',
+			'id'            => 'lead-volume',
+			'name'          => 'lead_volume',
 			'kind'          => 'single_choice',
-			'title_short'   => 'Hauptengpass',
-			'question'      => 'Was ist aktuell die größte Reibung?',
-			'description'   => 'So wird klar, wo im Anfrageprozess der größte Hebel liegt.',
-			'summary_label' => 'Hauptengpass',
+			'title_short'   => 'Lead-Volumen',
+			'question'      => 'Wie viele qualifizierte Anfragen erreichen Ihren Vertrieb aktuell pro Monat?',
+			'description'   => 'Gemeint sind ausschließlich Anfragen, die Ihr Vertrieb tatsächlich kontaktieren kann — nicht Klicks, nicht Newsletter-Abonnenten.',
+			'summary_label' => 'Lead-Volumen',
 			'auto_advance'  => true,
-			'next'          => 'site-state',
-			'options'       => $options['primary_challenge'],
+			'next'          => 'cpl-range',
+			'options'       => $options['lead_volume'],
 		],
 		[
-			'id'            => 'site-state',
-			'name'          => 'site_state',
+			'id'            => 'cpl-range',
+			'name'          => 'cpl_range',
 			'kind'          => 'single_choice',
-			'title_short'   => 'Aktueller Status',
-			'question'      => 'Gibt es bereits eine Website oder Landingpage, die aktiv Anfragen generiert?',
-			'description'   => 'So wird klar, ob eher Optimierung, Neuordnung oder ein sauberer Erstaufbau gebraucht wird.',
-			'summary_label' => 'Aktueller Status',
+			'title_short'   => 'CPL',
+			'question'      => 'Was kostet Sie eine qualifizierte Anfrage im Schnitt aktuell?',
+			'description'   => 'Wenn Sie überwiegend Portal-Leads einkaufen, nehmen Sie den durchschnittlichen Einkaufspreis. Wenn Sie selbst Werbung schalten: Werbebudget geteilt durch qualifizierte Anfragen.',
+			'summary_label' => 'CPL',
 			'auto_advance'  => true,
-			'next'          => 'timing',
-			'options'       => $options['site_state'],
+			'next'          => 'bottleneck',
+			'options'       => $options['cpl_range'],
 		],
 		[
-			'id'            => 'timing',
-			'name'          => 'project_timing',
+			'id'            => 'bottleneck',
+			'name'          => 'primary_bottleneck',
 			'kind'          => 'single_choice',
-			'title_short'   => 'Timing',
-			'question'      => 'Wie zeitnah möchten Sie das Thema angehen?',
-			'description'   => 'Timing hilft bei Einordnung, Priorisierung und der Frage, wie tief der nächste Schritt direkt gehen sollte.',
-			'summary_label' => 'Timing',
-			'auto_advance'  => true,
-			'next'          => 'contact-pref',
-			'options'       => $options['project_timing'],
-		],
-		[
-			'id'            => 'contact-pref',
-			'name'          => 'contact_preference',
-			'kind'          => 'single_choice',
-			'title_short'   => 'Kontaktweg',
-			'question'      => 'Wie soll die Rückmeldung ankommen?',
-			'description'   => 'Die Ersteinschätzung kommt immer per E-Mail. Hier entscheiden Sie, ob zusätzlich ein kurzes Telefonat sinnvoll ist.',
-			'summary_label' => 'Kontaktweg',
+			'title_short'   => 'Engpass',
+			'question'      => 'Wo liegt aktuell Ihr größter Engpass?',
+			'description'   => 'Eine Auswahl. Wenn mehrere zutreffen, nennen Sie den, dessen Lösung Ihrem Betrieb in den nächsten 6 Monaten am meisten bringt.',
+			'summary_label' => 'Engpass',
 			'auto_advance'  => true,
 			'next'          => 'contact',
-			'options'       => $options['contact_preference'],
+			'options'       => $options['primary_bottleneck'],
 		],
 		[
 			'id'            => 'contact',
 			'kind'          => 'contact',
 			'title_short'   => 'Kontakt',
-			'question'      => 'Wohin soll die Einordnung gehen?',
-			'description'   => 'Name, Unternehmen und geschäftliche E-Mail reichen. Telefon und Zusatzkontext bleiben optional.',
+			'question'      => 'An wen senden wir die Standortbestimmung?',
+			'description'   => 'Ihre Antworten werden ausschließlich für die Vorbereitung der Standortbestimmung verwendet. Keine Weitergabe an Dritte, kein Newsletter, kein automatisierter Anruf.',
 			'summary_label' => 'Kontakt',
 			'fields'        => [
-				[
-					'name'         => 'name',
-					'label'        => 'Name',
-					'type'         => 'text',
-					'autocomplete' => 'name',
-					'required'     => true,
-				],
 				[
 					'name'         => 'company',
 					'label'        => 'Unternehmen',
@@ -407,11 +439,19 @@ function nexus_get_energy_intake_flow_definition() {
 					'required'     => true,
 				],
 				[
+					'name'         => 'name',
+					'label'        => 'Vor- und Nachname',
+					'type'         => 'text',
+					'autocomplete' => 'name',
+					'required'     => true,
+				],
+				[
 					'name'         => 'email',
 					'label'        => 'Geschäftliche E-Mail',
 					'type'         => 'email',
 					'autocomplete' => 'email',
 					'inputmode'    => 'email',
+					'help'         => 'Bitte Firmen-Domain angeben. Bei Freemail-Adressen (gmail, gmx, web.de) verzögert sich die Antwort.',
 					'required'     => true,
 				],
 				[
@@ -423,23 +463,12 @@ function nexus_get_energy_intake_flow_definition() {
 					'required'     => false,
 				],
 				[
-					'name'         => 'page_url',
-					'label'        => 'Website oder relevante Landingpage (optional)',
-					'type'         => 'url',
-					'autocomplete' => 'url',
-					'inputmode'    => 'url',
-					'placeholder'  => 'https://www.beispiel.de',
-					'help'         => 'Hilft, wenn ich die aktuelle Struktur direkt im Kontext Ihrer Angaben sehen soll.',
-					'required'     => false,
-				],
-				[
 					'name'         => 'current_challenge',
-					'label'        => 'Optionale Nachricht',
+					'label'        => 'Anmerkung — falls Sie etwas vorab wissen sollten (optional)',
 					'type'         => 'textarea',
-					'rows'         => 5,
-					'maxlength'    => 1400,
-					'help'         => 'Zum Beispiel regionale Besonderheiten, Vertriebsrealität oder bereits laufende Kampagnen.',
-					'placeholder'  => 'Was sollte ich im ersten Blick nicht übersehen?',
+					'rows'         => 4,
+					'maxlength'    => 500,
+					'placeholder'  => 'Zum Beispiel regionale Besonderheiten, laufende Kampagnen oder bestehende Vertragsbindungen.',
 					'required'     => false,
 				],
 				[
@@ -766,7 +795,7 @@ function nexus_get_review_request_success_message( $payload ) {
 	$variant = isset( $payload['intake_variant'] ) ? sanitize_key( (string) $payload['intake_variant'] ) : '';
 
 	if ( 'energy_systems' === $variant ) {
-		return 'Danke. Ich prüfe Ihre Angaben als B2B-Energiesystem und melde mich mit einer priorisierten ersten Einordnung. Wenn ein System-Diagnose der sinnvollste nächste Schritt ist, sehen Sie das direkt in der Rückmeldung.';
+		return 'Eingegangen. Ihre Standortbestimmung liegt in der Bearbeitung. Sie erhalten innerhalb von 48 Werktagsstunden eine E-Mail von hasim@hasimuener.de — bei Eignung mit Vorschlag für ein 30-minütiges Erstgespräch, bei Nicht-Eignung mit konkretem Hinweis auf eine realistischere Alternative.';
 	}
 
 	if ( nexus_is_growth_audit_simple_intake_variant( $variant ) ) {
@@ -1143,6 +1172,10 @@ function nexus_validate_energy_review_request_payload( $payload ) {
 	$type_options          = nexus_get_audit_request_type_options();
 	$field_options         = nexus_get_energy_intake_field_options();
 	$audit_type            = isset( $payload['audit_type'] ) ? sanitize_key( (string) $payload['audit_type'] ) : 'growth_audit';
+	$postal_code           = isset( $payload['postal_code'] ) ? preg_replace( '/\D/', '', (string) $payload['postal_code'] ) : '';
+	$lead_volume           = isset( $payload['lead_volume'] ) ? sanitize_key( (string) $payload['lead_volume'] ) : '';
+	$cpl_range             = isset( $payload['cpl_range'] ) ? sanitize_key( (string) $payload['cpl_range'] ) : '';
+	$primary_bottleneck    = isset( $payload['primary_bottleneck'] ) ? sanitize_key( (string) $payload['primary_bottleneck'] ) : '';
 	$solution_focus        = isset( $payload['solution_focus'] ) ? sanitize_key( (string) $payload['solution_focus'] ) : '';
 	$sales_audience        = isset( $payload['sales_audience'] ) ? sanitize_key( (string) $payload['sales_audience'] ) : '';
 	$region_scope          = isset( $payload['region_scope'] ) ? sanitize_key( (string) $payload['region_scope'] ) : '';
@@ -1159,24 +1192,45 @@ function nexus_validate_energy_review_request_payload( $payload ) {
 	$email                 = isset( $payload['email'] ) ? sanitize_email( (string) $payload['email'] ) : '';
 	$phone                 = isset( $payload['phone'] ) ? sanitize_text_field( (string) $payload['phone'] ) : '';
 	$consent_privacy       = isset( $payload['consent_privacy'] ) ? sanitize_key( (string) $payload['consent_privacy'] ) : '';
-	// Region, measurement, acquisition mix and improvement goal are no longer
-	// collected in the reduced 6-step flow but kept as optional fields for
-	// backward compatibility with existing CRM entries.
+	// Solution focus, sales audience, site state, project timing, contact preference,
+	// measurement state, acquisition mix, improvement goal and region scope are
+	// not collected in the 5-step v1 flow. They remain optional in the payload
+	// so legacy entries and future variants stay compatible.
 
-	if ( empty( $solution_focus ) || ! isset( $field_options['solution_focus'][ $solution_focus ] ) ) {
-		return new WP_Error( 'missing_solution_focus', 'Bitte auswählen, welche Leistungen Sie hauptsächlich verkaufen.' );
+	if ( '' === $postal_code || ! preg_match( '/^[0-9]{5}$/', $postal_code ) ) {
+		return new WP_Error( 'invalid_postal_code', 'Bitte eine gültige fünfstellige deutsche Postleitzahl angeben.' );
 	}
 
-	if ( empty( $sales_audience ) || ! isset( $field_options['sales_audience'][ $sales_audience ] ) ) {
-		return new WP_Error( 'missing_sales_audience', 'Bitte auswählen, an wen Sie hauptsächlich verkaufen.' );
+	if ( (int) $postal_code < 1000 || (int) $postal_code > 99999 ) {
+		return new WP_Error( 'invalid_postal_code_range', 'Bitte eine deutsche Postleitzahl im gültigen Bereich angeben.' );
+	}
+
+	if ( empty( $lead_volume ) || ! isset( $field_options['lead_volume'][ $lead_volume ] ) ) {
+		return new WP_Error( 'missing_lead_volume', 'Bitte das aktuelle Lead-Volumen auswählen.' );
+	}
+
+	if ( empty( $cpl_range ) || ! isset( $field_options['cpl_range'][ $cpl_range ] ) ) {
+		return new WP_Error( 'missing_cpl_range', 'Bitte den aktuellen CPL-Bereich auswählen.' );
+	}
+
+	if ( empty( $primary_bottleneck ) || ! isset( $field_options['primary_bottleneck'][ $primary_bottleneck ] ) ) {
+		return new WP_Error( 'missing_primary_bottleneck', 'Bitte den größten aktuellen Engpass auswählen.' );
+	}
+
+	if ( '' !== $solution_focus && ! isset( $field_options['solution_focus'][ $solution_focus ] ) ) {
+		$solution_focus = '';
+	}
+
+	if ( '' !== $sales_audience && ! isset( $field_options['sales_audience'][ $sales_audience ] ) ) {
+		$sales_audience = '';
 	}
 
 	if ( '' !== $region_scope && ! isset( $field_options['region_scope'][ $region_scope ] ) ) {
 		$region_scope = '';
 	}
 
-	if ( empty( $primary_challenge ) || ! isset( $field_options['primary_challenge'][ $primary_challenge ] ) ) {
-		return new WP_Error( 'missing_primary_challenge', 'Bitte die größte aktuelle Reibung auswählen.' );
+	if ( '' !== $primary_challenge && ! isset( $field_options['primary_challenge'][ $primary_challenge ] ) ) {
+		$primary_challenge = '';
 	}
 
 	if ( '' !== $measurement_state && ! isset( $field_options['measurement_state'][ $measurement_state ] ) ) {
@@ -1187,16 +1241,16 @@ function nexus_validate_energy_review_request_payload( $payload ) {
 		$acquisition_mix = '';
 	}
 
-	if ( empty( $site_state ) || ! isset( $field_options['site_state'][ $site_state ] ) ) {
-		return new WP_Error( 'missing_site_state', 'Bitte den Status Ihrer aktuellen Website oder Landingpage auswählen.' );
+	if ( '' !== $site_state && ! isset( $field_options['site_state'][ $site_state ] ) ) {
+		$site_state = '';
 	}
 
 	if ( '' !== $improvement_goal && ! isset( $field_options['improvement_goal'][ $improvement_goal ] ) ) {
 		$improvement_goal = '';
 	}
 
-	if ( empty( $project_timing ) || ! isset( $field_options['project_timing'][ $project_timing ] ) ) {
-		return new WP_Error( 'missing_project_timing', 'Bitte auswählen, wie zeitnah Sie das Thema angehen möchten.' );
+	if ( '' !== $project_timing && ! isset( $field_options['project_timing'][ $project_timing ] ) ) {
+		$project_timing = '';
 	}
 
 	if ( '' !== $page_url ) {
@@ -1241,6 +1295,14 @@ function nexus_validate_energy_review_request_payload( $payload ) {
 		? (string) wp_parse_url( $page_url, PHP_URL_HOST )
 		: nexus_get_review_request_domain_from_email( $email );
 
+	$lookup_label = static function( $group, $key ) use ( $field_options ) {
+		if ( '' === $key || ! isset( $field_options[ $group ][ $key ]['label'] ) ) {
+			return '';
+		}
+
+		return (string) $field_options[ $group ][ $key ]['label'];
+	};
+
 	return [
 		'intake_variant'               => 'energy_systems',
 		'intake_variant_label'         => nexus_get_energy_intake_variant_label(),
@@ -1249,11 +1311,11 @@ function nexus_validate_energy_review_request_payload( $payload ) {
 		'page_url'                    => $page_url,
 		'domain'                      => $resolved_domain,
 		'company'                     => $company,
-		'focus_area'                  => $primary_challenge,
-		'focus_area_label'            => $field_options['primary_challenge'][ $primary_challenge ]['label'],
+		'focus_area'                  => $primary_bottleneck,
+		'focus_area_label'            => $lookup_label( 'primary_bottleneck', $primary_bottleneck ),
 		'current_challenge'           => $current_challenge,
 		'primary_goal'                => $improvement_goal,
-		'primary_goal_label'          => $field_options['improvement_goal'][ $improvement_goal ]['label'],
+		'primary_goal_label'          => $lookup_label( 'improvement_goal', $improvement_goal ),
 		'extra_context'               => '',
 		'name'                        => $name,
 		'email'                       => $email,
@@ -1267,24 +1329,31 @@ function nexus_validate_energy_review_request_payload( $payload ) {
 		'previous_internal_url'       => $previous_internal_url,
 		'referrer_url'                => $referrer_url,
 		'referrer_host'               => $referrer_url ? sanitize_text_field( strtolower( (string) wp_parse_url( $referrer_url, PHP_URL_HOST ) ) ) : '',
+		'postal_code'                 => $postal_code,
+		'lead_volume'                 => $lead_volume,
+		'lead_volume_label'           => $lookup_label( 'lead_volume', $lead_volume ),
+		'cpl_range'                   => $cpl_range,
+		'cpl_range_label'             => $lookup_label( 'cpl_range', $cpl_range ),
+		'primary_bottleneck'          => $primary_bottleneck,
+		'primary_bottleneck_label'    => $lookup_label( 'primary_bottleneck', $primary_bottleneck ),
 		'solution_focus'              => $solution_focus,
-		'solution_focus_label'        => $field_options['solution_focus'][ $solution_focus ]['label'],
+		'solution_focus_label'        => $lookup_label( 'solution_focus', $solution_focus ),
 		'sales_audience'              => $sales_audience,
-		'sales_audience_label'        => $field_options['sales_audience'][ $sales_audience ]['label'],
+		'sales_audience_label'        => $lookup_label( 'sales_audience', $sales_audience ),
 		'region_scope'                => $region_scope,
-		'region_scope_label'          => '' !== $region_scope && isset( $field_options['region_scope'][ $region_scope ] ) ? $field_options['region_scope'][ $region_scope ]['label'] : '',
+		'region_scope_label'          => $lookup_label( 'region_scope', $region_scope ),
 		'primary_challenge'           => $primary_challenge,
-		'primary_challenge_label'     => $field_options['primary_challenge'][ $primary_challenge ]['label'],
+		'primary_challenge_label'     => $lookup_label( 'primary_challenge', $primary_challenge ),
 		'measurement_state'           => $measurement_state,
-		'measurement_state_label'     => $measurement_state ? $field_options['measurement_state'][ $measurement_state ]['label'] : '',
+		'measurement_state_label'     => $lookup_label( 'measurement_state', $measurement_state ),
 		'acquisition_mix'             => $acquisition_mix,
-		'acquisition_mix_label'       => '' !== $acquisition_mix && isset( $field_options['acquisition_mix'][ $acquisition_mix ] ) ? $field_options['acquisition_mix'][ $acquisition_mix ]['label'] : '',
+		'acquisition_mix_label'       => $lookup_label( 'acquisition_mix', $acquisition_mix ),
 		'site_state'                  => $site_state,
-		'site_state_label'            => $field_options['site_state'][ $site_state ]['label'],
+		'site_state_label'            => $lookup_label( 'site_state', $site_state ),
 		'improvement_goal'            => $improvement_goal,
-		'improvement_goal_label'      => '' !== $improvement_goal && isset( $field_options['improvement_goal'][ $improvement_goal ] ) ? $field_options['improvement_goal'][ $improvement_goal ]['label'] : '',
+		'improvement_goal_label'      => $lookup_label( 'improvement_goal', $improvement_goal ),
 		'project_timing'              => $project_timing,
-		'project_timing_label'        => $field_options['project_timing'][ $project_timing ]['label'],
+		'project_timing_label'        => $lookup_label( 'project_timing', $project_timing ),
 	];
 }
 
@@ -1354,6 +1423,13 @@ function nexus_create_review_request_post( $payload ) {
 	update_post_meta( $post_id, '_nexus_review_referrer_host', sanitize_text_field( (string) ( $payload['referrer_host'] ?? '' ) ) );
 
 	if ( 'energy_systems' === ( $payload['intake_variant'] ?? '' ) ) {
+		update_post_meta( $post_id, '_nexus_review_energy_postal_code', sanitize_text_field( (string) ( $payload['postal_code'] ?? '' ) ) );
+		update_post_meta( $post_id, '_nexus_review_energy_lead_volume', sanitize_key( (string) ( $payload['lead_volume'] ?? '' ) ) );
+		update_post_meta( $post_id, '_nexus_review_energy_lead_volume_label', sanitize_text_field( (string) ( $payload['lead_volume_label'] ?? '' ) ) );
+		update_post_meta( $post_id, '_nexus_review_energy_cpl_range', sanitize_key( (string) ( $payload['cpl_range'] ?? '' ) ) );
+		update_post_meta( $post_id, '_nexus_review_energy_cpl_range_label', sanitize_text_field( (string) ( $payload['cpl_range_label'] ?? '' ) ) );
+		update_post_meta( $post_id, '_nexus_review_energy_primary_bottleneck', sanitize_key( (string) ( $payload['primary_bottleneck'] ?? '' ) ) );
+		update_post_meta( $post_id, '_nexus_review_energy_primary_bottleneck_label', sanitize_text_field( (string) ( $payload['primary_bottleneck_label'] ?? '' ) ) );
 		update_post_meta( $post_id, '_nexus_review_energy_solution_focus', sanitize_key( (string) ( $payload['solution_focus'] ?? '' ) ) );
 		update_post_meta( $post_id, '_nexus_review_energy_solution_focus_label', sanitize_text_field( (string) ( $payload['solution_focus_label'] ?? '' ) ) );
 		update_post_meta( $post_id, '_nexus_review_energy_sales_audience', sanitize_key( (string) ( $payload['sales_audience'] ?? '' ) ) );
@@ -1604,16 +1680,28 @@ function nexus_get_review_request_detail_rows( $payload ) {
 	} elseif ( 'energy_systems' === $variant ) {
 		$rows = [
 			[
+				'label' => 'Region (PLZ)',
+				'value' => (string) ( $payload['postal_code'] ?? '' ),
+			],
+			[
+				'label' => 'Lead-Volumen',
+				'value' => (string) ( $payload['lead_volume_label'] ?? '' ),
+			],
+			[
+				'label' => 'CPL',
+				'value' => (string) ( $payload['cpl_range_label'] ?? '' ),
+			],
+			[
+				'label' => 'Engpass',
+				'value' => (string) ( $payload['primary_bottleneck_label'] ?? $payload['focus_area_label'] ?? '' ),
+			],
+			[
 				'label' => 'Leistung',
 				'value' => (string) ( $payload['solution_focus_label'] ?? '' ),
 			],
 			[
 				'label' => 'Zielmarkt',
 				'value' => (string) ( $payload['sales_audience_label'] ?? '' ),
-			],
-			[
-				'label' => 'Hauptengpass',
-				'value' => (string) ( $payload['primary_challenge_label'] ?? $payload['focus_area_label'] ?? '' ),
 			],
 			[
 				'label' => 'Aktueller Status',
@@ -1628,7 +1716,7 @@ function nexus_get_review_request_detail_rows( $payload ) {
 				'value' => (string) ( $payload['page_url'] ?? '' ),
 			],
 			[
-				'label' => 'Nachricht',
+				'label' => 'Anmerkung',
 				'value' => (string) ( $payload['current_challenge'] ?? '' ),
 			],
 		];

--- a/blocksy-child/page-anfrage.php
+++ b/blocksy-child/page-anfrage.php
@@ -98,10 +98,10 @@ get_header();
 		<section class="nx-section nx-hero energy-hero energy-hero--compact" id="hero">
 			<div class="nx-container">
 				<div class="energy-hero__copy energy-hero__copy--centered">
-					<span class="nx-badge nx-badge--gold">Anfrage-Einordnung</span>
-					<h1 class="nx-hero__title">In 2 Minuten Situation einordnen — Ergebnis per E-Mail.</h1>
-					<p class="nx-hero__subtitle">Sie klicken sich durch 7 kurze Schritte. Keine generischen Felder, keine Sales-Hotline im Nachgang. Innerhalb von 48 Stunden eine persönliche Ersteinschätzung per E-Mail.</p>
-					<p class="nx-cta-microcopy">Referenz E3 New Energy: &minus;83 % Kosten pro Anfrage &middot; 1.750+ qualifizierte Anfragen in 9 Monaten &middot; 12 % Abschlussquote</p>
+					<span class="nx-badge nx-badge--gold">Standortbestimmung</span>
+					<h1 class="nx-hero__title">5 Fragen, ca. 90 Sekunden &mdash; Antwort innerhalb von 48 Stunden per E-Mail.</h1>
+					<p class="nx-hero__subtitle">Region, Lead-Volumen, CPL, Engpass, Kontakt. Keine Pflicht-Calls, keine Sales-Hotline im Nachgang. Wir prüfen, ob Infrastruktur statt Miete für Ihren Betrieb ein realistischer Hebel ist &mdash; bei Nicht-Eignung erhalten Sie einen ehrlichen Hinweis auf eine realistischere Alternative.</p>
+					<p class="nx-cta-microcopy">&minus;83 % CPL &middot; 1.750+ qualifizierte Anfragen &middot; 12 % Abschlussquote &mdash; Referenz E3 New Energy, 9 Monate</p>
 				</div>
 			</div>
 		</section>
@@ -113,16 +113,16 @@ get_header();
 						<div class="energy-form-shell__main">
 							<?php if ( $form_success ) : ?>
 								<div id="energy-request-success" class="review-success energy-review-success is-server-success" role="status" aria-live="polite" aria-atomic="true">
-									<div class="review-success-pill">Anfrage eingegangen</div>
-									<h3>Ihre Einordnung wird geprüft.</h3>
-									<p class="review-success-copy"><?php echo esc_html( $form_success['message'] ?? 'Danke. Die Anfrage ist eingegangen.' ); ?></p>
-									<p class="review-success-timeline">Sie erhalten innerhalb von <strong>48 Stunden</strong> eine persönliche Ersteinschätzung per E-Mail — mit konkreten Hebeln für Website, Tracking und Anfrageprozess.</p>
-									<div class="review-success-meta">
-										<span>persönliche Rückmeldung per E-Mail</span>
-										<span>konkrete Hebel statt generischem Score</span>
-										<span>kein Pflicht-Call</span>
-									</div>
-									<p class="review-success-inbox-hint">Prüfen Sie Ihr Postfach (auch Spam-Ordner) für die Eingangsbestätigung.</p>
+									<div class="review-success-pill">Eingegangen</div>
+									<h3>Ihre Standortbestimmung liegt in der Bearbeitung.</h3>
+									<p class="review-success-copy"><?php echo esc_html( $form_success['message'] ?? 'Eingegangen. Ihre Standortbestimmung liegt in der Bearbeitung.' ); ?></p>
+									<p class="review-success-timeline">Sie erhalten innerhalb von <strong>48 Werktagsstunden</strong> eine E-Mail von <strong>hasim@hasimuener.de</strong>.</p>
+									<ul class="review-success-list">
+										<li>ehrliche Einschätzung, ob WGOS für Ihren Betrieb der richtige Hebel ist</li>
+										<li>bei Eignung: Vorschlag für ein 30-minütiges Erstgespräch per Telefon oder Video</li>
+										<li>bei Nicht-Eignung: konkreter Hinweis, welche Alternative für Ihre Situation realistischer ist</li>
+									</ul>
+									<p class="review-success-inbox-hint">Falls die E-Mail nicht ankommt, prüfen Sie bitte den Spam-Ordner oder schreiben direkt an <a href="mailto:hasim@hasimuener.de">hasim@hasimuener.de</a>.</p>
 								</div>
 							<?php else : ?>
 								<form
@@ -143,7 +143,7 @@ get_header();
 									<div class="review-progress energy-progress" aria-label="Fortschritt im Branchen-Flow">
 										<div class="review-progress-head">
 											<div class="review-progress-copy">
-												<strong id="energy-progress-current" aria-live="polite" aria-atomic="true">Schritt 1 von <?php echo esc_html( (string) count( $flow_steps ) ); ?> — Ihre Leistung, ca. 60 Sekunden bis zur Einordnung.</strong>
+												<strong id="energy-progress-current" aria-live="polite" aria-atomic="true">Schritt 1 von <?php echo esc_html( (string) count( $flow_steps ) ); ?> &mdash; <?php echo ! empty( $flow_steps[0]['title_short'] ) ? esc_html( $flow_steps[0]['title_short'] ) : 'Region'; ?></strong>
 											</div>
 										</div>
 										<div
@@ -154,7 +154,7 @@ get_header();
 											aria-valuemin="1"
 											aria-valuemax="<?php echo esc_attr( (string) count( $flow_steps ) ); ?>"
 											aria-valuenow="1"
-											aria-valuetext="Abschnitt 1 von <?php echo esc_attr( (string) count( $flow_steps ) ); ?>: <?php echo ! empty( $flow_steps[0]['title_short'] ) ? esc_attr( $flow_steps[0]['title_short'] ) : 'Leistung'; ?>"
+											aria-valuetext="Abschnitt 1 von <?php echo esc_attr( (string) count( $flow_steps ) ); ?>: <?php echo ! empty( $flow_steps[0]['title_short'] ) ? esc_attr( $flow_steps[0]['title_short'] ) : 'Region'; ?>"
 										>
 											<div class="review-progress-fill" id="energy-progress-fill"></div>
 										</div>
@@ -236,6 +236,35 @@ get_header();
 													</div>
 													<p class="energy-field-error energy-choice-error" id="<?php echo esc_attr( $choice_error_id ); ?>" data-energy-choice-error="<?php echo esc_attr( $field_key ); ?>"></p>
 												</fieldset>
+											<?php elseif ( 'text_input' === $step['kind'] && ! empty( $step['field'] ) ) : ?>
+												<?php
+												$field         = $step['field'];
+												$field_name    = (string) $field['name'];
+												$field_id      = 'energy-field-' . $field_name;
+												$field_value   = $get_value( $field_name );
+												$field_help_id = $field_id . '-help';
+												$field_error_id = $field_id . '-error';
+												?>
+												<div class="energy-text-input-step">
+													<p class="review-choice-help" id="<?php echo esc_attr( $field_help_id ); ?>"><?php echo esc_html( $step['description'] ); ?></p>
+													<div class="review-field energy-text-input-step__field">
+														<label for="<?php echo esc_attr( $field_id ); ?>"><?php echo esc_html( $field['label'] ); ?></label>
+														<input
+															id="<?php echo esc_attr( $field_id ); ?>"
+															name="<?php echo esc_attr( $field_name ); ?>"
+															type="<?php echo esc_attr( $field['type'] ); ?>"
+															value="<?php echo esc_attr( $field_value ); ?>"
+															<?php echo ! empty( $field['autocomplete'] ) ? 'autocomplete="' . esc_attr( $field['autocomplete'] ) . '"' : ''; ?>
+															<?php echo ! empty( $field['inputmode'] ) ? 'inputmode="' . esc_attr( $field['inputmode'] ) . '"' : ''; ?>
+															<?php echo ! empty( $field['pattern'] ) ? 'pattern="' . esc_attr( $field['pattern'] ) . '"' : ''; ?>
+															<?php echo ! empty( $field['maxlength'] ) ? 'maxlength="' . esc_attr( (string) $field['maxlength'] ) . '"' : ''; ?>
+															<?php echo ! empty( $field['placeholder'] ) ? 'placeholder="' . esc_attr( $field['placeholder'] ) . '"' : ''; ?>
+															<?php echo ! empty( $field['required'] ) ? 'required' : ''; ?>
+															aria-describedby="<?php echo esc_attr( trim( $field_help_id . ' ' . $field_error_id ) ); ?>"
+														>
+														<p class="energy-field-error" id="<?php echo esc_attr( $field_error_id ); ?>" data-energy-field-error="<?php echo esc_attr( $field_name ); ?>"></p>
+													</div>
+												</div>
 											<?php elseif ( 'contact' === $step['kind'] ) : ?>
 												<div class="review-field-grid energy-field-grid">
 													<?php foreach ( $step['fields'] as $field ) : ?>
@@ -269,7 +298,7 @@ get_header();
 																<p class="energy-field-error" id="<?php echo esc_attr( $field_error_id ); ?>" data-energy-field-error="<?php echo esc_attr( $field_name ); ?>"></p>
 															</div>
 														<?php else : ?>
-															<div class="review-field<?php echo esc_attr( $is_textarea || 'page_url' === $field_name ? ' review-field-full' : '' ); ?>"<?php echo 'phone' === $field_name ? ' data-energy-phone-field hidden' : ''; ?>>
+															<div class="review-field<?php echo esc_attr( $is_textarea || 'page_url' === $field_name ? ' review-field-full' : '' ); ?>">
 																<label for="<?php echo esc_attr( $field_id ); ?>"><?php echo esc_html( $field['label'] ); ?></label>
 																<?php if ( ! empty( $field['help'] ) ) : ?>
 																	<p class="review-field-help" id="<?php echo esc_attr( $field_help_id ); ?>"><?php echo esc_html( $field['help'] ); ?></p>
@@ -317,30 +346,30 @@ get_header();
 									<div class="review-actions energy-actions">
 										<button type="button" class="review-prev-btn" data-energy-prev hidden>Zurück</button>
 										<button type="button" class="audit-submit-btn" data-energy-next-button>Weiter</button>
-										<button type="submit" class="audit-submit-btn" data-energy-submit hidden>Anfrage-Analyse einordnen</button>
+										<button type="submit" class="audit-submit-btn" data-energy-submit hidden>Standortbestimmung absenden</button>
 									</div>
 
-									<p class="energy-form-meta">Nur Rückmeldungen zu dieser Anfrage. Kein Newsletter-Opt-in, keine Weitergabe, kein Sales-Call als Pflichtschritt.</p>
+									<p class="energy-form-meta">Ihre Antworten werden ausschließlich für die Vorbereitung der Standortbestimmung verwendet. Keine Weitergabe an Dritte, kein Newsletter, kein automatisierter Anruf.</p>
 								</form>
 
 								<div id="energy-request-success" class="review-success energy-review-success" role="status" aria-live="polite" aria-atomic="true" hidden>
-									<div class="review-success-pill">Anfrage eingegangen</div>
-									<h3>Ihre Einordnung wird geprüft.</h3>
-									<p id="energy-success-message" class="review-success-copy">Danke. Ich prüfe Ihre Angaben und melde mich mit einer priorisierten Ersteinschätzung.</p>
-									<p class="review-success-timeline">Sie erhalten innerhalb von <strong>48 Stunden</strong> eine persönliche Ersteinschätzung per E-Mail — mit konkreten Hebeln für Website, Tracking und Anfrageprozess.</p>
-									<div class="review-success-meta">
-										<span>persönliche Rückmeldung per E-Mail</span>
-										<span>konkrete Hebel statt generischem Score</span>
-										<span>kein Pflicht-Call</span>
-									</div>
-									<p class="review-success-inbox-hint">Prüfen Sie Ihr Postfach (auch Spam-Ordner) für die Eingangsbestätigung.</p>
+									<div class="review-success-pill">Eingegangen</div>
+									<h3>Ihre Standortbestimmung liegt in der Bearbeitung.</h3>
+									<p id="energy-success-message" class="review-success-copy">Eingegangen. Ihre Standortbestimmung liegt in der Bearbeitung.</p>
+									<p class="review-success-timeline">Sie erhalten innerhalb von <strong>48 Werktagsstunden</strong> eine E-Mail von <strong>hasim@hasimuener.de</strong>.</p>
+									<ul class="review-success-list">
+										<li>ehrliche Einschätzung, ob WGOS für Ihren Betrieb der richtige Hebel ist</li>
+										<li>bei Eignung: Vorschlag für ein 30-minütiges Erstgespräch per Telefon oder Video</li>
+										<li>bei Nicht-Eignung: konkreter Hinweis, welche Alternative für Ihre Situation realistischer ist</li>
+									</ul>
+									<p class="review-success-inbox-hint">Falls die E-Mail nicht ankommt, prüfen Sie bitte den Spam-Ordner oder schreiben direkt an <a href="mailto:hasim@hasimuener.de">hasim@hasimuener.de</a>.</p>
 								</div>
 							<?php endif; ?>
 						</div>
 
 						<aside class="energy-form-shell__aside" aria-labelledby="energy-aside-title">
-							<h3 id="energy-aside-title">Ihre Anfrage in Klartext</h3>
-							<p>So lässt sich sofort erkennen, ob eher Nachfrage, Website-Struktur, Messbarkeit oder Vorqualifizierung zuerst zählt.</p>
+							<h3 id="energy-aside-title">Ihre Angaben im Überblick</h3>
+							<p>Region, Lead-Volumen, CPL und Engpass zusammen ergeben die Grundlage für eine ehrliche Einordnung &mdash; ohne Pflicht-Call und ohne generische Antwort.</p>
 							<dl class="review-brief-list">
 								<?php foreach ( $flow_steps as $step ) : ?>
 									<?php if ( empty( $step['name'] ) || empty( $step['summary_label'] ) ) : ?>

--- a/blocksy-child/page-solar-waermepumpen-leadgenerierung.php
+++ b/blocksy-child/page-solar-waermepumpen-leadgenerierung.php
@@ -29,6 +29,35 @@ $pain_cards = [
 	],
 ];
 
+$tco_rows = [
+	[
+		'label'         => 'Initiales Setup',
+		'rental'        => 'ca. 2.000 €',
+		'ownership'     => '12.000–18.000 € einmalig',
+	],
+	[
+		'label'         => 'Monatlich (ohne Werbebudget)',
+		'rental'        => 'ca. 850 € Honorar + ca. 150 € SaaS / CRM',
+		'ownership'     => 'ca. 50 € Hochleistungs-Hosting',
+	],
+	[
+		'label'         => 'TCO über 24 Monate',
+		'rental'        => 'ca. 26.000 €',
+		'ownership'     => 'ca. 13.200–19.200 €',
+		'highlight'     => true,
+	],
+	[
+		'label'         => 'Bilanzwirkung',
+		'rental'        => 'OPEX — fließt durch die GuV ab',
+		'ownership'     => 'CAPEX — aktivierbares Asset',
+	],
+	[
+		'label'         => 'Eigentum nach Vertragsende',
+		'rental'        => '0 % (Funnel, CRM, Tracking abgeschaltet)',
+		'ownership'     => '100 % (Code, Tracking, Daten bleiben)',
+	],
+];
+
 
 $journey_cards = [
 	[
@@ -65,24 +94,24 @@ $proof_kpis = [
 
 $faq_items = [
 	[
-		'question' => 'Was kostet das?',
-		'answer'   => 'Das hängt vom Umfang ab. Typische Retainer starten bei 2.500–4.000 €/Monat. Bei einem CPL von 80 € und 50 Anfragen/Monat investieren Sie aktuell 4.000 € in Portal-Leads mit 10 % Abschlussquote. Mein System zielt darauf, diese Kosten um 50–80 % zu senken — der Retainer refinanziert sich in den meisten Fällen innerhalb von 8–12 Wochen.',
+		'question' => 'Was kostet das im Vergleich zur Performance-Agentur?',
+		'answer'   => 'Initiales Setup: 12.000–18.000 € einmalig. Laufend: ca. 50 €/Monat Hochleistungs-Hosting. TCO über 24 Monate: 13.200–19.200 € — und Sie besitzen Code, Tracking und Daten. Eine Performance-Agentur mit Paket „Regio+" kostet im gleichen Zeitraum rund 26.000 € und Sie besitzen am Ende nichts. Bilanziell: CAPEX statt OPEX.',
 	],
 	[
 		'question' => 'Funktioniert das auch für kleinere Betriebe mit 5–10 Mitarbeitern?',
-		'answer'   => 'Ja, wenn Sie aktuell mindestens 20 Anfragen pro Monat verarbeiten und Kosten pro Anfrage spürbar sind. Unter dieser Schwelle ist oft ein schlankerer Ansatz sinnvoller — das klären wir im Erstgespräch.',
+		'answer'   => 'Belastbar ab 10 Mitarbeitern und mindestens 20 qualifizierten Anfragen pro Monat. Darunter trägt die Investition den TCO-Vorteil nicht — ehrlicher Hinweis: ein schlankerer Ansatz mit klarer Landingpage und sauberem Tracking ist dann der bessere Hebel.',
 	],
 	[
 		'question' => 'Warum nicht einfach mehr Google Ads schalten?',
-		'answer'   => 'Mehr Budget auf schlechte Seiten heißt mehr Geld für dieselben unqualifizierten Anfragen. Erst wenn Seite, Formular und Tracking sauber arbeiten, lohnt sich mehr Reichweite.',
+		'answer'   => 'Mehr Budget auf schlechte Seiten heißt mehr Geld für dieselben unqualifizierten Anfragen. Erst wenn Seite, Formular und serverseitiges Tracking sauber arbeiten, lohnt sich mehr Reichweite. Ohne eigene Datenebene bleiben Sie zudem bei den Performance-Daten der Plattform — und damit in deren Logik.',
 	],
 	[
 		'question' => 'Brauchen wir eine neue Website?',
-		'answer'   => 'Meistens nicht. In 80 % der Fälle reicht eine Optimierung der bestehenden Seite: bessere Formulare, klarere Struktur, sauberes Tracking. Ob ein Relaunch nötig ist, zeigt der erste Audit.',
+		'answer'   => 'Meistens nicht im Komplettumfang. Was Sie brauchen: hardcoded WordPress (kein Page-Builder, kein Plugin-Stack), serverseitiges Tracking auf eigenem Server, Conversion-Pfad ohne Mietsysteme. Ob das ein Teil-Umbau oder ein sauberer Erstaufbau wird, zeigt der erste Audit.',
 	],
 	[
-		'question' => 'Wir nutzen schon eine Agentur — warum sollten wir wechseln?',
-		'answer'   => 'Müssen Sie nicht. Ich ergänze oft bestehende Setups — besonders bei Tracking, Vorqualifizierung und Seitenstruktur. Wenn Ihre aktuelle Agentur alles abdeckt und Ihre Abschlussquote stimmt, brauchen Sie mich nicht.',
+		'question' => 'Wir nutzen schon eine Performance-Agentur — warum sollten wir wechseln?',
+		'answer'   => 'Müssen Sie nicht. Drei Prüffragen: 1) Wem gehört der Code Ihrer Landingpage? 2) Wem gehört das CRM, in dem Ihre Leads liegen? 3) Wem gehört der Tracking-Account? Wenn die Antwort dreimal „uns" ist, brauchen Sie mich nicht. Wenn die Antwort dreimal „der Agentur" ist, mieten Sie ein System.',
 	],
 ];
 
@@ -144,13 +173,14 @@ get_header();
 			<div class="nx-container">
 				<div class="energy-hero__grid">
 					<div class="energy-hero__copy">
-						<span class="nx-badge nx-badge--gold">Für Solar- und Wärmepumpen-Betriebe mit 10–25 Mitarbeitern</span>
-						<h1 class="nx-hero__title">Schluss mit teuren Portal-Leads, die nicht ans Telefon gehen.</h1>
-						<p class="nx-hero__subtitle">Ich baue Solar- und Wärmepumpen-Anbietern ein eigenes Anfrage-System &mdash; damit Ihr Vertrieb nur noch mit Interessenten spricht, die wirklich kaufen wollen.</p>
-						<p class="nx-cta-microcopy">Referenz E3 New Energy: –83 % Kosten pro Anfrage &middot; 1.750+ qualifizierte Anfragen in 9 Monaten &middot; 12 % Abschlussquote</p>
+						<span class="nx-badge nx-badge--gold">Für Solar- und Wärmepumpen-Betriebe ab 10 Mitarbeitern</span>
+						<h1 class="nx-hero__title">Eigene Anfrage-Infrastruktur statt geteilter Portal-Leads und gemieteter Agentur-Funnel.</h1>
+						<p class="nx-hero__subtitle">Sie bekommen ein hardcodes WordPress-System mit serverseitigem Tracking. Code, Tracking-Setup und Lead-Daten gehören Ihrem Betrieb &mdash; nicht einer Plattform und nicht uns.</p>
+						<p class="nx-cta-microcopy">&minus;83 % CPL &middot; 1.750+ qualifizierte Anfragen &middot; 12 % Abschlussquote &mdash; Referenz E3 New Energy, 9 Monate</p>
 						<div class="energy-hero__actions">
-							<a href="<?php echo esc_url( $request_url ); ?>" class="nx-btn nx-btn--primary" data-track-action="cta_energy_hero_request" data-track-category="lead_gen" data-track-section="energy_hero" data-track-funnel-stage="energy_hero"><?php echo esc_html( $request_cta ); ?></a>
+							<a href="<?php echo esc_url( $request_url ); ?>" class="nx-btn nx-btn--primary" data-track-action="cta_energy_hero_request" data-track-category="lead_gen" data-track-section="energy_hero" data-track-funnel-stage="energy_hero">Standortbestimmung anfordern</a>
 						</div>
+						<p class="energy-hero__cta-microcopy">5 Fragen, ca. 90 Sekunden. Keine Verkaufsgespräche per Cold Call &mdash; Antwort innerhalb von 48 Stunden per E-Mail.</p>
 					</div>
 
 				</div>
@@ -250,10 +280,49 @@ get_header();
 						</div>
 					</div>
 					<div class="energy-compare__outcome-actions">
-						<a href="<?php echo esc_url( $request_url ); ?>" class="nx-btn nx-btn--primary" data-track-action="cta_energy_compare_request" data-track-category="lead_gen" data-track-section="energy_compare" data-track-funnel-stage="energy_compare"><?php echo esc_html( $request_cta ); ?></a>
-						<span class="energy-compare__outcome-microcopy">2 Minuten &middot; kein Pitch &middot; Antwort per E-Mail in 48 h</span>
+						<a href="<?php echo esc_url( $request_url ); ?>" class="nx-btn nx-btn--primary" data-track-action="cta_energy_compare_request" data-track-category="lead_gen" data-track-section="energy_compare" data-track-funnel-stage="energy_compare">Standortbestimmung anfordern</a>
+						<span class="energy-compare__outcome-microcopy">5 Fragen &middot; ca. 90 Sekunden &middot; Antwort per E-Mail in 48 Stunden</span>
 					</div>
 				</aside>
+			</div>
+		</section>
+
+		<section class="nx-section energy-section energy-tco" id="tco" aria-labelledby="tco-title">
+			<div class="nx-container">
+				<header class="energy-section__head energy-section__head--narrow">
+					<span class="nx-badge nx-badge--ghost">CAPEX statt OPEX</span>
+					<h2 id="tco-title">Der gleiche Hebel, zwei Bilanzwirkungen: Miete oder Werkzeug.</h2>
+					<p>Performance-Agenturen verkaufen Ihnen Reichweite zur Miete: Funnel auf deren Server, CRM unter deren Lizenz, Tracking unter deren Account. Vertrag endet, Hebel weg. Der gleiche monatliche Betrag fließt 24 Monate lang in ein System, das Ihnen am Ende nicht gehört.</p>
+				</header>
+
+				<div class="energy-tco__table-wrap">
+					<table class="energy-tco__table" aria-describedby="tco-title">
+						<caption class="screen-reader-text">TCO-Vergleich über 24 Monate: Performance-Agentur (Miete) gegenüber Infrastruktur-Aufbau (Eigentum).</caption>
+						<thead>
+							<tr>
+								<th scope="col">Kostenpunkt</th>
+								<th scope="col" class="energy-tco__col energy-tco__col--rental">Mietsystem<small>Performance-Agentur, Paket „Regio+"</small></th>
+								<th scope="col" class="energy-tco__col energy-tco__col--ownership">Infrastruktur-Aufbau<small>WGOS &middot; Code im Eigentum</small></th>
+							</tr>
+						</thead>
+						<tbody>
+							<?php foreach ( $tco_rows as $tco_row ) : ?>
+								<tr<?php echo ! empty( $tco_row['highlight'] ) ? ' class="is-highlight"' : ''; ?>>
+									<th scope="row"><?php echo esc_html( $tco_row['label'] ); ?></th>
+									<td class="energy-tco__col energy-tco__col--rental"><?php echo esc_html( $tco_row['rental'] ); ?></td>
+									<td class="energy-tco__col energy-tco__col--ownership"><?php echo esc_html( $tco_row['ownership'] ); ?></td>
+								</tr>
+							<?php endforeach; ?>
+						</tbody>
+					</table>
+				</div>
+
+				<p class="energy-tco__pointe">Nach 24 Monaten haben Sie im Mietmodell rund 26.000 € ausgegeben und besitzen nichts. Im Infrastruktur-Modell haben Sie weniger ausgegeben und ein laufendes System in Ihrer Bilanz. Der Unterschied ist nicht der Preis &mdash; der Unterschied ist, was am Tag der Vertragskündigung übrig bleibt.</p>
+
+				<div class="energy-tco__cta">
+					<a href="<?php echo esc_url( $request_url ); ?>" class="nx-btn nx-btn--ghost" data-track-action="cta_energy_tco_request" data-track-category="lead_gen" data-track-section="energy_tco" data-track-funnel-stage="energy_tco">TCO-Rechnung für Ihren Betrieb anfordern</a>
+					<span class="energy-tco__cta-microcopy">Sie erhalten eine Aufstellung mit den Annahmen für Ihre Region und Ihr aktuelles Lead-Volumen. Kein Vertriebsgespräch erforderlich.</span>
+				</div>
 			</div>
 		</section>
 
@@ -265,7 +334,7 @@ get_header();
 						<h2>E3 New Energy.</h2>
 						<p>E3 New Energy ist ein regionaler Energieanbieter für Photovoltaik, Wärmepumpen und Speicherlösungen. Ausgangslage: Hohe Kosten pro Anfrage durch Portal-Zukauf, keine eigene digitale Anfrage-Infrastruktur. In 9 Monaten: eigenes System aufgebaut, Kosten pro Anfrage um 83 % gesenkt, Vertrieb arbeitet nur noch mit vorqualifizierten Anfragen.</p>
 						<div class="energy-proof__actions">
-							<a href="<?php echo esc_url( $request_url ); ?>" class="nx-btn nx-btn--primary" data-track-action="cta_energy_proof_request" data-track-category="lead_gen" data-track-section="energy_proof" data-track-funnel-stage="energy_proof"><?php echo esc_html( $request_cta ); ?></a>
+							<a href="<?php echo esc_url( $request_url ); ?>" class="nx-btn nx-btn--primary" data-track-action="cta_energy_proof_request" data-track-category="lead_gen" data-track-section="energy_proof" data-track-funnel-stage="energy_proof">Standortbestimmung anfordern</a>
 						</div>
 					</div>
 
@@ -323,10 +392,10 @@ get_header();
 		<section class="nx-section energy-section energy-section--alt" id="erstgespraech">
 			<div class="nx-container">
 				<div class="nx-cta-box energy-cta-box">
-					<h2>Nicht sicher, ob das für Sie passt?</h2>
-					<p>2 Minuten. Kein Pitch. Sie beschreiben Ihre Situation — ich melde mich innerhalb von 48 Stunden mit einer konkreten Einordnung per E-Mail.</p>
+					<h2>Unsicher, ob Infrastruktur statt Miete für Ihren Betrieb passt?</h2>
+					<p>5 Fragen, ca. 90 Sekunden. Sie beschreiben Region, Lead-Volumen und aktuellen Engpass — ich melde mich innerhalb von 48 Stunden mit einer ehrlichen Einordnung per E-Mail. Bei Nicht-Eignung bekommen Sie einen konkreten Hinweis auf eine realistischere Alternative.</p>
 					<div class="energy-cta-box__actions">
-						<a href="<?php echo esc_url( $request_url ); ?>" class="nx-btn nx-btn--primary" data-track-action="cta_energy_erstgespraech" data-track-category="lead_gen" data-track-section="energy_midpage" data-track-funnel-stage="energy_midpage"><?php echo esc_html( $request_cta ); ?></a>
+						<a href="<?php echo esc_url( $request_url ); ?>" class="nx-btn nx-btn--primary" data-track-action="cta_energy_erstgespraech" data-track-category="lead_gen" data-track-section="energy_midpage" data-track-funnel-stage="energy_midpage">Standortbestimmung anfordern</a>
 					</div>
 				</div>
 			</div>
@@ -354,11 +423,12 @@ get_header();
 			<div class="nx-container">
 				<div class="nx-cta-box energy-cta-box">
 					<span class="nx-badge nx-badge--gold">Nächster Schritt</span>
-					<h2>Eigene Anfragen statt Portal-Abhängigkeit. In 2 Minuten Situation einordnen — Ergebnis per E-Mail.</h2>
-					<p class="nx-cta-microcopy">Referenz E3 New Energy: –83 % Kosten pro Anfrage &middot; 1.750+ qualifizierte Anfragen in 9 Monaten &middot; 12 % Abschlussquote</p>
+					<h2>Eigene Infrastruktur statt geteilter Portal-Leads und gemieteter Agentur-Funnel.</h2>
+					<p class="nx-cta-microcopy">&minus;83 % CPL &middot; 1.750+ qualifizierte Anfragen &middot; 12 % Abschlussquote &mdash; Referenz E3 New Energy, 9 Monate</p>
 					<div class="energy-cta-box__actions">
-						<a href="<?php echo esc_url( $request_url ); ?>" class="nx-btn nx-btn--primary" data-track-action="cta_energy_footer_request" data-track-category="lead_gen" data-track-section="energy_footer" data-track-funnel-stage="energy_footer"><?php echo esc_html( $request_cta ); ?></a>
+						<a href="<?php echo esc_url( $request_url ); ?>" class="nx-btn nx-btn--primary" data-track-action="cta_energy_footer_request" data-track-category="lead_gen" data-track-section="energy_footer" data-track-funnel-stage="energy_footer">Standortbestimmung anfordern</a>
 					</div>
+					<p class="energy-final-cta__microcopy">5 Fragen, ca. 90 Sekunden. Antwort innerhalb von 48 Stunden per E-Mail. Aktuell ehrlich kommuniziert: Einzelperson &mdash; begrenzte Slots pro Quartal.</p>
 				</div>
 			</div>
 		</section>


### PR DESCRIPTION
- Hero v2: H1 differentiates against portals AND performance agencies ("Eigene Anfrage-Infrastruktur statt geteilter Portal-Leads und gemieteter Agentur-Funnel"); CTA shifts from generic "Anfrage stellen" to "Standortbestimmung anfordern"; eyebrow opens to 10+ MA segment
- New TCO comparison block above proof: CAPEX vs. OPEX framing, 5-row table with concrete numbers, pointe paragraph in GF-language, ghost secondary CTA
- FAQ rewritten to lead with TCO/eigentum framing instead of retainer math
- Multi-step funnel rebuilt to v1 spec (5 steps): PLZ → Lead-Volumen → CPL → Engpass → Kontakt; new MECE option sets without "Sonstiges"; validation and CRM meta extended for postal_code, lead_volume, cpl_range, primary_bottleneck (legacy fields kept optional)
- /anfrage hero rewritten to match new voice; submit confirmation upgraded with explicit eligible/non-eligible outcomes
- CSS for TCO table, text-input step, success bullet list

https://claude.ai/code/session_01Rp9WQHocuhfM8RBNFNSRpX