### PR TITLE
Editorial hero for /solar-waermepumpen-leadgenerierung/ (CRO v2)

### DIFF
--- a/blocksy-child/assets/css/energy-systems.css
+++ b/blocksy-child/assets/css/energy-systems.css
@@ -323,3 +323,427 @@
     font-size: 0.875rem;
   }
 }
+
+/* ══════════════════════════════════════════════════════════════
+   Editorial Hero (CRO v2) — solar-hero
+   Engineering-Editorial: Instrument Serif display + paper/ink
+   palette + animated system architecture preview.
+   Scoped to .solar-hero so .energy-hero (page-anfrage.php) is
+   untouched.
+   ══════════════════════════════════════════════════════════════ */
+.solar-hero {
+  --paper:        #f3efe5;
+  --ink:          #0c0d0e;
+  --ink-dark:     #14161a;
+  --ink-soft:     rgba(12, 13, 14, 0.66);
+  --ink-mute:     rgba(12, 13, 14, 0.46);
+  --rule:         rgba(12, 13, 14, 0.14);
+  --rule-strong:  rgba(12, 13, 14, 0.28);
+  --solar:        #f0b540;
+  --solar-deep:   #c97a1a;
+  --signal:       #4fb87a;
+  --serif:        "Instrument Serif", "Times New Roman", "Georgia", serif;
+  --mono:         ui-monospace, "SF Mono", "Cascadia Mono", "Roboto Mono", "Menlo", "Consolas", monospace;
+  --solar-gutter: clamp(20px, 4vw, 56px);
+  --solar-max:    1320px;
+
+  background: var(--paper);
+  color: var(--ink);
+  padding: clamp(48px, 6vw, 56px) 0 0;
+  position: relative;
+  isolation: isolate;
+}
+
+.solar-hero ::selection {
+  background: var(--solar);
+  color: var(--ink);
+}
+
+.solar-hero__inner {
+  max-width: var(--solar-max);
+  margin: 0 auto;
+  padding-left: var(--solar-gutter);
+  padding-right: var(--solar-gutter);
+}
+
+.solar-hero__eyebrow-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: clamp(28px, 5vw, 56px);
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.solar-hero__eyebrow {
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.solar-hero__eyebrow::before {
+  content: "";
+  width: 22px;
+  height: 1px;
+  background: currentColor;
+  opacity: 0.5;
+}
+
+.solar-hero__meta {
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+}
+
+.solar-hero__headline {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: clamp(40px, 8.4vw, 124px);
+  line-height: 0.95;
+  letter-spacing: -0.025em;
+  margin: 0 0 clamp(24px, 3vw, 36px);
+  color: var(--ink);
+  text-wrap: balance;
+}
+
+.solar-hero__headline em {
+  font-style: italic;
+  font-family: var(--serif);
+  color: var(--solar-deep);
+}
+
+.solar-hero__nowrap {
+  white-space: nowrap;
+}
+
+.solar-hero__grid {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 48px;
+  align-items: end;
+  margin-bottom: clamp(40px, 6vw, 64px);
+}
+
+.solar-hero__lede {
+  font-size: clamp(18px, 1.4vw, 22px);
+  line-height: 1.5;
+  color: var(--ink-soft);
+  max-width: 52ch;
+  margin: 0;
+}
+
+.solar-hero__cta-row {
+  display: flex;
+  gap: 12px;
+  margin-top: 32px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.solar-hero__btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 22px;
+  border: 1px solid var(--ink);
+  background: var(--ink);
+  color: var(--paper);
+  font-weight: 500;
+  font-size: 15px;
+  letter-spacing: 0.005em;
+  border-radius: 999px;
+  text-decoration: none;
+  transition: transform 0.2s ease, background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.solar-hero__btn:hover,
+.solar-hero__btn:focus-visible {
+  transform: translateY(-1px);
+  background: var(--ink-dark);
+  color: var(--paper);
+}
+
+.solar-hero__btn--ghost {
+  background: transparent;
+  color: var(--ink);
+  border-color: var(--rule-strong);
+}
+
+.solar-hero__btn--ghost:hover,
+.solar-hero__btn--ghost:focus-visible {
+  background: var(--ink);
+  color: var(--paper);
+  border-color: var(--ink);
+}
+
+.solar-hero__btn-arrow {
+  width: 18px;
+  height: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.2s ease;
+}
+
+.solar-hero__btn:hover .solar-hero__btn-arrow,
+.solar-hero__btn:focus-visible .solar-hero__btn-arrow {
+  transform: translateX(2px);
+}
+
+.solar-hero__btn-arrow svg {
+  width: 100%;
+  height: 100%;
+}
+
+.solar-hero__micro {
+  margin: 18px 0 0;
+  font-size: 13px;
+  color: var(--ink-mute);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.solar-hero__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--signal);
+  display: inline-block;
+  flex: 0 0 auto;
+}
+
+.solar-hero__dot--signal {
+  background: var(--signal);
+}
+
+/* ── Architecture Preview ──────────────────────────────────── */
+.solar-arch {
+  border: 1px solid var(--rule-strong);
+  background: rgba(255, 255, 255, 0.5);
+  padding: 20px 22px;
+  border-radius: 4px;
+  position: relative;
+}
+
+.solar-arch__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 14px;
+}
+
+.solar-arch__label {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+}
+
+.solar-arch__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--signal);
+}
+
+.solar-arch__rows {
+  display: flex;
+  flex-direction: column;
+}
+
+.solar-arch__row {
+  display: grid;
+  grid-template-columns: 32px 1fr auto;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 0;
+  border-top: 1px dashed var(--rule);
+  opacity: 0.55;
+  transition: opacity 0.4s ease;
+}
+
+.solar-arch__row:first-child {
+  border-top: 0;
+}
+
+.solar-arch__row.is-active {
+  opacity: 1;
+}
+
+.solar-arch__num {
+  font-family: var(--mono);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: var(--ink-mute);
+  font-variant-numeric: tabular-nums;
+}
+
+.solar-arch__row.is-active .solar-arch__num {
+  color: var(--solar-deep);
+}
+
+.solar-arch__name {
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.solar-arch__note {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  color: var(--ink-mute);
+}
+
+.solar-arch__foot {
+  margin-top: 14px;
+  padding-top: 12px;
+  border-top: 1px solid var(--rule);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.solar-arch__cpl {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: 22px;
+  letter-spacing: -0.02em;
+  line-height: 0.9;
+  color: var(--ink);
+  font-feature-settings: "lnum";
+}
+
+.solar-arch__cpl span {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--ink-mute);
+  margin-left: 6px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+/* ── Hairline + Proof Bar ──────────────────────────────────── */
+.solar-hero__hairline {
+  height: 1px;
+  background: var(--rule);
+}
+
+.solar-proof {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  padding: 32px 0 56px;
+}
+
+.solar-proof__cell {
+  padding: 8px 24px 8px 0;
+  border-right: 1px solid var(--rule);
+}
+
+.solar-proof__cell:last-child {
+  border-right: 0;
+}
+
+.solar-proof__num {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: clamp(34px, 4vw, 56px);
+  line-height: 0.9;
+  letter-spacing: -0.02em;
+  color: var(--ink);
+  margin-bottom: 8px;
+  font-feature-settings: "lnum";
+}
+
+.solar-proof__lbl {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  margin-bottom: 4px;
+}
+
+.solar-proof__sub {
+  font-size: 13px;
+  color: var(--ink-soft);
+  line-height: 1.4;
+}
+
+/* ── Responsive ────────────────────────────────────────────── */
+@media (max-width: 900px) {
+  .solar-hero__grid {
+    grid-template-columns: 1fr;
+    gap: 36px;
+    align-items: stretch;
+  }
+}
+
+@media (max-width: 820px) {
+  .solar-proof {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 24px;
+    padding: 28px 0 48px;
+  }
+
+  .solar-proof__cell {
+    padding: 8px 16px 8px 0;
+  }
+
+  .solar-proof__cell:nth-child(2) {
+    border-right: 0;
+  }
+
+  .solar-hero__meta {
+    display: none;
+  }
+}
+
+@media (max-width: 520px) {
+  .solar-hero__eyebrow-row {
+    margin-bottom: 28px;
+  }
+
+  .solar-proof {
+    grid-template-columns: 1fr;
+    gap: 0;
+    padding: 24px 0 40px;
+  }
+
+  .solar-proof__cell {
+    padding: 16px 0;
+    border-right: 0;
+    border-bottom: 1px solid var(--rule);
+  }
+
+  .solar-proof__cell:last-child {
+    border-bottom: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .solar-hero__btn,
+  .solar-hero__btn-arrow,
+  .solar-arch__row {
+    transition: none;
+  }
+}

--- a/blocksy-child/assets/js/solar-hero.js
+++ b/blocksy-child/assets/js/solar-hero.js
@@ -1,0 +1,78 @@
+/**
+ * /solar-waermepumpen-leadgenerierung/
+ * Architecture preview — rotates the active step every 1.8s.
+ * Pauses when off-screen, respects prefers-reduced-motion.
+ */
+(function () {
+  'use strict';
+
+  var ROTATE_MS = 1800;
+  var ACTIVE_CLASS = 'is-active';
+
+  function init() {
+    var container = document.querySelector('[data-solar-arch-rows]');
+    if (!container) return;
+
+    var rows = Array.prototype.slice.call(
+      container.querySelectorAll('.solar-arch__row')
+    );
+    if (rows.length < 2) return;
+
+    var reduceMotion = window.matchMedia
+      && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if (reduceMotion) return;
+
+    var active = 0;
+    rows.forEach(function (row, i) {
+      row.classList.toggle(ACTIVE_CLASS, i === 0);
+    });
+
+    var timer = null;
+
+    function tick() {
+      rows[active].classList.remove(ACTIVE_CLASS);
+      active = (active + 1) % rows.length;
+      rows[active].classList.add(ACTIVE_CLASS);
+    }
+
+    function start() {
+      if (timer) return;
+      timer = window.setInterval(tick, ROTATE_MS);
+    }
+
+    function stop() {
+      if (!timer) return;
+      window.clearInterval(timer);
+      timer = null;
+    }
+
+    if ('IntersectionObserver' in window) {
+      var io = new IntersectionObserver(function (entries) {
+        entries.forEach(function (entry) {
+          if (entry.isIntersecting) {
+            start();
+          } else {
+            stop();
+          }
+        });
+      }, { threshold: 0.2 });
+      io.observe(container);
+    } else {
+      start();
+    }
+
+    document.addEventListener('visibilitychange', function () {
+      if (document.hidden) {
+        stop();
+      } else {
+        start();
+      }
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/blocksy-child/inc/enqueue.php
+++ b/blocksy-child/inc/enqueue.php
@@ -230,6 +230,7 @@ function hu_enqueue_assets() {
 	if ( is_page( 'solar-waermepumpen-leadgenerierung' ) || is_page( 'website-fuer-solar-und-waermepumpen-anbieter' ) || is_page_template( 'page-solar-waermepumpen-leadgenerierung.php' ) || is_page_template( 'page-website-fuer-solar-und-waermepumpen-anbieter.php' ) ) {
 		hu_enqueue_css( 'nexus-review-funnel-css', 'review-funnel.css', [ 'nexus-design-system' ] );
 		hu_enqueue_css( 'nexus-energy-systems-css', 'energy-systems.css', [ 'nexus-review-funnel-css' ] );
+		hu_enqueue_js( 'nexus-solar-hero-js', 'solar-hero.js', [ 'nexus-core-js' ] );
 	}
 
 	// ── G) Template: WGOS System ──────────────────────────────────

--- a/blocksy-child/page-solar-waermepumpen-leadgenerierung.php
+++ b/blocksy-child/page-solar-waermepumpen-leadgenerierung.php
@@ -116,19 +116,120 @@ foreach ( $faq_items as $faq_item ) {
 	];
 }
 
+$arch_steps = [
+	[ 'n' => '01', 'lbl' => 'Landing',        'note' => 'Google → WordPress' ],
+	[ 'n' => '02', 'lbl' => 'Qualifizierung', 'note' => '60s-Funnel · React' ],
+	[ 'n' => '03', 'lbl' => 'Segmentierung',  'note' => 'n8n · Routing' ],
+	[ 'n' => '04', 'lbl' => 'Scoring',        'note' => 'Heiß / Warm / Kalt' ],
+	[ 'n' => '05', 'lbl' => 'Vertrieb',       'note' => 'Slack · CRM · 5 Min.' ],
+];
+
+add_action(
+	'wp_head',
+	static function () {
+		echo "<link rel=\"preconnect\" href=\"https://fonts.googleapis.com\">\n";
+		echo "<link rel=\"preconnect\" href=\"https://fonts.gstatic.com\" crossorigin>\n";
+		echo "<link rel=\"stylesheet\" href=\"https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&display=swap\">\n";
+	},
+	200
+);
+
 get_header();
 ?>
 <main id="main" class="site-main">
-	<div class="energy-page-wrapper" data-track-section="energy_service_landing">
+	<div class="energy-page-wrapper solar-page" data-track-section="energy_service_landing">
 
-		<section class="nx-section energy-hero" id="hero">
-			<div class="nx-container">
-				<h1 class="energy-hero__title">Ihre Website kann mehr als eine Broschüre. Sie kann Anfragen produzieren.</h1>
-				<p class="energy-hero__subtitle">Ich baue Solar- und Wärmepumpen-Betrieben ein eigenes Anfrage-System. Kein Portal. Keine gemieteten Leads. Keine Agentur-Abhängigkeit. Eine Infrastruktur, die Ihnen gehört und die Ihre Vertriebskosten senkt — messbar.</p>
-				<div class="energy-hero__actions">
-					<a href="<?php echo esc_url( $request_url ); ?>" class="nx-btn nx-btn--primary" data-track-action="cta_energy_hero" data-track-category="lead_gen">System prüfen</a>
+		<section class="nx-section solar-hero" id="hero">
+			<div class="solar-hero__inner">
+				<div class="solar-hero__eyebrow-row">
+					<span class="solar-hero__eyebrow">Für Solar- und Wärmepumpen-Betriebe · 10–25 Mitarbeiter</span>
+					<span class="solar-hero__meta">Hannover · DE · Q2 / 2026</span>
 				</div>
-				<p class="energy-hero__micro">8 Schritte. Lokales Ergebnis. Keine E-Mail im Default-Pfad.</p>
+
+				<h1 class="solar-hero__headline">
+					Hören Sie auf, <em>Anfragen zu mieten.</em><br />
+					Bauen Sie eine, <span class="solar-hero__nowrap">die <em>Ihnen gehört.</em></span>
+				</h1>
+
+				<div class="solar-hero__grid">
+					<div class="solar-hero__lede-col">
+						<p class="solar-hero__lede">
+							Portal-Leads kosten 80–150 €. Die Hälfte geht nicht ans Telefon.
+							Wir bauen Ihrem Betrieb stattdessen ein eigenes Anfrage-System &mdash;
+							mit WordPress-Infrastruktur, serverseitigem Tracking und Vorqualifizierung.
+							Das System gehört Ihnen. Die Anfragen sind exklusiv.
+						</p>
+
+						<div class="solar-hero__cta-row">
+							<a href="<?php echo esc_url( $request_url ); ?>" class="solar-hero__btn" data-track-action="cta_solar_hero_primary" data-track-category="lead_gen">
+								<span>Anfrage-System-Analyse starten</span>
+								<span class="solar-hero__btn-arrow" aria-hidden="true">
+									<svg viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false">
+										<path d="M3 9h12m0 0l-5-5m5 5l-5 5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+									</svg>
+								</span>
+							</a>
+							<a href="#proof" class="solar-hero__btn solar-hero__btn--ghost" data-track-action="cta_solar_hero_proof" data-track-category="trust">
+								E3-Ergebnis ansehen
+							</a>
+						</div>
+
+						<p class="solar-hero__micro">
+							<span class="solar-hero__dot" aria-hidden="true"></span>
+							8 Schritte · lokales Ergebnis · keine E-Mail im Default-Pfad
+						</p>
+					</div>
+
+					<aside class="solar-arch" aria-label="System-Architektur — Vorschau">
+						<div class="solar-arch__head">
+							<span class="solar-arch__label">System · Live</span>
+							<span class="solar-arch__status">
+								<span class="solar-hero__dot solar-hero__dot--signal" aria-hidden="true"></span>
+								Routing OK
+							</span>
+						</div>
+
+						<div class="solar-arch__rows" data-solar-arch-rows>
+							<?php foreach ( $arch_steps as $i => $step ) : ?>
+								<div class="solar-arch__row<?php echo 0 === $i ? ' is-active' : ''; ?>">
+									<span class="solar-arch__num"><?php echo esc_html( $step['n'] ); ?></span>
+									<span class="solar-arch__name"><?php echo esc_html( $step['lbl'] ); ?></span>
+									<span class="solar-arch__note"><?php echo esc_html( $step['note'] ); ?></span>
+								</div>
+							<?php endforeach; ?>
+						</div>
+
+						<div class="solar-arch__foot">
+							<span class="solar-arch__label">Ø 4 Min · Anfrage → Anruf</span>
+							<span class="solar-arch__cpl"><?php echo esc_html( $e3_cpl_after ); ?><span>CPL</span></span>
+						</div>
+					</aside>
+				</div>
+
+				<div class="solar-hero__hairline" role="presentation"></div>
+
+				<div class="solar-proof">
+					<div class="solar-proof__cell">
+						<div class="solar-proof__num"><?php echo esc_html( $e3_lead_count ); ?></div>
+						<div class="solar-proof__lbl">qualifizierte Anfragen</div>
+						<div class="solar-proof__sub">in <?php echo esc_html( $e3_timeframe_dative ); ?></div>
+					</div>
+					<div class="solar-proof__cell">
+						<div class="solar-proof__num"><?php echo esc_html( $e3_sales_conversion ); ?></div>
+						<div class="solar-proof__lbl">Abschlussquote</div>
+						<div class="solar-proof__sub">von Anfrage zu Vertrag</div>
+					</div>
+					<div class="solar-proof__cell">
+						<div class="solar-proof__num"><?php echo esc_html( $e3_cpl_reduction ); ?></div>
+						<div class="solar-proof__lbl">Kosten pro Anfrage</div>
+						<div class="solar-proof__sub"><?php echo esc_html( $e3_cpl_before ); ?> &rarr; <?php echo esc_html( $e3_cpl_after ); ?></div>
+					</div>
+					<div class="solar-proof__cell">
+						<div class="solar-proof__num">100&nbsp;%</div>
+						<div class="solar-proof__lbl">Eigentum am System</div>
+						<div class="solar-proof__sub">Code · Tracking · Daten</div>
+					</div>
+				</div>
 			</div>
 		</section>
 


### PR DESCRIPTION
Implements HeroVariantA from the Claude Design handoff bundle (solar-landinf-cro-seo): editorial Instrument-Serif headline with italic accent, two-column lede + animated system-architecture preview, and a four-cell proof bar pulling E3-canon metrics.

Scoped to .solar-hero so .energy-hero (page-anfrage.php) is unaffected. Architecture-preview rotation pauses off-screen and respects prefers-reduced-motion.

https://claude.ai/code/session_01Wmr5swjP5Nhn2t1FhJvELP