### PR TITLE
cro: revamp homepage to champions-league level (hero, pain, proof, di…

### DIFF
--- a/blocksy-child/assets/css/homepage-cro.css
+++ b/blocksy-child/assets/css/homepage-cro.css
@@ -1,0 +1,839 @@
+/* =========================================
+   HOMEPAGE CRO LAYER
+   Champions-League visual layer for the front-page funnel.
+   Builds on tokens from design-system.css / homepage.css.
+   ========================================= */
+
+/* ---------- Reveal-on-scroll (used across sections) ---------- */
+.cro-reveal {
+    opacity: 0;
+    transform: translateY(28px);
+    transition:
+        opacity 0.7s cubic-bezier(0.16, 1, 0.3, 1),
+        transform 0.7s cubic-bezier(0.16, 1, 0.3, 1);
+    will-change: opacity, transform;
+}
+.cro-reveal.is-visible {
+    opacity: 1;
+    transform: none;
+}
+@media (prefers-reduced-motion: reduce) {
+    .cro-reveal { opacity: 1; transform: none; transition: none; }
+}
+
+/* =========================================================
+   1. HERO
+   ========================================================= */
+.cro-hero {
+    position: relative;
+    overflow: hidden;
+}
+.cro-hero__shell {
+    position: relative;
+    padding: clamp(2rem, 4vw, 3rem) 0 clamp(2.5rem, 5vw, 3.5rem);
+}
+.cro-hero__shell::before {
+    content: "";
+    position: absolute;
+    inset: -10% -10% auto auto;
+    width: 36rem;
+    height: 36rem;
+    background: radial-gradient(circle, hsl(var(--accent-hsl) / 0.18) 0%, transparent 65%);
+    filter: blur(40px);
+    pointer-events: none;
+    z-index: 0;
+}
+.cro-hero__copy {
+    position: relative;
+    z-index: 1;
+    max-width: 880px;
+}
+.cro-hero__title {
+    margin: 0.6rem 0 1.1rem;
+}
+.cro-hero__sub {
+    color: var(--nx-text-secondary);
+    font-size: clamp(1.05rem, 1.6vw, 1.2rem);
+    line-height: 1.65;
+    max-width: 60ch;
+    margin: 0 0 2rem;
+}
+
+.cro-hero__kpi-ribbon {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.85rem;
+    margin: 0 0 2rem;
+    padding: 1.1rem;
+    border-radius: var(--nx-radius-xl);
+    border: 1px solid hsl(var(--accent-hsl) / 0.22);
+    background:
+        linear-gradient(180deg, hsl(var(--accent-hsl) / 0.08), rgba(255,255,255,0.02)),
+        var(--nx-card-gradient);
+    box-shadow: var(--nx-shadow-sm);
+    backdrop-filter: blur(12px);
+}
+.cro-hero__kpi {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    padding: 0.5rem 0.9rem;
+    border-right: 1px solid var(--nx-border);
+}
+.cro-hero__kpi:last-child { border-right: 0; }
+.cro-hero__kpi-value {
+    font-size: clamp(1.5rem, 2.5vw, 2rem);
+    font-weight: 800;
+    line-height: 1;
+    color: var(--nx-text);
+    letter-spacing: -0.02em;
+}
+.cro-hero__kpi-label {
+    font-size: 0.78rem;
+    color: var(--nx-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-weight: 600;
+}
+
+.cro-hero__cta-stack {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.1rem 1.4rem;
+    align-items: center;
+    margin-bottom: 1.5rem;
+}
+.cro-hero__cta-secondary {
+    color: var(--nx-text-secondary);
+    text-decoration: none;
+    font-size: 0.95rem;
+    font-weight: 600;
+    border-bottom: 1px solid var(--nx-link-divider);
+    padding-bottom: 2px;
+    transition: color 0.2s ease, border-color 0.2s ease;
+}
+.cro-hero__cta-secondary:hover,
+.cro-hero__cta-secondary:focus-visible {
+    color: var(--nx-accent-text);
+    border-bottom-color: hsl(var(--accent-hsl) / 0.5);
+}
+
+.cro-hero__trust {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.65rem 1.4rem;
+    align-items: center;
+    color: var(--nx-text-muted);
+    font-size: 0.85rem;
+    line-height: 1.45;
+}
+.cro-hero__trust-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+}
+.cro-hero__trust-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: hsl(var(--accent-hsl) / 0.7);
+    flex-shrink: 0;
+}
+
+@media (max-width: 720px) {
+    .cro-hero__kpi-ribbon {
+        grid-template-columns: 1fr;
+        gap: 0;
+        padding: 0.4rem;
+    }
+    .cro-hero__kpi {
+        border-right: 0;
+        border-bottom: 1px solid var(--nx-border);
+        padding: 0.85rem 1rem;
+    }
+    .cro-hero__kpi:last-child { border-bottom: 0; }
+}
+
+/* =========================================================
+   2. COST-OF-INACTION (Pain redesign)
+   ========================================================= */
+.cro-pain {
+    padding: clamp(4rem, 7vw, 6rem) 0;
+    border-top: 1px solid var(--nx-border);
+    border-bottom: 1px solid var(--nx-border);
+    background: linear-gradient(180deg, rgba(255, 90, 90, 0.03), transparent 60%);
+}
+.cro-pain__head {
+    text-align: center;
+    margin-bottom: 2.5rem;
+}
+.cro-pain__lead {
+    color: var(--nx-text-secondary);
+    max-width: 56ch;
+    margin: 0.5rem auto 0;
+    font-size: 1.05rem;
+    line-height: 1.65;
+}
+.cro-pain__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.25rem;
+    max-width: 1080px;
+    margin: 0 auto 2.5rem;
+}
+.cro-pain__card {
+    position: relative;
+    padding: 1.6rem 1.5rem 1.5rem;
+    border-radius: var(--nx-radius-xl);
+    border: 1px solid var(--nx-border);
+    background: var(--nx-card-gradient);
+    overflow: hidden;
+    transition: transform 0.3s ease, border-color 0.3s ease;
+}
+.cro-pain__card:hover {
+    transform: translateY(-4px);
+    border-color: rgba(255, 107, 107, 0.35);
+}
+.cro-pain__card::before {
+    content: "";
+    position: absolute;
+    inset: 0 0 auto 0;
+    height: 3px;
+    background: linear-gradient(90deg, #ff6b6b, transparent);
+}
+.cro-pain__damage {
+    display: inline-block;
+    font-size: 1.85rem;
+    font-weight: 800;
+    color: #ff6b6b;
+    margin-bottom: 0.5rem;
+    letter-spacing: -0.015em;
+    line-height: 1;
+}
+.cro-pain__title {
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: var(--nx-text);
+    margin: 0 0 0.55rem;
+    line-height: 1.3;
+}
+.cro-pain__text {
+    color: var(--nx-text-secondary);
+    line-height: 1.6;
+    font-size: 0.95rem;
+    margin: 0;
+}
+.cro-pain__footer {
+    text-align: center;
+}
+
+/* =========================================================
+   3. PROOF — Before/After Split
+   ========================================================= */
+.cro-proof {
+    padding: clamp(4rem, 7vw, 6rem) 0;
+}
+.cro-proof__head {
+    text-align: center;
+    margin-bottom: 2.5rem;
+}
+.cro-proof__brand {
+    font-weight: 900;
+    font-size: 1.25rem;
+    letter-spacing: -0.02em;
+    color: var(--nx-text);
+    margin-top: 0.5rem;
+}
+.cro-proof__split {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    gap: 1.5rem;
+    align-items: stretch;
+    max-width: 1100px;
+    margin: 0 auto 2.5rem;
+}
+.cro-proof__column {
+    padding: 1.75rem 1.5rem;
+    border-radius: var(--nx-radius-xl);
+    border: 1px solid var(--nx-border);
+    background: var(--nx-card-gradient);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+.cro-proof__column--before {
+    opacity: 0.78;
+    border-style: dashed;
+}
+.cro-proof__column--after {
+    border-color: hsl(var(--accent-hsl) / 0.34);
+    background:
+        radial-gradient(circle at 100% 0%, hsl(var(--accent-hsl) / 0.18), transparent 40%),
+        var(--nx-card-gradient-strong);
+    box-shadow: var(--nx-shadow-md);
+    position: relative;
+}
+.cro-proof__column--after::before {
+    content: "";
+    position: absolute;
+    inset: 1.2rem auto 1.2rem 0;
+    width: 4px;
+    border-radius: 999px;
+    background: linear-gradient(180deg, hsl(var(--accent-hsl) / 0.95), hsl(var(--accent-hsl) / 0.3));
+}
+.cro-proof__col-tag {
+    display: inline-block;
+    font-size: 0.72rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--nx-text-muted);
+    margin-bottom: 0.25rem;
+}
+.cro-proof__column--after .cro-proof__col-tag {
+    color: var(--nx-accent-text);
+}
+.cro-proof__col-title {
+    font-size: 1.15rem;
+    font-weight: 700;
+    color: var(--nx-text);
+    margin: 0 0 0.5rem;
+    line-height: 1.3;
+}
+.cro-proof__col-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.55rem;
+}
+.cro-proof__col-list li {
+    color: var(--nx-text-secondary);
+    line-height: 1.55;
+    font-size: 0.95rem;
+    padding-left: 1.4rem;
+    position: relative;
+}
+.cro-proof__column--before .cro-proof__col-list li::before {
+    content: "✕";
+    color: #ff6b6b;
+    position: absolute;
+    left: 0;
+    font-weight: 700;
+    line-height: 1.55;
+}
+.cro-proof__column--after .cro-proof__col-list li::before {
+    content: "✓";
+    color: var(--nx-accent-text);
+    position: absolute;
+    left: 0;
+    font-weight: 700;
+    line-height: 1.55;
+}
+.cro-proof__arrow {
+    align-self: center;
+    font-size: 2rem;
+    color: hsl(var(--accent-hsl) / 0.6);
+    user-select: none;
+}
+.cro-proof__counters {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 1rem;
+    max-width: 1100px;
+    margin: 0 auto 2.5rem;
+}
+.cro-proof__counter {
+    padding: 1.4rem 1.2rem;
+    border-radius: var(--nx-radius-lg);
+    border: 1px solid hsl(var(--accent-hsl) / 0.22);
+    background: linear-gradient(180deg, hsl(var(--accent-hsl) / 0.08), rgba(255,255,255,0.02));
+    text-align: center;
+}
+.cro-proof__counter-value {
+    display: block;
+    font-size: clamp(1.75rem, 3vw, 2.4rem);
+    font-weight: 800;
+    color: var(--nx-text);
+    line-height: 1;
+    letter-spacing: -0.02em;
+}
+.cro-proof__counter-label {
+    display: block;
+    margin-top: 0.45rem;
+    font-size: 0.85rem;
+    color: var(--nx-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-weight: 600;
+}
+.cro-proof__footer {
+    text-align: center;
+}
+
+@media (max-width: 900px) {
+    .cro-proof__split {
+        grid-template-columns: 1fr;
+    }
+    .cro-proof__arrow {
+        transform: rotate(90deg);
+        justify-self: center;
+    }
+}
+
+/* =========================================================
+   4. MODELL A/B (overrides for crisper hierarchy)
+   ========================================================= */
+.cro-models__card {
+    position: relative;
+}
+.cro-models__card--bad {
+    border-color: rgba(255, 107, 107, 0.28);
+}
+.cro-models__card--bad::before {
+    content: "";
+    position: absolute;
+    inset: 0 0 auto 0;
+    height: 3px;
+    background: linear-gradient(90deg, #ff6b6b, transparent);
+    border-radius: var(--nx-radius-xl) var(--nx-radius-xl) 0 0;
+}
+.cro-models__card--good::before {
+    content: "";
+    position: absolute;
+    inset: 0 0 auto 0;
+    height: 3px;
+    background: linear-gradient(90deg, var(--nx-accent-text), transparent);
+    border-radius: var(--nx-radius-xl) var(--nx-radius-xl) 0 0;
+}
+.cro-models__cost {
+    margin-top: 1.5rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--nx-border);
+    font-weight: 700;
+    color: var(--nx-text);
+    font-size: 0.95rem;
+}
+.cro-models__card--good .cro-models__cost {
+    border-top-color: hsl(var(--accent-hsl) / 0.34);
+}
+.cro-models__card .cro-models__verdict {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    margin-top: 1.25rem;
+    padding: 0.45rem 0.85rem;
+    border-radius: 999px;
+    font-size: 0.8rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+}
+.cro-models__verdict--bad {
+    background: rgba(255, 107, 107, 0.1);
+    color: #ff8b8b;
+    border: 1px solid rgba(255, 107, 107, 0.25);
+}
+.cro-models__verdict--good {
+    background: hsl(var(--accent-hsl) / 0.14);
+    color: var(--nx-accent-text);
+    border: 1px solid hsl(var(--accent-hsl) / 0.32);
+}
+
+/* =========================================================
+   5. SYSTEM TIMELINE (3-step process)
+   ========================================================= */
+.cro-system {
+    padding: clamp(4rem, 7vw, 6rem) 0;
+    border-top: 1px solid var(--nx-border);
+}
+.cro-system__head {
+    text-align: center;
+    margin-bottom: 3rem;
+}
+.cro-timeline {
+    position: relative;
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 2rem;
+    max-width: 1100px;
+    margin: 0 auto 2.5rem;
+}
+.cro-timeline::before {
+    content: "";
+    position: absolute;
+    top: 38px;
+    left: calc(100% / 6);
+    right: calc(100% / 6);
+    height: 2px;
+    background: linear-gradient(90deg,
+        hsl(var(--accent-hsl) / 0.4),
+        hsl(var(--accent-hsl) / 0.7),
+        hsl(var(--accent-hsl) / 0.4));
+    z-index: 0;
+}
+.cro-timeline__step {
+    position: relative;
+    z-index: 1;
+    padding: 1.5rem 1.25rem;
+    border-radius: var(--nx-radius-xl);
+    border: 1px solid var(--nx-border);
+    background: var(--nx-card-gradient);
+    text-align: center;
+    transition: transform 0.3s ease, border-color 0.3s ease;
+}
+.cro-timeline__step:hover {
+    transform: translateY(-4px);
+    border-color: hsl(var(--accent-hsl) / 0.3);
+}
+.cro-timeline__num {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
+    background: linear-gradient(180deg, var(--nx-gold-hover), var(--gold));
+    color: var(--text-inverse);
+    font-weight: 800;
+    font-size: 1.4rem;
+    margin: 0 auto 1rem;
+    box-shadow: 0 10px 24px hsl(var(--accent-hsl) / 0.28);
+    line-height: 1;
+}
+.cro-timeline__title {
+    font-size: 1.15rem;
+    font-weight: 700;
+    color: var(--nx-text);
+    margin: 0 0 0.5rem;
+    line-height: 1.3;
+}
+.cro-timeline__text {
+    color: var(--nx-text-secondary);
+    font-size: 0.95rem;
+    line-height: 1.6;
+    margin: 0;
+}
+.cro-system__footer {
+    text-align: center;
+}
+
+@media (max-width: 760px) {
+    .cro-timeline {
+        grid-template-columns: 1fr;
+        gap: 1.25rem;
+    }
+    .cro-timeline::before {
+        top: 0;
+        bottom: 0;
+        left: 50%;
+        right: auto;
+        width: 2px;
+        height: auto;
+        background: linear-gradient(180deg,
+            hsl(var(--accent-hsl) / 0.4),
+            hsl(var(--accent-hsl) / 0.7),
+            hsl(var(--accent-hsl) / 0.4));
+    }
+}
+
+/* =========================================================
+   6. INTERACTIVE DIAGNOSE (Self-check)
+   ========================================================= */
+.cro-diagnose {
+    padding: clamp(4rem, 7vw, 6rem) 0;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.02), transparent 80%);
+    border-top: 1px solid var(--nx-border);
+    border-bottom: 1px solid var(--nx-border);
+}
+.cro-diagnose__head {
+    text-align: center;
+    margin-bottom: 2.5rem;
+}
+.cro-diagnose__sub {
+    color: var(--nx-text-secondary);
+    max-width: 56ch;
+    margin: 0.6rem auto 0;
+    font-size: 1.05rem;
+    line-height: 1.6;
+}
+.cro-diagnose__quiz {
+    max-width: 760px;
+    margin: 0 auto;
+    padding: 2rem;
+    border-radius: var(--nx-radius-xl);
+    border: 1px solid var(--nx-border);
+    background: var(--nx-card-gradient-strong);
+    box-shadow: var(--nx-shadow-md);
+}
+.cro-diagnose__question {
+    border-bottom: 1px solid var(--nx-border);
+    padding: 1rem 0;
+}
+.cro-diagnose__question:first-child { padding-top: 0; }
+.cro-diagnose__question:last-of-type {
+    border-bottom: 0;
+    padding-bottom: 0;
+}
+.cro-diagnose__q-label {
+    display: block;
+    font-size: 1.05rem;
+    font-weight: 700;
+    color: var(--nx-text);
+    margin-bottom: 0.85rem;
+    line-height: 1.4;
+}
+.cro-diagnose__q-num {
+    display: inline-block;
+    width: 1.6rem;
+    color: var(--nx-accent-text);
+    font-weight: 800;
+}
+.cro-diagnose__answers {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+}
+.cro-diagnose__answer {
+    flex: 1 1 auto;
+    padding: 0.7rem 1.1rem;
+    border-radius: 999px;
+    border: 1px solid var(--nx-border);
+    background: rgba(255, 255, 255, 0.03);
+    color: var(--nx-text-secondary);
+    font-size: 0.9rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    text-align: center;
+    min-height: 44px;
+}
+.cro-diagnose__answer:hover {
+    border-color: hsl(var(--accent-hsl) / 0.4);
+    background: hsl(var(--accent-hsl) / 0.06);
+    color: var(--nx-text);
+}
+.cro-diagnose__answer.is-selected[data-value="bad"] {
+    background: rgba(255, 107, 107, 0.12);
+    border-color: rgba(255, 107, 107, 0.4);
+    color: #ff8b8b;
+}
+.cro-diagnose__answer.is-selected[data-value="good"] {
+    background: hsl(var(--accent-hsl) / 0.16);
+    border-color: hsl(var(--accent-hsl) / 0.5);
+    color: var(--nx-accent-text);
+}
+.cro-diagnose__result {
+    margin-top: 2rem;
+    padding: 1.5rem 1.5rem;
+    border-radius: var(--nx-radius-lg);
+    border: 1px dashed var(--nx-border);
+    background: rgba(255, 255, 255, 0.02);
+    text-align: center;
+    color: var(--nx-text-secondary);
+    font-size: 0.95rem;
+    line-height: 1.6;
+    transition: all 0.3s ease;
+}
+.cro-diagnose__result.is-active {
+    border-style: solid;
+    border-color: hsl(var(--accent-hsl) / 0.34);
+    background:
+        linear-gradient(180deg, hsl(var(--accent-hsl) / 0.1), rgba(255,255,255,0.02));
+    color: var(--nx-text);
+}
+.cro-diagnose__result-title {
+    font-weight: 800;
+    color: var(--nx-text);
+    font-size: 1.05rem;
+    margin: 0 0 0.4rem;
+    line-height: 1.35;
+}
+.cro-diagnose__result-cta {
+    margin-top: 1rem;
+    display: none;
+}
+.cro-diagnose__result.is-active .cro-diagnose__result-cta {
+    display: inline-flex;
+}
+
+/* =========================================================
+   7. TRUST STRIP
+   ========================================================= */
+.cro-trust-strip {
+    padding: 2.5rem 0 1rem;
+    border-top: 1px solid var(--nx-border);
+}
+.cro-trust-strip__inner {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
+    gap: 1rem 2rem;
+    color: var(--nx-text-muted);
+    font-size: 0.85rem;
+    text-align: center;
+}
+.cro-trust-strip__item {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    line-height: 1.4;
+}
+.cro-trust-strip__icon {
+    color: var(--nx-accent-text);
+    font-weight: 700;
+}
+
+/* =========================================================
+   8. FINAL CTA + SLOT VISUAL
+   ========================================================= */
+.cro-final {
+    padding: clamp(3rem, 6vw, 5rem) 0 clamp(4rem, 7vw, 6rem);
+}
+.cro-final__box {
+    max-width: 780px;
+    margin: 0 auto;
+    padding: clamp(2rem, 4vw, 3rem);
+    border-radius: var(--nx-radius-xl);
+    border: 1px solid hsl(var(--accent-hsl) / 0.32);
+    background:
+        radial-gradient(circle at 0% 0%, hsl(var(--accent-hsl) / 0.18), transparent 45%),
+        var(--nx-card-gradient-strong);
+    box-shadow: var(--nx-shadow-lg);
+    text-align: center;
+}
+.cro-final__title {
+    font-size: clamp(1.75rem, 3vw, 2.25rem);
+    color: var(--nx-text);
+    margin: 0.5rem 0 0.75rem;
+    line-height: 1.2;
+}
+.cro-final__lead {
+    color: var(--nx-text-secondary);
+    font-size: 1.05rem;
+    line-height: 1.65;
+    margin: 0 0 2rem;
+}
+.cro-slot-bar {
+    margin: 0 auto 1.5rem;
+    max-width: 480px;
+}
+.cro-slot-bar__label {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    font-size: 0.85rem;
+    margin-bottom: 0.55rem;
+    color: var(--nx-text-secondary);
+    font-weight: 600;
+}
+.cro-slot-bar__count {
+    color: var(--nx-accent-text);
+    font-weight: 800;
+}
+.cro-slot-bar__track {
+    display: flex;
+    gap: 0.4rem;
+}
+.cro-slot-bar__seg {
+    flex: 1;
+    height: 12px;
+    border-radius: 4px;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid var(--nx-border);
+}
+.cro-slot-bar__seg.is-booked {
+    background: linear-gradient(180deg, var(--nx-gold-hover), var(--gold));
+    border-color: hsl(var(--accent-hsl) / 0.6);
+    box-shadow: 0 4px 14px hsl(var(--accent-hsl) / 0.32);
+}
+.cro-final__cta-row {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.85rem;
+    margin-bottom: 1.25rem;
+}
+.cro-final__risk-reversal {
+    display: inline-flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.35rem 1rem;
+    margin: 0;
+    color: var(--nx-text-muted);
+    font-size: 0.85rem;
+}
+.cro-final__risk-reversal span::before {
+    content: "·";
+    margin-right: 1rem;
+    color: var(--nx-text-dim);
+}
+.cro-final__risk-reversal span:first-child::before {
+    content: none;
+    margin-right: 0;
+}
+
+/* =========================================================
+   9. STICKY MOBILE CTA
+   ========================================================= */
+.cro-sticky-cta {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 80;
+    padding: 0.65rem 0.85rem calc(0.65rem + env(safe-area-inset-bottom));
+    background: rgba(15, 18, 26, 0.92);
+    border-top: 1px solid hsl(var(--accent-hsl) / 0.3);
+    backdrop-filter: blur(14px);
+    box-shadow: 0 -8px 24px rgba(0, 0, 0, 0.35);
+    transform: translateY(110%);
+    transition: transform 0.35s cubic-bezier(0.16, 1, 0.3, 1);
+    display: none;
+}
+.cro-sticky-cta.is-visible {
+    transform: translateY(0);
+}
+.cro-sticky-cta__inner {
+    display: flex;
+    gap: 0.6rem;
+    align-items: center;
+    justify-content: space-between;
+    max-width: 720px;
+    margin: 0 auto;
+}
+.cro-sticky-cta__copy {
+    color: var(--nx-text);
+    font-size: 0.85rem;
+    line-height: 1.3;
+    font-weight: 600;
+    flex: 1;
+}
+.cro-sticky-cta__copy small {
+    display: block;
+    color: var(--nx-text-muted);
+    font-size: 0.72rem;
+    font-weight: 500;
+    margin-top: 2px;
+}
+.cro-sticky-cta__btn {
+    flex-shrink: 0;
+    min-height: 46px;
+    padding: 0 1.1rem;
+    font-size: 0.9rem;
+}
+@media (max-width: 760px) {
+    .cro-sticky-cta { display: block; }
+    /* push body content above sticky bar */
+    .homepage-template { padding-bottom: 88px; }
+}
+
+/* Light theme adjustments */
+:root[data-nx-theme='light'] .cro-sticky-cta {
+    background: rgba(255, 255, 255, 0.95);
+    border-top-color: hsl(var(--accent-hsl) / 0.4);
+}
+:root[data-nx-theme='light'] .cro-pain__damage { color: #d63838; }
+:root[data-nx-theme='light'] .cro-proof__column--before .cro-proof__col-list li::before,
+:root[data-nx-theme='light'] .cro-pain__card::before { color: #d63838; }

--- a/blocksy-child/assets/js/homepage-cro.js
+++ b/blocksy-child/assets/js/homepage-cro.js
@@ -1,0 +1,200 @@
+/**
+ * Homepage CRO Layer — animations & interactions
+ *
+ * - IntersectionObserver: reveal on scroll
+ * - Counter animation for proof KPIs
+ * - Interactive 3-question diagnose self-check
+ * - Sticky mobile CTA visibility (after hero leaves viewport)
+ */
+(function () {
+    'use strict';
+
+    var prefersReducedMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    /* ---------- Reveal-on-scroll ---------- */
+    function initReveal() {
+        var els = document.querySelectorAll('.cro-reveal');
+        if (!els.length) return;
+
+        if (prefersReducedMotion || !('IntersectionObserver' in window)) {
+            els.forEach(function (el) { el.classList.add('is-visible'); });
+            return;
+        }
+
+        var io = new IntersectionObserver(function (entries) {
+            entries.forEach(function (entry) {
+                if (entry.isIntersecting) {
+                    entry.target.classList.add('is-visible');
+                    io.unobserve(entry.target);
+                }
+            });
+        }, { threshold: 0.12, rootMargin: '0px 0px -40px 0px' });
+
+        els.forEach(function (el) { io.observe(el); });
+    }
+
+    /* ---------- Counter animation ---------- */
+    function animateCounter(el) {
+        var target = parseFloat(el.getAttribute('data-counter-target'));
+        if (isNaN(target)) return;
+
+        var prefix = el.getAttribute('data-counter-prefix') || '';
+        var suffix = el.getAttribute('data-counter-suffix') || '';
+        var decimals = parseInt(el.getAttribute('data-counter-decimals') || '0', 10);
+        var duration = 1400;
+        var start = performance.now();
+
+        function format(v) {
+            var fixed = decimals > 0 ? v.toFixed(decimals) : Math.round(v).toString();
+            // German thousand separator
+            var parts = fixed.split('.');
+            parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, '.');
+            return prefix + parts.join(',') + suffix;
+        }
+
+        function step(now) {
+            var elapsed = now - start;
+            var t = Math.min(1, elapsed / duration);
+            // easeOutCubic
+            var eased = 1 - Math.pow(1 - t, 3);
+            el.textContent = format(target * eased);
+            if (t < 1) requestAnimationFrame(step);
+            else el.textContent = format(target);
+        }
+
+        if (prefersReducedMotion) {
+            el.textContent = format(target);
+            return;
+        }
+        requestAnimationFrame(step);
+    }
+
+    function initCounters() {
+        var counters = document.querySelectorAll('[data-counter-target]');
+        if (!counters.length) return;
+
+        if (!('IntersectionObserver' in window)) {
+            counters.forEach(animateCounter);
+            return;
+        }
+
+        var io = new IntersectionObserver(function (entries) {
+            entries.forEach(function (entry) {
+                if (entry.isIntersecting) {
+                    animateCounter(entry.target);
+                    io.unobserve(entry.target);
+                }
+            });
+        }, { threshold: 0.4 });
+
+        counters.forEach(function (el) { io.observe(el); });
+    }
+
+    /* ---------- Interactive diagnose ---------- */
+    function initDiagnose() {
+        var quiz = document.querySelector('[data-cro-diagnose]');
+        if (!quiz) return;
+
+        var result = quiz.querySelector('[data-cro-diagnose-result]');
+        var resultTitle = quiz.querySelector('[data-cro-diagnose-result-title]');
+        var resultText = quiz.querySelector('[data-cro-diagnose-result-text]');
+        if (!result || !resultTitle || !resultText) return;
+
+        var answers = {};
+
+        quiz.querySelectorAll('.cro-diagnose__answer').forEach(function (btn) {
+            btn.addEventListener('click', function () {
+                var q = btn.getAttribute('data-question');
+                var v = btn.getAttribute('data-value');
+                if (!q || !v) return;
+
+                quiz
+                    .querySelectorAll('.cro-diagnose__answer[data-question="' + q + '"]')
+                    .forEach(function (b) { b.classList.remove('is-selected'); });
+                btn.classList.add('is-selected');
+
+                answers[q] = v;
+                evaluate();
+            });
+        });
+
+        function evaluate() {
+            var keys = Object.keys(answers);
+            if (keys.length < 3) {
+                result.classList.remove('is-active');
+                resultTitle.textContent = 'Beantworten Sie alle drei Fragen.';
+                resultText.textContent = 'Sie erhalten in 60 Sekunden eine ehrliche Diagnose, ob Sie ein System besitzen oder eines mieten.';
+                return;
+            }
+
+            var bad = 0;
+            keys.forEach(function (k) { if (answers[k] === 'bad') bad++; });
+
+            result.classList.add('is-active');
+
+            if (bad === 0) {
+                resultTitle.textContent = 'Sie besitzen Ihr System.';
+                resultText.textContent = 'Code, CRM und Tracking gehören Ihnen. Sie brauchen mich vermutlich nicht — oder nur punktuell für Skalierung. Senden Sie mir einen Screenshot, ich gebe Ihnen ehrliches Feedback.';
+            } else if (bad === 1) {
+                resultTitle.textContent = 'Eine Lücke — und sie kostet Sie.';
+                resultText.textContent = 'Ein einziger fremdgesteuerter Hebel reicht, um aus Ihren Leads schnell die Leads des Anbieters zu machen. Diagnose zeigt, welcher Schritt sich wirtschaftlich am schnellsten amortisiert.';
+            } else {
+                resultTitle.textContent = 'Sie mieten Ihr System.';
+                resultText.textContent = 'Code, CRM oder Tracking liegen außerhalb Ihrer Kontrolle. Bei Vertragsende oder Preiserhöhung haben Sie keine Hebel. Genau das löse ich — auf bestehender Infrastruktur, ohne Relaunch.';
+            }
+        }
+
+        evaluate();
+    }
+
+    /* ---------- Sticky mobile CTA ---------- */
+    function initStickyCta() {
+        var cta = document.querySelector('.cro-sticky-cta');
+        if (!cta) return;
+        var hero = document.querySelector('.cro-hero');
+        var finalSection = document.querySelector('.cro-final');
+        if (!hero) return;
+
+        if (!('IntersectionObserver' in window)) {
+            cta.classList.add('is-visible');
+            return;
+        }
+
+        var heroIo = new IntersectionObserver(function (entries) {
+            entries.forEach(function (entry) {
+                // Hero leaves viewport → show CTA
+                if (entry.intersectionRatio < 0.2) {
+                    cta.classList.add('is-visible');
+                } else {
+                    cta.classList.remove('is-visible');
+                }
+            });
+        }, { threshold: [0, 0.2, 0.5, 1] });
+
+        heroIo.observe(hero);
+
+        // Hide when final CTA section is in view (would be redundant)
+        if (finalSection) {
+            var finalIo = new IntersectionObserver(function (entries) {
+                entries.forEach(function (entry) {
+                    if (entry.isIntersecting) {
+                        cta.classList.remove('is-visible');
+                    }
+                });
+            }, { threshold: 0.3 });
+            finalIo.observe(finalSection);
+        }
+    }
+
+    function ready(fn) {
+        if (document.readyState !== 'loading') fn();
+        else document.addEventListener('DOMContentLoaded', fn);
+    }
+
+    ready(function () {
+        initReveal();
+        initCounters();
+        initDiagnose();
+        initStickyCta();
+    });
+})();

--- a/blocksy-child/front-page.php
+++ b/blocksy-child/front-page.php
@@ -14,26 +14,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 $urls = function_exists( 'hu_home_urls' ) ? hu_home_urls() : [];
 
-$request_url             = function_exists( 'nexus_get_primary_request_url' ) ? nexus_get_primary_request_url() : home_url( '/solar-waermepumpen-leadgenerierung/#energie-anfrage' );
-$primary_cta_label       = 'System-Diagnose starten (60 Sek.)';
-$secondary_cta_label     = 'Schon entschieden? Direkt anfragen.';
+$request_url         = function_exists( 'nexus_get_primary_request_url' ) ? nexus_get_primary_request_url() : home_url( '/solar-waermepumpen-leadgenerierung/#energie-anfrage' );
+$diagnose_anchor     = '#diagnose';
+$primary_cta_label   = 'System-Diagnose starten (60 Sek.)';
+$secondary_cta_label = 'Schon entschieden? Direkt anfragen.';
 
-$slots_booked = 3; // Verknappung Variable
-
-$hero_metrics = function_exists( 'nexus_get_public_proof_metric_list' ) ? nexus_get_public_proof_metric_list( [ 'lead_count', 'sales_conversion', 'cpl_reduction' ] ) : [
-	[
-		'value' => '1.750+',
-		'label' => 'qualifizierte Anfragen',
-	],
-	[
-		'value' => '12 %',
-		'label' => 'Abschlussquote',
-	],
-	[
-		'value' => '-83 %',
-		'label' => 'Kosten pro Anfrage',
-	],
-];
+$slots_total  = 4;
+$slots_booked = 3;
 
 $faq_items = [
 	[
@@ -51,105 +38,150 @@ get_header();
 
 <main id="main" class="site-main" data-track-section="homepage">
 	<div class="cs-page homepage-template">
-		<section id="hero" class="wp-hero wp-home-hero">
-			<div class="wp-container wp-home-shell">
-				<div class="wp-home-hero__grid">
-					<div class="wp-hero-copy wp-home-hero__copy">
-						<span class="wp-badge">Für Solar- und Wärmepumpen-Betriebe mit 10–25 Mitarbeitern</span>
-						<h1 class="wp-hero-title">Schluss mit teuren Portal-Leads, die nicht ans Telefon gehen.</h1>
-						<p class="wp-hero-subtitle wp-home-hero__subtitle">
-							&minus;83 % Kosten pro Anfrage in 9 Monaten &mdash; Referenz E3 New Energy. Eigenes Anfrage-System statt Portal-Abhängigkeit.
-						</p>
 
-						<div class="wp-home-hero__actions">
-							<a href="<?php echo esc_url( $request_url ); ?>" class="wp-btn wp-btn-primary wp-home-hero__primary" data-track-action="cta_home_hero_diagnose" data-track-category="lead_gen"><?php echo esc_html( $primary_cta_label ); ?></a>
-							<div style="margin-top: 0.75rem;">
-								<a href="<?php echo esc_url( $request_url ); ?>" class="wp-home-hero__secondary" style="font-size: 0.85rem; text-decoration: underline;" data-track-action="cta_home_hero_request" data-track-category="lead_gen"><?php echo esc_html( $secondary_cta_label ); ?></a>
-							</div>
-						</div>
-
-					</div>
-				</div>
-			</div>
-		</section>
-
-		<!-- Task 3: Pain-Block -->
-		<section id="pain" class="wp-section homepage-pain" data-track-section="homepage_pain" style="background: var(--nx-bg-glass-light, rgba(255, 255, 255, 0.02)); padding: 4rem 0; border-top: 1px solid var(--nx-border, rgba(255, 255, 255, 0.05)); border-bottom: 1px solid var(--nx-border, rgba(255, 255, 255, 0.05));">
-			<div class="wp-container wp-home-shell">
-				<div class="wp-section-title wp-home-section-title text-center">
-					<h2 class="wp-section-h2">Die Realität im Lead-Einkauf</h2>
-				</div>
-				<ul class="premium-list" style="max-width: 600px; margin: 0 auto 2rem; list-style: none; padding: 0;">
-					<li style="margin-bottom: 1rem;"><span class="check-icon" style="color: #ff6b6b; margin-right: 10px;">✕</span>80 &euro; pro Lead &mdash; Hälfte geht nicht ans Telefon</li>
-					<li style="margin-bottom: 1rem;"><span class="check-icon" style="color: #ff6b6b; margin-right: 10px;">✕</span>Kein Überblick, welcher Kanal wirklich konvertiert</li>
-					<li style="margin-bottom: 1rem;"><span class="check-icon" style="color: #ff6b6b; margin-right: 10px;">✕</span>Seit 2024: Anfragen kommen nicht mehr von allein</li>
-				</ul>
-				<div class="text-center">
-					<a href="<?php echo esc_url( $request_url ); ?>" class="nx-btn nx-btn--primary" data-track-action="cta_home_pain_diagnose" data-track-category="lead_gen"><?php echo esc_html( $primary_cta_label ); ?></a>
-					<div style="margin-top: 0.75rem;">
-						<a href="<?php echo esc_url( $request_url ); ?>" style="font-size: 0.85rem; text-decoration: underline;" data-track-action="cta_home_pain_request" data-track-category="lead_gen"><?php echo esc_html( $secondary_cta_label ); ?></a>
-					</div>
-				</div>
-			</div>
-		</section>
-
-		<section id="proof" class="wp-section homepage-track-record" data-track-section="homepage_proof">
-			<div class="wp-container wp-home-shell">
-				<div class="wp-section-title wp-home-section-title text-center">
-					<span class="wp-badge">Proof</span>
-					<h2 class="wp-section-h2">Ergebnis statt Behauptung.</h2>
-				</div>
-
-				<article class="wp-success-card homepage-track-record__card homepage-track-record__card--primary" aria-labelledby="homepage-proof-case-title">
-					<div class="homepage-track-record__case-head">
-						<!-- Kundenlogo E3 New Energy -->
-						<div style="margin-bottom: 1rem; font-weight: 900; font-size: 1.5rem; letter-spacing: -0.02em;">E3 New Energy</div>
-						<h3 id="homepage-proof-case-title" class="wp-success-title">Vom Lead-Einkauf zur Lead-Autonomie.</h3>
-					</div>
-
-					<p class="homepage-track-record__summary">
-						Ausgangslage: Hohe Leadkosten und unklare Qualität durch eingekaufte Portal-Leads.<br>
-						Ergebnis: Eigenes, skalierbares System mit signifikant reduzierten CPL und echten Entscheidungssignalen.
+		<!-- ============== HERO ============== -->
+		<section id="hero" class="wp-hero cro-hero" data-track-section="homepage_hero">
+			<div class="wp-container wp-home-shell cro-hero__shell">
+				<div class="cro-hero__copy">
+					<span class="wp-badge">Für Solar- und Wärmepumpen-Betriebe mit 10–25 Mitarbeitern</span>
+					<h1 class="wp-hero-title cro-hero__title">Schluss mit teuren Portal-Leads, die nicht ans Telefon gehen.</h1>
+					<p class="cro-hero__sub">
+						&minus;83 % Kosten pro Anfrage in 9 Monaten &mdash; Referenz E3 New Energy. Eigenes Anfrage-System statt Portal-Abhängigkeit.
 					</p>
 
-					<div class="wp-home-kpi-row" role="list" aria-label="Zentrale Ergebniskennzahlen" style="margin: 2rem 0; display: flex; flex-wrap: wrap; gap: 1rem;">
-						<div class="wp-home-kpi-card" role="listitem" style="flex: 1; min-width: 120px;">
-							<span class="wp-home-kpi-card__value" style="display: block; font-size: 1.5rem; font-weight: bold;">9 Monate</span>
-							<span class="wp-home-kpi-card__label" style="font-size: 0.85rem;">Dauer</span>
+					<div class="cro-hero__kpi-ribbon" role="list" aria-label="Kennzahlen aus der Referenz E3 New Energy">
+						<div class="cro-hero__kpi" role="listitem">
+							<span class="cro-hero__kpi-value">1.750+</span>
+							<span class="cro-hero__kpi-label">qualifizierte Anfragen</span>
 						</div>
-						<div class="wp-home-kpi-card" role="listitem" style="flex: 1; min-width: 120px;">
-							<span class="wp-home-kpi-card__value" style="display: block; font-size: 1.5rem; font-weight: bold;">1.750+</span>
-							<span class="wp-home-kpi-card__label" style="font-size: 0.85rem;">Anfragen</span>
+						<div class="cro-hero__kpi" role="listitem">
+							<span class="cro-hero__kpi-value">12&nbsp;%</span>
+							<span class="cro-hero__kpi-label">Abschlussquote</span>
 						</div>
-						<div class="wp-home-kpi-card" role="listitem" style="flex: 1; min-width: 120px;">
-							<span class="wp-home-kpi-card__value" style="display: block; font-size: 1.5rem; font-weight: bold;">12 %</span>
-							<span class="wp-home-kpi-card__label" style="font-size: 0.85rem;">Abschlussquote</span>
-						</div>
-						<div class="wp-home-kpi-card" role="listitem" style="flex: 1; min-width: 120px;">
-							<span class="wp-home-kpi-card__value" style="display: block; font-size: 1.5rem; font-weight: bold;">&minus;83 %</span>
-							<span class="wp-home-kpi-card__label" style="font-size: 0.85rem;">CPL</span>
+						<div class="cro-hero__kpi" role="listitem">
+							<span class="cro-hero__kpi-value">&minus;83&nbsp;%</span>
+							<span class="cro-hero__kpi-label">Kosten pro Anfrage</span>
 						</div>
 					</div>
 
-					<div class="homepage-track-record__actions">
-						<a href="<?php echo esc_url( $request_url ); ?>" class="nx-btn nx-btn--primary" data-track-action="cta_home_proof_diagnose" data-track-category="lead_gen"><?php echo esc_html( $primary_cta_label ); ?></a>
-						<div style="margin-top: 0.75rem;">
-							<a href="<?php echo esc_url( $request_url ); ?>" style="font-size: 0.85rem; text-decoration: underline;" data-track-action="cta_home_proof_request" data-track-category="lead_gen"><?php echo esc_html( $secondary_cta_label ); ?></a>
-						</div>
+					<div class="cro-hero__cta-stack">
+						<a href="<?php echo esc_url( $diagnose_anchor ); ?>" class="nx-btn nx-btn--primary" data-track-action="cta_home_hero_diagnose" data-track-category="lead_gen"><?php echo esc_html( $primary_cta_label ); ?></a>
+						<a href="<?php echo esc_url( $request_url ); ?>" class="cro-hero__cta-secondary" data-track-action="cta_home_hero_request" data-track-category="lead_gen"><?php echo esc_html( $secondary_cta_label ); ?></a>
 					</div>
-				</article>
+
+					<div class="cro-hero__trust" aria-label="Vertrauenssignale">
+						<span class="cro-hero__trust-item"><span class="cro-hero__trust-dot" aria-hidden="true"></span>9 Monate Track Record</span>
+						<span class="cro-hero__trust-item"><span class="cro-hero__trust-dot" aria-hidden="true"></span>Privacy-first Tracking</span>
+						<span class="cro-hero__trust-item"><span class="cro-hero__trust-dot" aria-hidden="true"></span>Hannover &middot; remote</span>
+					</div>
+				</div>
 			</div>
 		</section>
 
+		<!-- ============== COST OF INACTION ============== -->
+		<section id="pain" class="cro-pain" data-track-section="homepage_pain">
+			<div class="wp-container wp-home-shell">
+				<div class="cro-pain__head cro-reveal">
+					<h2 class="wp-section-h2">Was Sie der Status quo wirklich kostet.</h2>
+					<p class="cro-pain__lead">Drei stille Posten, die jeder Betrieb spürt &mdash; aber selten in Euro misst.</p>
+				</div>
+
+				<div class="cro-pain__grid">
+					<article class="cro-pain__card cro-reveal">
+						<span class="cro-pain__damage">~ 4.800&nbsp;&euro; / Monat</span>
+						<h3 class="cro-pain__title">Portal-Leads, die nicht ans Telefon gehen</h3>
+						<p class="cro-pain__text">60 Leads &times; 80 &euro; CPL &times; 50 % Erreichbarkeit &mdash; Geld, das ohne Termin verbrennt.</p>
+					</article>
+
+					<article class="cro-pain__card cro-reveal">
+						<span class="cro-pain__damage">Blindflug</span>
+						<h3 class="cro-pain__title">Kein Kanal-Klarbild</h3>
+						<p class="cro-pain__text">Welche Kampagne bringt Termine, welche nur Klicks? Ohne Tracking entscheiden Sie nach Bauchgefühl &mdash; das skaliert nicht.</p>
+					</article>
+
+					<article class="cro-pain__card cro-reveal">
+						<span class="cro-pain__damage">Seit 2024</span>
+						<h3 class="cro-pain__title">Anfragen kommen nicht mehr von allein</h3>
+						<p class="cro-pain__text">Der Solar-Boom ist vorbei. Wer kein eigenes System hat, ist auf Portale angewiesen &mdash; mit jedem Quartal teurer.</p>
+					</article>
+				</div>
+
+				<div class="cro-pain__footer cro-reveal">
+					<a href="<?php echo esc_url( $diagnose_anchor ); ?>" class="nx-btn nx-btn--primary" data-track-action="cta_home_pain_diagnose" data-track-category="lead_gen"><?php echo esc_html( $primary_cta_label ); ?></a>
+				</div>
+			</div>
+		</section>
+
+		<!-- ============== PROOF — BEFORE / AFTER ============== -->
+		<section id="proof" class="cro-proof" data-track-section="homepage_proof">
+			<div class="wp-container wp-home-shell">
+				<div class="cro-proof__head cro-reveal">
+					<span class="wp-badge">Proof</span>
+					<h2 class="wp-section-h2">Vom Lead-Einkauf zur Lead-Autonomie.</h2>
+					<div class="cro-proof__brand">E3 New Energy</div>
+				</div>
+
+				<div class="cro-proof__split">
+					<article class="cro-proof__column cro-proof__column--before cro-reveal">
+						<span class="cro-proof__col-tag">Vorher</span>
+						<h3 class="cro-proof__col-title">Portal-Lead-Welt</h3>
+						<ul class="cro-proof__col-list">
+							<li>Hohe Lead-Kosten, schwankende Qualität</li>
+							<li>Hälfte der Leads geht nicht ans Telefon</li>
+							<li>Kein Überblick &uuml;ber konvertierende Kanäle</li>
+							<li>Wachstum nur durch Budget-Erhöhung möglich</li>
+						</ul>
+					</article>
+
+					<div class="cro-proof__arrow" aria-hidden="true">→</div>
+
+					<article class="cro-proof__column cro-proof__column--after cro-reveal">
+						<span class="cro-proof__col-tag">Nach 9 Monaten</span>
+						<h3 class="cro-proof__col-title">Eigenes, skalierbares System</h3>
+						<ul class="cro-proof__col-list">
+							<li>Vorqualifizierte Anfragen direkt im CRM</li>
+							<li>Privacy-first Tracking auf Kanal-Ebene</li>
+							<li>Money Pages und Proof als bleibende Assets</li>
+							<li>Skalierbar ohne CPL-Explosion</li>
+						</ul>
+					</article>
+				</div>
+
+				<div class="cro-proof__counters cro-reveal" role="list" aria-label="Ergebniskennzahlen">
+					<div class="cro-proof__counter" role="listitem">
+						<span class="cro-proof__counter-value" data-counter-target="9" data-counter-suffix=" Monate">9 Monate</span>
+						<span class="cro-proof__counter-label">Dauer</span>
+					</div>
+					<div class="cro-proof__counter" role="listitem">
+						<span class="cro-proof__counter-value" data-counter-target="1750" data-counter-suffix="+">1.750+</span>
+						<span class="cro-proof__counter-label">qualifizierte Anfragen</span>
+					</div>
+					<div class="cro-proof__counter" role="listitem">
+						<span class="cro-proof__counter-value" data-counter-target="12" data-counter-suffix=" %">12 %</span>
+						<span class="cro-proof__counter-label">Abschlussquote</span>
+					</div>
+					<div class="cro-proof__counter" role="listitem">
+						<span class="cro-proof__counter-value" data-counter-target="-83" data-counter-suffix=" %">&minus;83 %</span>
+						<span class="cro-proof__counter-label">Kosten pro Anfrage</span>
+					</div>
+				</div>
+
+				<div class="cro-proof__footer cro-reveal">
+					<a href="<?php echo esc_url( $diagnose_anchor ); ?>" class="nx-btn nx-btn--primary" data-track-action="cta_home_proof_diagnose" data-track-category="lead_gen"><?php echo esc_html( $primary_cta_label ); ?></a>
+				</div>
+			</div>
+		</section>
+
+		<!-- ============== MODELL A / B ============== -->
 		<section class="wp-section homepage-problem-frame" data-track-section="homepage_models">
 			<div class="wp-container wp-home-shell">
-				<div class="wp-section-title wp-home-section-title text-center">
+				<div class="wp-section-title wp-home-section-title text-center cro-reveal">
 					<span class="wp-badge">Modell</span>
 					<h2 class="wp-section-h2">Zwei Wege. Ein Unterschied.</h2>
 				</div>
 
 				<div class="homepage-problem-frame__grid">
-					<article class="wp-success-card homepage-problem-frame__card homepage-problem-frame__card--muted">
+					<article class="wp-success-card homepage-problem-frame__card homepage-problem-frame__card--muted cro-models__card cro-models__card--bad cro-reveal">
 						<p class="wp-success-subtitle">Modell A</p>
 						<h3 class="wp-success-title">Nachfrage mieten</h3>
 						<ul class="premium-list" aria-label="Modell A">
@@ -157,12 +189,11 @@ get_header();
 							<li><span class="check-icon homepage-problem-frame__arrow">→</span><div>Reports ohne Entscheidungssignale</div></li>
 							<li><span class="check-icon homepage-problem-frame__arrow">→</span><div>Budgetstop = Nachfrage-Stopp</div></li>
 						</ul>
-						<div style="margin-top: 1.5rem; padding-top: 1rem; border-top: 1px solid var(--nx-border-color, rgba(255, 255, 255, 0.1)); font-weight: 600;">
-							24 Monate &approx; 26.000 &euro; &middot; 0 &euro; Asset
-						</div>
+						<div class="cro-models__cost">24 Monate &approx; 26.000 &euro; &middot; 0 &euro; Asset</div>
+						<span class="cro-models__verdict cro-models__verdict--bad">Kostet ohne zu skalieren</span>
 					</article>
 
-					<article class="wp-success-card homepage-problem-frame__card homepage-problem-frame__card--accent">
+					<article class="wp-success-card homepage-problem-frame__card homepage-problem-frame__card--accent cro-models__card cro-models__card--good cro-reveal">
 						<p class="wp-success-subtitle">Modell B</p>
 						<h3 class="wp-success-title">Infrastruktur aufbauen</h3>
 						<ul class="premium-list" aria-label="Modell B">
@@ -170,87 +201,121 @@ get_header();
 							<li><span class="check-icon">✓</span><div>Privacy-first Tracking schafft echte Entscheidungssignale</div></li>
 							<li><span class="check-icon">✓</span><div>Ads erst skalieren, wenn das Fundament steht</div></li>
 						</ul>
-						<div style="margin-top: 1.5rem; padding-top: 1rem; border-top: 1px solid var(--nx-border-color-accent, rgba(255,255,255,0.2)); font-weight: 600;">
-							24 Monate &approx; 13.200&ndash;19.200 &euro; &middot; aktiviertes Asset
-						</div>
+						<div class="cro-models__cost">24 Monate &approx; 13.200&ndash;19.200 &euro; &middot; aktiviertes Asset</div>
+						<span class="cro-models__verdict cro-models__verdict--good">Asset, das bleibt</span>
 					</article>
 				</div>
 
-				<div class="homepage-problem-frame__cta text-center" style="margin-top: 3rem;">
-					<a href="<?php echo esc_url( $request_url ); ?>" class="nx-btn nx-btn--primary" data-track-action="cta_home_models_diagnose" data-track-category="lead_gen"><?php echo esc_html( $primary_cta_label ); ?></a>
-					<div style="margin-top: 0.75rem;">
-						<a href="<?php echo esc_url( $request_url ); ?>" style="font-size: 0.85rem; text-decoration: underline;" data-track-action="cta_home_models_request" data-track-category="lead_gen"><?php echo esc_html( $secondary_cta_label ); ?></a>
-					</div>
+				<div class="homepage-problem-frame__cta text-center cro-reveal">
+					<a href="<?php echo esc_url( $diagnose_anchor ); ?>" class="nx-btn nx-btn--primary" data-track-action="cta_home_models_diagnose" data-track-category="lead_gen"><?php echo esc_html( $primary_cta_label ); ?></a>
 				</div>
 			</div>
 		</section>
 
-		<!-- Task 7: System-Sektion ersetzen (3-Schritt-Prozess) -->
-		<section id="system" class="wp-section homepage-system-teaser" data-track-section="homepage_system">
+		<!-- ============== SYSTEM TIMELINE ============== -->
+		<section id="system" class="cro-system" data-track-section="homepage_system">
 			<div class="wp-container wp-home-shell">
-				<div class="wp-section-title wp-home-section-title text-center">
+				<div class="cro-system__head cro-reveal">
 					<span class="wp-badge">System</span>
 					<h2 class="wp-section-h2">Der 3-Schritt-Prozess</h2>
 				</div>
 
-				<div class="homepage-system-teaser__card" style="display: grid; gap: 2rem; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));">
-					<div class="system-step">
-						<h3 style="font-size: 1.25rem; margin-bottom: 0.5rem;">1. Fundament ordnen</h3>
-						<p>Tracking &amp; Datenebene aufsetzen.</p>
-					</div>
-					<div class="system-step">
-						<h3 style="font-size: 1.25rem; margin-bottom: 0.5rem;">2. Conversion-Pfade schärfen</h3>
-						<p>Formular, Call, Buchung optimieren.</p>
-					</div>
-					<div class="system-step">
-						<h3 style="font-size: 1.25rem; margin-bottom: 0.5rem;">3. Skalieren</h3>
-						<p>Money Pages, Proof und Unabhängigkeit aufbauen.</p>
-					</div>
+				<div class="cro-timeline" role="list" aria-label="Drei aufeinander aufbauende Schritte">
+					<article class="cro-timeline__step cro-reveal" role="listitem">
+						<div class="cro-timeline__num" aria-hidden="true">1</div>
+						<h3 class="cro-timeline__title">Fundament ordnen</h3>
+						<p class="cro-timeline__text">Tracking und Datenebene aufsetzen. Quellen, Termine, CRM &mdash; sauber verknüpft.</p>
+					</article>
+					<article class="cro-timeline__step cro-reveal" role="listitem">
+						<div class="cro-timeline__num" aria-hidden="true">2</div>
+						<h3 class="cro-timeline__title">Conversion-Pfade schärfen</h3>
+						<p class="cro-timeline__text">Formular, Call und Buchung optimieren &mdash; aus Klicks werden qualifizierte Termine.</p>
+					</article>
+					<article class="cro-timeline__step cro-reveal" role="listitem">
+						<div class="cro-timeline__num" aria-hidden="true">3</div>
+						<h3 class="cro-timeline__title">Skalieren</h3>
+						<p class="cro-timeline__text">Money Pages, Proof und Unabhängigkeit aufbauen &mdash; Ads erst, wenn das Fundament steht.</p>
+					</article>
 				</div>
-				<div class="text-center" style="margin-top: 3rem;">
-					<a href="<?php echo esc_url( $request_url ); ?>" class="nx-btn nx-btn--primary" data-track-action="cta_home_system_diagnose" data-track-category="lead_gen"><?php echo esc_html( $primary_cta_label ); ?></a>
-					<div style="margin-top: 0.75rem;">
-						<a href="<?php echo esc_url( $request_url ); ?>" style="font-size: 0.85rem; text-decoration: underline;" data-track-action="cta_home_system_request" data-track-category="lead_gen"><?php echo esc_html( $secondary_cta_label ); ?></a>
-					</div>
+
+				<div class="cro-system__footer cro-reveal">
+					<a href="<?php echo esc_url( $diagnose_anchor ); ?>" class="nx-btn nx-btn--primary" data-track-action="cta_home_system_diagnose" data-track-category="lead_gen"><?php echo esc_html( $primary_cta_label ); ?></a>
 				</div>
 			</div>
 		</section>
 
-		<!-- Task 6 & 8: Drei Prüffragen + Trust-Elemente -->
-		<section id="prueffragen" class="wp-section homepage-prueffragen" style="background: var(--nx-bg-glass-light, rgba(255, 255, 255, 0.02)); padding: 4rem 0; border-top: 1px solid var(--nx-border, rgba(255, 255, 255, 0.05)); border-bottom: 1px solid var(--nx-border, rgba(255, 255, 255, 0.05));">
+		<!-- ============== INTERACTIVE DIAGNOSE (Self-Check) ============== -->
+		<section id="diagnose" class="cro-diagnose" data-track-section="homepage_diagnose">
 			<div class="wp-container wp-home-shell">
-				<div style="display: flex; flex-wrap: wrap; gap: 3rem; align-items: center;">
-					<div style="flex: 1; min-width: 300px;">
-						<h2 class="wp-section-h2" style="margin-bottom: 2rem;">Drei Fragen, die klären, ob Sie ein System besitzen oder mieten.</h2>
-						<ol style="font-size: 1.1rem; line-height: 1.6; margin-bottom: 2rem; padding-left: 1.5rem;">
-							<li style="margin-bottom: 1rem;">Wem gehört der Code Ihrer Landingpage?</li>
-							<li style="margin-bottom: 1rem;">Wem gehört das CRM, in dem Ihre Leads liegen?</li>
-							<li style="margin-bottom: 1rem;">Wem gehört der Tracking-Account?</li>
-						</ol>
-						<p style="font-weight: 600; font-size: 1.1rem;">
-							Dreimal &bdquo;uns&ldquo;: Sie brauchen mich nicht.<br>
-							Dreimal &bdquo;der Agentur&ldquo;: Sie mieten ein System.
-						</p>
-					</div>
-					<div style="flex: 1; min-width: 300px; text-align: center;">
-						<img src="https://hasimuener.de/wp-content/uploads/2026/04/Hasim_Uener_Portrait.png" alt="Hasim Üner" style="width: 200px; height: 200px; border-radius: 50%; object-fit: cover; margin-bottom: 1.5rem; border: 2px solid var(--nx-border, rgba(255, 255, 255, 0.1)); box-shadow: var(--nx-shadow-md, 0 10px 30px rgba(0,0,0,0.5));">
-						<div style="text-align: left; max-width: 280px; margin: 0 auto; font-size: 0.95rem; line-height: 1.5; background: var(--nx-bg-glass-light, rgba(255, 255, 255, 0.05)); padding: 2rem; border-radius: 12px; border: 1px solid var(--nx-border, rgba(255, 255, 255, 0.1));">
-							<strong>Hasim Üner.</strong><br>
-							Experte für B2B-Leadgenerierung und Tracking.<br>
-							Baut Systeme, die unabhängig machen.
+				<div class="cro-diagnose__head cro-reveal">
+					<span class="wp-badge">System-Diagnose</span>
+					<h2 class="wp-section-h2">Drei Fragen. Eine ehrliche Diagnose.</h2>
+					<p class="cro-diagnose__sub">
+						Klären Sie in 60 Sekunden, ob Sie ein Lead-System <strong>besitzen</strong> oder <strong>mieten</strong>.
+					</p>
+				</div>
+
+				<div class="cro-diagnose__quiz cro-reveal" data-cro-diagnose>
+
+					<div class="cro-diagnose__question">
+						<span class="cro-diagnose__q-label">
+							<span class="cro-diagnose__q-num">1.</span>Wem gehört der Code Ihrer Landingpage?
+						</span>
+						<div class="cro-diagnose__answers" role="radiogroup" aria-label="Frage 1">
+							<button type="button" class="cro-diagnose__answer" data-question="q1" data-value="good">Uns &mdash; eigener Code</button>
+							<button type="button" class="cro-diagnose__answer" data-question="q1" data-value="bad">Der Agentur / Plattform</button>
 						</div>
 					</div>
+
+					<div class="cro-diagnose__question">
+						<span class="cro-diagnose__q-label">
+							<span class="cro-diagnose__q-num">2.</span>Wem gehört das CRM, in dem Ihre Leads liegen?
+						</span>
+						<div class="cro-diagnose__answers" role="radiogroup" aria-label="Frage 2">
+							<button type="button" class="cro-diagnose__answer" data-question="q2" data-value="good">Uns &mdash; eigener Account</button>
+							<button type="button" class="cro-diagnose__answer" data-question="q2" data-value="bad">Der Agentur / Portal</button>
+						</div>
+					</div>
+
+					<div class="cro-diagnose__question">
+						<span class="cro-diagnose__q-label">
+							<span class="cro-diagnose__q-num">3.</span>Wem gehört der Tracking-Account?
+						</span>
+						<div class="cro-diagnose__answers" role="radiogroup" aria-label="Frage 3">
+							<button type="button" class="cro-diagnose__answer" data-question="q3" data-value="good">Uns &mdash; eigener Account</button>
+							<button type="button" class="cro-diagnose__answer" data-question="q3" data-value="bad">Der Agentur / Plattform</button>
+						</div>
+					</div>
+
+					<div class="cro-diagnose__result" data-cro-diagnose-result aria-live="polite">
+						<p class="cro-diagnose__result-title" data-cro-diagnose-result-title>Beantworten Sie alle drei Fragen.</p>
+						<p data-cro-diagnose-result-text>Sie erhalten in 60 Sekunden eine ehrliche Diagnose, ob Sie ein System besitzen oder eines mieten.</p>
+						<a href="<?php echo esc_url( $request_url ); ?>" class="nx-btn nx-btn--primary cro-diagnose__result-cta" data-cro-diagnose-result-cta data-track-action="cta_home_diagnose_request" data-track-category="lead_gen"><?php echo esc_html( $secondary_cta_label ); ?></a>
+					</div>
 				</div>
 			</div>
 		</section>
 
+		<!-- ============== TRUST STRIP ============== -->
+		<section class="cro-trust-strip" aria-label="Vertrauen">
+			<div class="wp-container wp-home-shell">
+				<div class="cro-trust-strip__inner">
+					<span class="cro-trust-strip__item"><span class="cro-trust-strip__icon" aria-hidden="true">✓</span>9 Monate Referenz mit E3 New Energy</span>
+					<span class="cro-trust-strip__item"><span class="cro-trust-strip__icon" aria-hidden="true">✓</span>Privacy-first Tracking-Setup</span>
+					<span class="cro-trust-strip__item"><span class="cro-trust-strip__icon" aria-hidden="true">✓</span>Eigene Assets &mdash; keine Mietmodelle</span>
+					<span class="cro-trust-strip__item"><span class="cro-trust-strip__icon" aria-hidden="true">✓</span>Hannover &middot; remote</span>
+				</div>
+			</div>
+		</section>
+
+		<!-- ============== FAQ ============== -->
 		<section id="faq" class="homepage-faq-section homepage-faq-section--home" aria-labelledby="faq-heading">
 			<div class="nx-container wp-home-shell">
-				<div class="wp-home-section-title text-center">
+				<div class="wp-home-section-title text-center cro-reveal">
 					<span class="nx-badge nx-badge--gold">FAQ</span>
 					<h2 id="faq-heading" class="wp-section-h2">Häufige Fragen</h2>
 				</div>
-				<div class="nx-faq">
+				<div class="nx-faq cro-reveal">
 					<?php foreach ( $faq_items as $index => $item ) : ?>
 						<details class="nx-faq__item"<?php echo 0 === $index ? ' open' : ''; ?>>
 							<summary><?php echo esc_html( $item['question'] ); ?></summary>
@@ -261,27 +326,53 @@ get_header();
 			</div>
 		</section>
 
-		<section id="cta" class="wp-section homepage-conversion-cta" data-track-section="homepage_cta">
+		<!-- ============== FINAL CTA ============== -->
+		<section id="cta" class="cro-final" data-track-section="homepage_cta">
 			<div class="wp-container wp-home-shell">
-				<div class="nx-cta-box homepage-conversion-cta__box text-center">
+				<div class="cro-final__box cro-reveal">
 					<span class="nx-badge nx-badge--gold">Nächster Schritt</span>
-					<h2>Direkt anfragen.</h2>
-					<p class="homepage-conversion-cta__lead" style="margin-bottom: 1rem;">Gehen Sie direkt ins qualifizierte Formular.</p>
-					
-					<!-- Task 9: Verknappung -->
-					<p style="font-weight: 600; margin-bottom: 2rem; color: var(--nx-text-muted);">Aktuell <?php echo esc_html( $slots_booked ); ?> von 4 Slots in Q2 2026 vergeben.</p>
+					<h2 class="cro-final__title">Direkt anfragen.</h2>
+					<p class="cro-final__lead">Gehen Sie direkt ins qualifizierte Formular &mdash; oder starten Sie zuerst die System-Diagnose.</p>
 
-					<div class="homepage-track-record__actions">
-						<a class="nx-btn nx-btn--primary homepage-conversion-cta__button" href="<?php echo esc_url( $request_url ); ?>" data-track-action="cta_home_final_diagnose" data-track-category="lead_gen"><?php echo esc_html( $primary_cta_label ); ?></a>
-						<div style="margin-top: 0.75rem;">
-							<a href="<?php echo esc_url( $request_url ); ?>" style="font-size: 0.85rem; text-decoration: underline;" data-track-action="cta_home_final_request" data-track-category="lead_gen"><?php echo esc_html( $secondary_cta_label ); ?></a>
+					<div class="cro-slot-bar" aria-label="Slot-Verfügbarkeit Q2 2026">
+						<div class="cro-slot-bar__label">
+							<span>Q2 2026 Slots</span>
+							<span><span class="cro-slot-bar__count"><?php echo esc_html( $slots_booked ); ?></span> von <?php echo esc_html( $slots_total ); ?> vergeben</span>
+						</div>
+						<div class="cro-slot-bar__track" aria-hidden="true">
+							<?php for ( $i = 1; $i <= $slots_total; $i++ ) : ?>
+								<span class="cro-slot-bar__seg<?php echo $i <= $slots_booked ? ' is-booked' : ''; ?>"></span>
+							<?php endfor; ?>
 						</div>
 					</div>
+
+					<div class="cro-final__cta-row">
+						<a class="nx-btn nx-btn--primary" href="<?php echo esc_url( $request_url ); ?>" data-track-action="cta_home_final_request" data-track-category="lead_gen">Anfrage stellen</a>
+						<a href="<?php echo esc_url( $diagnose_anchor ); ?>" class="cro-hero__cta-secondary" data-track-action="cta_home_final_diagnose" data-track-category="lead_gen">Erst System-Diagnose machen</a>
+					</div>
+
+					<p class="cro-final__risk-reversal">
+						<span>Kostenlos</span>
+						<span>60 Sek.</span>
+						<span>Keine Verkaufsmasche</span>
+					</p>
 				</div>
 			</div>
 		</section>
-	</div>
+
+	</div><!-- .cs-page -->
 </main>
+
+<!-- ============== STICKY MOBILE CTA ============== -->
+<div class="cro-sticky-cta" aria-hidden="false">
+	<div class="cro-sticky-cta__inner">
+		<div class="cro-sticky-cta__copy">
+			Direkt anfragen?
+			<small><?php echo esc_html( $slots_booked ); ?>/<?php echo esc_html( $slots_total ); ?> Slots vergeben</small>
+		</div>
+		<a href="<?php echo esc_url( $request_url ); ?>" class="nx-btn nx-btn--primary cro-sticky-cta__btn" data-track-action="cta_home_sticky_request" data-track-category="lead_gen">Anfragen</a>
+	</div>
+</div>
 
 <?php
 get_footer();

--- a/blocksy-child/inc/enqueue.php
+++ b/blocksy-child/inc/enqueue.php
@@ -128,7 +128,9 @@ function hu_enqueue_assets() {
 	// ── A) Startseite (homepage.css nur auf Front, nicht Blog-Index) ──
 	if ( is_front_page() ) {
 		hu_enqueue_css( 'nexus-home-css', 'homepage.css', [ 'nexus-design-system' ] );
+		hu_enqueue_css( 'nexus-home-cro-css', 'homepage-cro.css', [ 'nexus-home-css' ] );
 		hu_enqueue_js( 'nexus-home-js', 'homepage.js', [ 'nexus-core-js' ] );
+		hu_enqueue_js( 'nexus-home-cro-js', 'homepage-cro.js', [ 'nexus-home-js' ] );
 		hu_enqueue_js( 'nexus-home-mindmap-teaser-js', 'homepage-mindmap-teaser.js', [ 'nexus-home-js' ] );
 		wp_localize_script(
 			'nexus-home-mindmap-teaser-js',


### PR DESCRIPTION
…agnose)

- Hero: KPI ribbon (1.750+/12%/-83%), split CTA hierarchy (primary -> #diagnose, secondary -> direct request), trust bar
- Pain reframed as cost-of-inaction cards with euro damage, red top accents, hover lift
- Proof: before/after split (Portal-Lead-Welt vs. nach 9 Monaten)
  + animated counter KPIs via IntersectionObserver
- Modell A/B: red/green verdict pills + cost line as classes
- System: 3-step timeline with connecting gradient line + numbered medallions
- Diagnose: 3-question interactive self-check with three result variants (besitzen / eine Lücke / mieten) and contextual CTA
- Trust strip + final CTA box with 4-segment slot bar visual and risk-reversal microcopy (Kostenlos · 60 Sek. · Keine Verkaufsmasche)
- Sticky mobile CTA: appears after hero leaves viewport, hides over final
- All inline styles moved to dedicated homepage-cro.css
- Reveal-on-scroll for every section; respects prefers-reduced-motion