### PR TITLE
feat(solar-landing): SOLARA hybrid redesign · CTA to /system-diagnose/

### DIFF
--- a/blocksy-child/assets/css/solar-leadgenerierung-solara.css
+++ b/blocksy-child/assets/css/solar-leadgenerierung-solara.css
@@ -1,0 +1,1148 @@
+/* ══════════════════════════════════════════════════════════════
+   /solar-waermepumpen-leadgenerierung/ — SOLARA visual language
+   Premium · cinematic · minimalistisch mit AHA-Wirkung.
+   HYBRID-Theme: warm-cremes Grundtuch (B2B-Mittelstand-Vertrauen),
+   dunkle Sonne nur als zentrales Visual & Final-CTA-Anker.
+   Scope: alles unter .solara-landing.
+   Tokens: Satoshi · Figtree · JetBrains Mono · Copper #b46a3c.
+   ══════════════════════════════════════════════════════════════ */
+
+.solara-landing {
+  /* warm-cream Grundpalette (Mittelstand-credible) */
+  --sol-bg:       oklch(0.97 0.008 80);
+  --sol-bg-2:     oklch(0.95 0.010 78);
+  --sol-bg-3:     oklch(0.92 0.014 75);
+  --sol-bg-warm:  oklch(0.94 0.020 70);
+
+  --sol-line:     oklch(0.88 0.010 75);
+  --sol-line-2:   oklch(0.80 0.012 70);
+  --sol-line-3:   oklch(0.72 0.014 65);
+
+  --sol-fg:       oklch(0.18 0.012 60);
+  --sol-fg-mute:  oklch(0.42 0.014 60);
+  --sol-fg-dim:  oklch(0.58 0.014 60);
+
+  /* Copper-Akzent aus Hasim's Design-System */
+  --sol-accent:     #b46a3c;
+  --sol-accent-2:   #c97a1a;
+  --sol-accent-ink: #ffffff;
+  --sol-accent-tint:    rgba(180,106,60,.08);
+  --sol-accent-tint-2:  rgba(180,106,60,.18);
+
+  /* Status-Farben (semantisch) */
+  --sol-good:       oklch(0.52 0.16 145);
+  --sol-info:       oklch(0.48 0.14 230);
+
+  --sol-t-fast: 160ms;
+  --sol-t-med:  240ms;
+  --sol-gutter: clamp(20px, 4vw, 56px);
+  --sol-maxw:   1320px;
+  --sol-radius: 14px;
+
+  --sol-font-display: 'Satoshi', 'Figtree', -apple-system, BlinkMacSystemFont, sans-serif;
+  --sol-font-body:    'Figtree', -apple-system, BlinkMacSystemFont, sans-serif;
+  --sol-font-mono:    'JetBrains Mono', 'Fira Code', ui-monospace, monospace;
+
+  position: relative;
+  background: var(--sol-bg);
+  color: var(--sol-fg);
+  font-family: var(--sol-font-body);
+  line-height: 1.5;
+  overflow-x: hidden;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* sehr feines Raster — Engineering-Atmosphäre statt Dekor */
+.solara-landing::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1;
+  background-image:
+    linear-gradient(oklch(0.30 0.012 60 / 0.04) 1px, transparent 1px),
+    linear-gradient(90deg, oklch(0.30 0.012 60 / 0.04) 1px, transparent 1px);
+  background-size: 64px 64px;
+  opacity: 0.5;
+}
+
+.solara-landing * { box-sizing: border-box; }
+
+/* ── Layout-Basis ─────────────────────────────────────────── */
+.solara-landing .sol-wrap {
+  max-width: var(--sol-maxw);
+  margin: 0 auto;
+  padding-left: var(--sol-gutter);
+  padding-right: var(--sol-gutter);
+  position: relative;
+  z-index: 3;
+}
+.solara-landing .sol-section {
+  padding: clamp(80px, 11vw, 160px) 0;
+  position: relative;
+  z-index: 3;
+}
+.solara-landing .sol-section--tinted { background: var(--sol-bg-2); }
+.solara-landing .sol-section--warm   { background: var(--sol-bg-warm); }
+
+/* ── Typo ─────────────────────────────────────────────────── */
+.solara-landing .sol-display {
+  font-family: var(--sol-font-display);
+  font-weight: 600;
+  line-height: 0.95;
+  letter-spacing: -0.035em;
+  text-wrap: balance;
+  color: var(--sol-fg);
+}
+.solara-landing .sol-display em {
+  font-style: normal;
+  color: var(--sol-accent);
+}
+.solara-landing .sol-mono {
+  font-family: var(--sol-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--sol-fg-mute);
+}
+.solara-landing .sol-eyebrow {
+  font-family: var(--sol-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--sol-accent);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6em;
+}
+.solara-landing .sol-eyebrow::before {
+  content: "";
+  width: 18px;
+  height: 1px;
+  background: currentColor;
+  opacity: 0.6;
+}
+
+/* ── Buttons ──────────────────────────────────────────────── */
+.solara-landing .sol-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 14px 22px;
+  border-radius: 999px;
+  font-family: var(--sol-font-body);
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 1;
+  letter-spacing: 0.01em;
+  border: 1px solid transparent;
+  cursor: pointer;
+  text-decoration: none;
+  transition: transform var(--sol-t-fast), background var(--sol-t-fast), color var(--sol-t-fast), border-color var(--sol-t-fast), box-shadow var(--sol-t-fast);
+  white-space: nowrap;
+}
+.solara-landing .sol-btn-primary {
+  background: var(--sol-accent);
+  color: var(--sol-accent-ink);
+  box-shadow: 0 10px 24px -8px rgba(180,106,60,.45);
+}
+.solara-landing .sol-btn-primary:hover {
+  background: var(--sol-accent-2);
+  transform: translateY(-1px);
+  box-shadow: 0 14px 28px -8px rgba(201,122,26,.5);
+}
+.solara-landing .sol-btn-ghost {
+  background: transparent;
+  color: var(--sol-fg);
+  border-color: var(--sol-line-2);
+}
+.solara-landing .sol-btn-ghost:hover {
+  background: var(--sol-accent-tint);
+  border-color: var(--sol-accent);
+  color: var(--sol-accent);
+}
+.solara-landing .sol-btn-arrow {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: currentColor;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.solara-landing .sol-btn-primary .sol-btn-arrow {
+  background: rgba(255,255,255,.22);
+  color: var(--sol-accent-ink);
+}
+.solara-landing .sol-btn-arrow svg { width: 12px; height: 12px; }
+
+/* ── Selection & Focus ────────────────────────────────────── */
+.solara-landing ::selection { background: var(--sol-accent); color: var(--sol-accent-ink); }
+.solara-landing a:focus-visible,
+.solara-landing button:focus-visible {
+  outline: 2px solid var(--sol-accent);
+  outline-offset: 3px;
+  border-radius: 6px;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   HERO — warm-cremes Sonnenfeld (hybrid: helles AHA-Visual)
+   ══════════════════════════════════════════════════════════════ */
+.solara-landing .sol-hero {
+  position: relative;
+  isolation: isolate;
+  padding: clamp(40px, 6vw, 80px) 0 clamp(80px, 11vw, 140px);
+  overflow: hidden;
+  min-height: 86vh;
+}
+.solara-landing .sol-hero-sky {
+  position: absolute;
+  inset: 0;
+  z-index: -2;
+  pointer-events: none;
+  background:
+    radial-gradient(ellipse 70% 55% at 50% 110%, oklch(0.86 0.16 65 / 0.55), transparent 55%),
+    linear-gradient(180deg, oklch(0.97 0.008 80) 0%, oklch(0.95 0.020 72) 55%, oklch(0.91 0.060 60) 100%);
+}
+.solara-landing .sol-hero-sun {
+  position: absolute;
+  left: 50%;
+  bottom: -28%;
+  z-index: -1;
+  width: min(1100px, 110vw);
+  aspect-ratio: 1;
+  transform: translate(-50%, 0);
+  pointer-events: none;
+}
+.solara-landing .sol-hero-sun-disc {
+  position: absolute;
+  inset: 22%;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 50% 45%,
+      oklch(0.95 0.16 80) 0%,
+      oklch(0.85 0.18 65) 38%,
+      oklch(0.70 0.20 50) 70%,
+      transparent 100%);
+  filter: blur(2px);
+  animation: sol-pulse 7s ease-in-out infinite;
+  opacity: 0.85;
+}
+.solara-landing .sol-hero-sun-halo {
+  position: absolute;
+  inset: -8%;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(201,122,26,.22) 0%, transparent 60%);
+  filter: blur(28px);
+  animation: sol-pulse 9s ease-in-out infinite reverse;
+}
+.solara-landing .sol-hero-sun-rays {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  opacity: 0.18;
+  animation: sol-spin 240s linear infinite;
+}
+.solara-landing .sol-hero-sun-ray {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 1px;
+  height: 56%;
+  background: linear-gradient(0deg, transparent 0%, var(--sol-accent) 60%, transparent 100%);
+  transform-origin: center top;
+}
+.solara-landing .sol-hero-horizon {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 22%;
+  z-index: 0;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--sol-accent) 25%, var(--sol-accent) 75%, transparent);
+  opacity: 0.55;
+}
+
+@keyframes sol-pulse {
+  0%, 100% { transform: scale(1); opacity: 0.9; }
+  50%      { transform: scale(1.03); opacity: 1; }
+}
+@keyframes sol-spin { to { transform: rotate(360deg); } }
+@keyframes sol-pulse-dot { 50% { transform: scale(1.3); opacity: 0.6; } }
+
+.solara-landing .sol-hero-inner {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(420px, 0.9fr);
+  gap: clamp(32px, 5vw, 80px);
+  align-items: start;
+  padding-top: clamp(40px, 7vw, 90px);
+}
+.solara-landing .sol-hero-left {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(20px, 2.4vw, 32px);
+  padding-top: 12px;
+}
+.solara-landing .sol-hero-h1 {
+  font-size: clamp(44px, 7vw, 104px);
+  margin: 6px 0 0;
+}
+.solara-landing .sol-hero-sub {
+  margin: 0;
+  max-width: 52ch;
+  color: var(--sol-fg-mute);
+  font-size: clamp(16px, 1.25vw, 19px);
+  line-height: 1.55;
+}
+.solara-landing .sol-hero-metrics {
+  display: flex;
+  gap: clamp(20px, 3vw, 44px);
+  margin-top: 12px;
+  padding-top: 24px;
+  border-top: 1px solid var(--sol-line);
+}
+.solara-landing .sol-metric { display: flex; flex-direction: column; }
+.solara-landing .sol-metric-n {
+  font-family: var(--sol-font-display);
+  font-size: clamp(28px, 3.2vw, 44px);
+  color: var(--sol-fg);
+  font-weight: 600;
+  letter-spacing: -0.03em;
+  line-height: 1;
+}
+.solara-landing .sol-metric-l { margin-top: 6px; }
+.solara-landing .sol-hero-right { position: relative; z-index: 5; }
+
+@media (max-width: 960px) {
+  .solara-landing .sol-hero-inner { grid-template-columns: 1fr; }
+  .solara-landing .sol-hero-h1 { font-size: clamp(40px, 11vw, 72px); }
+  .solara-landing .sol-hero-metrics { flex-wrap: wrap; gap: 20px; }
+}
+
+/* ── Hero-CTA-Card ────────────────────────────────────────── */
+.solara-landing .sol-cta-card {
+  position: relative;
+  background: linear-gradient(180deg, rgba(255,255,255,.92), rgba(255,255,255,.78));
+  border: 1px solid var(--sol-line);
+  border-radius: 18px;
+  padding: clamp(24px, 2.4vw, 30px);
+  box-shadow:
+    0 1px 0 rgba(255,255,255,.7) inset,
+    0 32px 60px -16px rgba(180,106,60,.16),
+    0 0 0 1px oklch(0.30 0.012 60 / 0.04);
+  backdrop-filter: blur(20px) saturate(140%);
+  -webkit-backdrop-filter: blur(20px) saturate(140%);
+}
+.solara-landing .sol-cta-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  background: linear-gradient(135deg, rgba(255,170,90,.08), transparent 40%);
+}
+.solara-landing .sol-cta-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 18px;
+}
+.solara-landing .sol-cta-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border: 1px solid var(--sol-line);
+  border-radius: 999px;
+  background: rgba(255,255,255,.6);
+}
+.solara-landing .sol-cta-tag-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--sol-accent);
+  box-shadow: 0 0 0 4px rgba(180,106,60,.18);
+  animation: sol-pulse-dot 2s ease-in-out infinite;
+}
+.solara-landing .sol-cta-head-right {
+  color: var(--sol-accent);
+  font-weight: 600;
+}
+
+.solara-landing .sol-cta-title {
+  font-family: var(--sol-font-display);
+  font-size: clamp(22px, 2.4vw, 30px);
+  margin: 0 0 8px;
+  line-height: 1.15;
+  letter-spacing: -0.03em;
+  font-weight: 600;
+  color: var(--sol-fg);
+}
+.solara-landing .sol-cta-hint {
+  color: var(--sol-fg-mute);
+  margin: 0 0 22px;
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.solara-landing .sol-cta-list {
+  list-style: none;
+  margin: 0 0 22px;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.solara-landing .sol-cta-list li {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px 14px;
+  background: rgba(255,255,255,.55);
+  border: 1px solid var(--sol-line);
+  border-radius: 12px;
+  font-size: 14px;
+  line-height: 1.4;
+  transition: border-color var(--sol-t-fast), background var(--sol-t-fast);
+}
+.solara-landing .sol-cta-list li:hover {
+  border-color: var(--sol-accent);
+  background: rgba(255,255,255,.85);
+}
+.solara-landing .sol-cta-list-num {
+  color: var(--sol-accent);
+  font-family: var(--sol-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  flex-shrink: 0;
+  padding-top: 2px;
+  font-weight: 600;
+}
+.solara-landing .sol-cta-list-body { display: flex; flex-direction: column; gap: 2px; }
+.solara-landing .sol-cta-list-t { color: var(--sol-fg); font-weight: 500; }
+.solara-landing .sol-cta-list-s { color: var(--sol-fg-dim); font-size: 12px; }
+
+.solara-landing .sol-cta-submit {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 16px 22px;
+  border: 0;
+  border-radius: 999px;
+  background: var(--sol-accent);
+  color: var(--sol-accent-ink);
+  font: 600 15px/1 var(--sol-font-body);
+  text-decoration: none;
+  cursor: pointer;
+  transition: background var(--sol-t-fast), transform var(--sol-t-fast), box-shadow var(--sol-t-fast);
+  box-shadow: 0 12px 24px -10px rgba(180,106,60,.5);
+}
+.solara-landing .sol-cta-submit:hover {
+  background: var(--sol-accent-2);
+  transform: translateY(-1px);
+  box-shadow: 0 16px 30px -10px rgba(201,122,26,.55);
+}
+.solara-landing .sol-cta-submit-arrow {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: rgba(255,255,255,.22);
+  color: var(--sol-accent-ink);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.solara-landing .sol-cta-submit-arrow svg { width: 14px; height: 14px; }
+
+.solara-landing .sol-cta-fineprint {
+  color: var(--sol-fg-dim);
+  margin: 14px 0 0;
+  text-align: center;
+  font-size: 10.5px !important;
+  letter-spacing: 0.06em;
+  font-family: var(--sol-font-mono);
+  text-transform: uppercase;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   TRUST STRIP
+   ══════════════════════════════════════════════════════════════ */
+.solara-landing .sol-trust {
+  padding: 28px 0;
+  border-top: 1px solid var(--sol-line);
+  border-bottom: 1px solid var(--sol-line);
+  background: var(--sol-bg-2);
+  position: relative;
+  z-index: 3;
+}
+.solara-landing .sol-trust-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 32px;
+  row-gap: 12px;
+  align-items: center;
+  justify-content: space-between;
+}
+.solara-landing .sol-trust-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--sol-fg-mute);
+  font-size: 10.5px !important;
+}
+.solara-landing .sol-trust-dot {
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--sol-accent);
+}
+
+/* ══════════════════════════════════════════════════════════════
+   PROBLEM
+   ══════════════════════════════════════════════════════════════ */
+.solara-landing .sol-problem-h {
+  font-size: clamp(36px, 5.4vw, 84px);
+  max-width: 22ch;
+  margin: 18px 0 60px;
+}
+.solara-landing .sol-problem-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1px;
+  background: var(--sol-line);
+  border: 1px solid var(--sol-line);
+  border-radius: 16px;
+  overflow: hidden;
+}
+.solara-landing .sol-problem-card {
+  padding: clamp(28px, 3.6vw, 44px);
+  background: var(--sol-bg);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.solara-landing .sol-problem-card-n {
+  color: var(--sol-accent);
+  font-size: 12px;
+  font-family: var(--sol-font-mono);
+  letter-spacing: 0.08em;
+  font-weight: 600;
+}
+.solara-landing .sol-problem-card-t {
+  font-family: var(--sol-font-display);
+  font-size: clamp(22px, 2.2vw, 28px);
+  font-weight: 600;
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+  color: var(--sol-fg);
+}
+.solara-landing .sol-problem-card-s {
+  color: var(--sol-fg-mute);
+  margin: 0;
+  font-size: 15px;
+  line-height: 1.6;
+}
+@media (max-width: 880px) {
+  .solara-landing .sol-problem-grid { grid-template-columns: 1fr; }
+}
+
+/* ══════════════════════════════════════════════════════════════
+   METHOD / SYSTEM
+   ══════════════════════════════════════════════════════════════ */
+.solara-landing .sol-method {
+  background: var(--sol-bg-2);
+  border-top: 1px solid var(--sol-line);
+  border-bottom: 1px solid var(--sol-line);
+}
+.solara-landing .sol-method-head {
+  max-width: 800px;
+  margin-bottom: clamp(48px, 6vw, 80px);
+}
+.solara-landing .sol-method-h {
+  font-size: clamp(40px, 5.6vw, 88px);
+  margin: 18px 0 0;
+}
+.solara-landing .sol-method-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: clamp(16px, 2vw, 24px);
+}
+@media (max-width: 880px) {
+  .solara-landing .sol-method-grid { grid-template-columns: 1fr; }
+}
+.solara-landing .sol-method-card {
+  position: relative;
+  padding: clamp(28px, 3.4vw, 40px);
+  background: var(--sol-bg);
+  border: 1px solid var(--sol-line);
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  min-height: 340px;
+  transition: transform var(--sol-t-med), border-color var(--sol-t-med), box-shadow var(--sol-t-med);
+}
+.solara-landing .sol-method-card:hover {
+  transform: translateY(-4px);
+  border-color: var(--sol-accent);
+  box-shadow: 0 30px 60px -28px rgba(180,106,60,.22);
+}
+.solara-landing .sol-method-card-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+.solara-landing .sol-method-card-n {
+  font-family: var(--sol-font-display);
+  font-size: clamp(60px, 7vw, 96px);
+  color: var(--sol-accent);
+  line-height: 0.85;
+  margin-bottom: 24px;
+  letter-spacing: -0.04em;
+  font-weight: 600;
+}
+.solara-landing .sol-method-card-pill {
+  padding: 5px 10px;
+  border: 1px solid var(--sol-line);
+  border-radius: 999px;
+  color: var(--sol-fg-mute);
+  font-family: var(--sol-font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  background: var(--sol-bg-2);
+}
+.solara-landing .sol-method-card-t {
+  font-family: var(--sol-font-display);
+  font-size: clamp(22px, 2vw, 28px);
+  margin: 8px 0 12px;
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+  font-weight: 600;
+  color: var(--sol-fg);
+}
+.solara-landing .sol-method-card-s {
+  color: var(--sol-fg-mute);
+  margin: 0 0 22px;
+  font-size: 14.5px;
+  line-height: 1.6;
+}
+.solara-landing .sol-method-card-list {
+  list-style: none;
+  padding: 18px 0 0;
+  margin: auto 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  border-top: 1px solid var(--sol-line);
+}
+.solara-landing .sol-method-card-list li {
+  display: flex;
+  gap: 10px;
+  font-size: 13.5px;
+  color: var(--sol-fg-mute);
+  align-items: center;
+}
+.solara-landing .sol-method-tick {
+  color: var(--sol-accent);
+  font-family: var(--sol-font-mono);
+  font-weight: 600;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   RESULTS / DASHBOARD-MOCK
+   ══════════════════════════════════════════════════════════════ */
+.solara-landing .sol-results-inner {
+  display: grid;
+  grid-template-columns: 1fr 1.1fr;
+  gap: clamp(40px, 5vw, 80px);
+  align-items: center;
+}
+@media (max-width: 960px) {
+  .solara-landing .sol-results-inner { grid-template-columns: 1fr; }
+}
+.solara-landing .sol-results-h {
+  font-size: clamp(40px, 5.6vw, 84px);
+  margin: 14px 0 22px;
+}
+.solara-landing .sol-results-sub {
+  color: var(--sol-fg-mute);
+  font-size: 16px;
+  line-height: 1.6;
+  max-width: 46ch;
+  margin: 0 0 32px;
+}
+.solara-landing .sol-results-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.solara-landing .sol-results-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--sol-line);
+  font-size: 15px;
+  color: var(--sol-fg);
+}
+.solara-landing .sol-results-list-v {
+  color: var(--sol-accent);
+  font-weight: 600;
+}
+
+.solara-landing .sol-results-mock {
+  background: var(--sol-bg);
+  border: 1px solid var(--sol-line);
+  border-radius: var(--sol-radius);
+  overflow: hidden;
+  box-shadow: 0 30px 60px -28px rgba(180,106,60,.22), 0 0 0 1px oklch(0.30 0.012 60 / 0.03);
+}
+.solara-landing .sol-results-mock-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--sol-line);
+  background: var(--sol-bg-2);
+}
+.solara-landing .sol-results-mock-dots {
+  display: flex;
+  gap: 5px;
+}
+.solara-landing .sol-results-mock-dots span {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--sol-line-2);
+}
+.solara-landing .sol-results-mock-title { color: var(--sol-fg-mute); }
+.solara-landing .sol-results-mock-live {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--sol-good);
+}
+.solara-landing .sol-live-dot {
+  width: 6px;
+  height: 6px;
+  background: var(--sol-good);
+  border-radius: 50%;
+  animation: sol-pulse-dot 1.8s ease-in-out infinite;
+}
+.solara-landing .sol-results-mock-body {
+  padding: 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+}
+.solara-landing .sol-results-mock-row {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 14px;
+}
+.solara-landing .sol-results-mock-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 14px;
+  background: var(--sol-bg-2);
+  border: 1px solid var(--sol-line);
+  border-radius: 10px;
+}
+.solara-landing .sol-results-mock-big {
+  font-family: var(--sol-font-display);
+  font-size: clamp(26px, 2.8vw, 36px);
+  color: var(--sol-fg);
+  letter-spacing: -0.03em;
+  font-weight: 600;
+  line-height: 1;
+}
+.solara-landing .sol-results-mock-delta {
+  color: var(--sol-good);
+  font-size: 11px;
+  font-family: var(--sol-font-mono);
+  font-weight: 600;
+}
+.solara-landing .sol-results-mock-chart { position: relative; padding: 10px 0 0; }
+.solara-landing .sol-results-mock-axis {
+  display: flex;
+  justify-content: space-between;
+  color: var(--sol-fg-dim);
+  padding: 8px 4px 0;
+  font-size: 10px !important;
+  font-family: var(--sol-font-mono);
+}
+.solara-landing .sol-results-mock-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  background: var(--sol-line);
+  border: 1px solid var(--sol-line);
+  border-radius: 10px;
+  overflow: hidden;
+}
+.solara-landing .sol-results-mock-item {
+  display: grid;
+  grid-template-columns: auto 1fr auto auto;
+  gap: 14px;
+  align-items: center;
+  padding: 12px 14px;
+  background: var(--sol-bg);
+  font-size: 13px;
+}
+.solara-landing .sol-results-mock-tag {
+  font-family: var(--sol-font-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 3px 8px;
+  border-radius: 999px;
+  font-weight: 600;
+}
+.solara-landing .sol-results-mock-tag.is-new {
+  color: var(--sol-accent);
+  background: rgba(180,106,60,.1);
+  border: 1px solid rgba(180,106,60,.3);
+}
+.solara-landing .sol-results-mock-tag.is-call {
+  color: var(--sol-info);
+  background: oklch(0.48 0.14 230 / .1);
+  border: 1px solid oklch(0.48 0.14 230 / .3);
+}
+.solara-landing .sol-results-mock-tag.is-booked {
+  color: var(--sol-good);
+  background: oklch(0.52 0.16 145 / .1);
+  border: 1px solid oklch(0.52 0.16 145 / .3);
+}
+.solara-landing .sol-results-mock-prod {
+  color: var(--sol-fg-mute);
+  font-size: 11px;
+}
+.solara-landing .sol-results-mock-time {
+  color: var(--sol-fg-dim);
+  font-size: 11px;
+  font-family: var(--sol-font-mono);
+}
+
+/* ══════════════════════════════════════════════════════════════
+   GUARANTEE — warm-cremes Risiko-Umkehr
+   ══════════════════════════════════════════════════════════════ */
+.solara-landing .sol-guarantee {
+  position: relative;
+  overflow: hidden;
+  background: var(--sol-bg-warm);
+}
+.solara-landing .sol-guarantee-inner {
+  max-width: 880px;
+  margin: 0 auto;
+  text-align: center;
+  position: relative;
+}
+.solara-landing .sol-guarantee-glow {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 720px;
+  height: 720px;
+  background: radial-gradient(circle, rgba(201,122,26,.20) 0%, transparent 60%);
+  filter: blur(40px);
+  pointer-events: none;
+  z-index: -1;
+}
+.solara-landing .sol-guarantee-h {
+  font-size: clamp(44px, 6.8vw, 100px);
+  margin: 22px 0 24px;
+}
+.solara-landing .sol-guarantee-sub {
+  color: var(--sol-fg-mute);
+  font-size: clamp(16px, 1.3vw, 19px);
+  line-height: 1.55;
+  max-width: 56ch;
+  margin: 0 auto 50px;
+}
+.solara-landing .sol-guarantee-points {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: clamp(16px, 2vw, 28px);
+  text-align: left;
+}
+@media (max-width: 760px) {
+  .solara-landing .sol-guarantee-points { grid-template-columns: 1fr; }
+}
+.solara-landing .sol-guarantee-point {
+  display: flex;
+  gap: 14px;
+  align-items: flex-start;
+  padding: 24px;
+  border: 1px solid var(--sol-line);
+  border-radius: 14px;
+  background: var(--sol-bg);
+}
+.solara-landing .sol-guarantee-point-mark {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: rgba(180,106,60,.1);
+  color: var(--sol-accent);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(180,106,60,.3);
+  flex-shrink: 0;
+}
+.solara-landing .sol-guarantee-point-mark svg { width: 16px; height: 16px; }
+.solara-landing .sol-guarantee-point-t {
+  font-weight: 600;
+  font-size: 16px;
+  margin-bottom: 4px;
+  color: var(--sol-fg);
+}
+.solara-landing .sol-guarantee-point-s {
+  color: var(--sol-fg-mute);
+  font-size: 13.5px;
+  line-height: 1.6;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   FAQ
+   ══════════════════════════════════════════════════════════════ */
+.solara-landing .sol-faq {
+  border-top: 1px solid var(--sol-line);
+}
+.solara-landing .sol-faq-inner {
+  display: grid;
+  grid-template-columns: 1fr 1.4fr;
+  gap: clamp(40px, 6vw, 100px);
+  align-items: start;
+}
+@media (max-width: 960px) {
+  .solara-landing .sol-faq-inner { grid-template-columns: 1fr; }
+  .solara-landing .sol-faq-left { position: static; }
+}
+.solara-landing .sol-faq-left {
+  position: sticky;
+  top: 100px;
+}
+.solara-landing .sol-faq-h {
+  font-size: clamp(40px, 5.6vw, 80px);
+  margin: 14px 0 22px;
+}
+.solara-landing .sol-faq-sub {
+  color: var(--sol-fg-mute);
+  font-size: 15px;
+  line-height: 1.6;
+  max-width: 36ch;
+}
+.solara-landing .sol-faq-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+}
+.solara-landing .sol-faq-item { border-top: 1px solid var(--sol-line); }
+.solara-landing .sol-faq-item:last-child { border-bottom: 1px solid var(--sol-line); }
+.solara-landing .sol-faq-q {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--sol-fg);
+  display: flex;
+  align-items: center;
+  gap: 22px;
+  width: 100%;
+  text-align: left;
+  padding: 24px 0;
+  font: 500 clamp(16px, 1.5vw, 19px)/1.35 var(--sol-font-body);
+  cursor: pointer;
+}
+.solara-landing .sol-faq-q-n {
+  color: var(--sol-fg-dim);
+  flex-shrink: 0;
+  font-family: var(--sol-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  font-weight: 600;
+}
+.solara-landing .sol-faq-q-t { flex: 1; }
+.solara-landing .sol-faq-q-mark {
+  position: relative;
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+.solara-landing .sol-faq-q-mark span {
+  position: absolute;
+  background: var(--sol-fg-mute);
+  transition: transform var(--sol-t-fast), background var(--sol-t-fast);
+}
+.solara-landing .sol-faq-q-mark span:nth-child(1) {
+  left: 0;
+  right: 0;
+  top: 50%;
+  height: 1.5px;
+  transform: translateY(-50%);
+}
+.solara-landing .sol-faq-q-mark span:nth-child(2) {
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 1.5px;
+  transform: translateX(-50%);
+}
+.solara-landing .sol-faq-item.is-open .sol-faq-q-mark span:nth-child(2) {
+  transform: translateX(-50%) scaleY(0);
+}
+.solara-landing .sol-faq-item.is-open .sol-faq-q-mark span { background: var(--sol-accent); }
+.solara-landing .sol-faq-a-wrap {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 360ms cubic-bezier(.2,.7,.2,1);
+}
+.solara-landing .sol-faq-item.is-open .sol-faq-a-wrap { grid-template-rows: 1fr; }
+.solara-landing .sol-faq-a-wrap > .sol-faq-a {
+  overflow: hidden;
+  min-height: 0;
+}
+.solara-landing .sol-faq-a {
+  color: var(--sol-fg-mute);
+  font-size: 15px;
+  line-height: 1.65;
+  padding: 0 40px 24px calc(11px + 22px);
+  max-width: 60ch;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   FINAL CTA — warmes Sonnenfeld als Reim auf den Hero
+   ══════════════════════════════════════════════════════════════ */
+.solara-landing .sol-final {
+  position: relative;
+  overflow: hidden;
+  padding-bottom: 0;
+}
+.solara-landing .sol-final-inner {
+  position: relative;
+  padding: clamp(60px, 9vw, 140px) clamp(24px, 4vw, 64px);
+  text-align: center;
+  border: 1px solid var(--sol-line);
+  border-radius: 24px;
+  overflow: hidden;
+  background: linear-gradient(180deg, var(--sol-bg-warm) 0%, oklch(0.90 0.060 60) 100%);
+  isolation: isolate;
+}
+.solara-landing .sol-final-sun {
+  position: absolute;
+  left: 50%;
+  top: 120%;
+  transform: translateX(-50%);
+  width: 900px;
+  height: 900px;
+  z-index: -1;
+  pointer-events: none;
+}
+.solara-landing .sol-final-sun-disc {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: radial-gradient(circle at 50% 40%, oklch(0.92 0.16 80) 0%, oklch(0.78 0.18 55) 30%, transparent 60%);
+  filter: blur(2px);
+  animation: sol-pulse 7s ease-in-out infinite;
+}
+.solara-landing .sol-final-h {
+  font-size: clamp(44px, 7vw, 104px);
+  margin: 18px 0 22px;
+}
+.solara-landing .sol-final-sub {
+  color: var(--sol-fg-mute);
+  font-size: clamp(15px, 1.2vw, 17px);
+  margin: 0 0 36px;
+}
+.solara-landing .sol-final-btn {
+  padding: 18px 28px;
+  font-size: 16px;
+}
+.solara-landing .sol-final-btn .sol-btn-arrow {
+  width: 28px;
+  height: 28px;
+}
+.solara-landing .sol-final-btn .sol-btn-arrow svg {
+  width: 13px;
+  height: 13px;
+}
+.solara-landing .sol-final-micro {
+  margin-top: 24px;
+  color: var(--sol-fg-dim);
+  font-family: var(--sol-font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   STICKY MOBILE CTA
+   ══════════════════════════════════════════════════════════════ */
+.solara-landing .sol-sticky-cta { display: none; }
+@media (max-width: 760px) {
+  .solara-landing .sol-sticky-cta {
+    display: flex;
+    position: fixed;
+    left: 12px;
+    right: 12px;
+    bottom: 12px;
+    z-index: 50;
+    padding: 14px 18px;
+    border-radius: 999px;
+    background: var(--sol-accent);
+    color: var(--sol-accent-ink);
+    font: 600 15px/1 var(--sol-font-body);
+    text-decoration: none;
+    box-shadow: 0 12px 40px rgba(180,106,60,.35), 0 0 0 1px rgba(0,0,0,.05);
+    align-items: center;
+    justify-content: space-between;
+    opacity: 0;
+    transform: translateY(120%);
+    transition: opacity var(--sol-t-med), transform var(--sol-t-med);
+    pointer-events: none;
+  }
+  .solara-landing .sol-sticky-cta.is-visible {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+  }
+  .solara-landing .sol-sticky-cta-arrow {
+    display: inline-flex;
+    width: 26px;
+    height: 26px;
+    border-radius: 50%;
+    background: rgba(255,255,255,.22);
+    align-items: center;
+    justify-content: center;
+  }
+}
+
+/* ── prefers-reduced-motion ───────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .solara-landing .sol-hero-sun-disc,
+  .solara-landing .sol-hero-sun-halo,
+  .solara-landing .sol-hero-sun-rays,
+  .solara-landing .sol-final-sun-disc,
+  .solara-landing .sol-cta-tag-dot,
+  .solara-landing .sol-live-dot {
+    animation: none !important;
+  }
+}
+
+/* ── Theme-Title-Bar verbergen (Hero füllt H1 selbst) ────── */
+body.page-template-page-solar-waermepumpen-leadgenerierung .entry-header,
+body.page-template-page-solar-waermepumpen-leadgenerierung .ct-page-title,
+body.page-template-page-solar-waermepumpen-leadgenerierung-php .entry-header,
+body.page-template-page-solar-waermepumpen-leadgenerierung-php .ct-page-title {
+  display: none !important;
+}

--- a/blocksy-child/assets/js/solar-leadgenerierung-solara.js
+++ b/blocksy-child/assets/js/solar-leadgenerierung-solara.js
@@ -1,0 +1,107 @@
+/* solar-leadgenerierung-solara.js
+   - FAQ-Accordion (eine offen zur Zeit)
+   - Sticky Mobile-CTA (erscheint nach Hero)
+   - Sonnenstrahlen werden client-seitig gemountet (24 Rays)
+   Vanilla, ohne Dependencies. Touch- und Keyboard-freundlich. */
+(function () {
+  'use strict';
+
+  function ready(fn) {
+    if (document.readyState !== 'loading') { fn(); return; }
+    document.addEventListener('DOMContentLoaded', fn, { once: true });
+  }
+
+  function mountSunRays() {
+    var hosts = document.querySelectorAll('.solara-landing [data-sol-rays]');
+    if (!hosts.length) return;
+    hosts.forEach(function (host) {
+      if (host.dataset.solRaysMounted === '1') return;
+      var frag = document.createDocumentFragment();
+      for (var i = 0; i < 24; i++) {
+        var ray = document.createElement('span');
+        ray.className = 'sol-hero-sun-ray';
+        ray.style.transform = 'rotate(' + (i * 15) + 'deg)';
+        ray.setAttribute('aria-hidden', 'true');
+        frag.appendChild(ray);
+      }
+      host.appendChild(frag);
+      host.dataset.solRaysMounted = '1';
+    });
+  }
+
+  function setupFaq() {
+    var items = document.querySelectorAll('.solara-landing .sol-faq-item');
+    if (!items.length) return;
+
+    items.forEach(function (item) {
+      var btn = item.querySelector('.sol-faq-q');
+      var ans = item.querySelector('.sol-faq-a');
+      if (!btn || !ans) return;
+
+      var id = 'sol-faq-a-' + Math.random().toString(36).slice(2, 8);
+      ans.id = id;
+      btn.setAttribute('aria-controls', id);
+      btn.setAttribute('aria-expanded', item.classList.contains('is-open') ? 'true' : 'false');
+
+      btn.addEventListener('click', function () {
+        var isOpen = item.classList.contains('is-open');
+        // close all
+        items.forEach(function (other) {
+          other.classList.remove('is-open');
+          var otherBtn = other.querySelector('.sol-faq-q');
+          if (otherBtn) otherBtn.setAttribute('aria-expanded', 'false');
+        });
+        // open clicked if it was closed
+        if (!isOpen) {
+          item.classList.add('is-open');
+          btn.setAttribute('aria-expanded', 'true');
+        }
+      });
+    });
+  }
+
+  function setupStickyCta() {
+    var sticky = document.querySelector('.solara-landing .sol-sticky-cta');
+    var hero   = document.querySelector('.solara-landing .sol-hero');
+    if (!sticky || !hero) return;
+
+    if (!('IntersectionObserver' in window)) {
+      sticky.classList.add('is-visible');
+      return;
+    }
+    var io = new IntersectionObserver(function (entries) {
+      entries.forEach(function (entry) {
+        if (entry.isIntersecting) {
+          sticky.classList.remove('is-visible');
+        } else {
+          // only when hero is above viewport (we've scrolled past it)
+          if (entry.boundingClientRect.top < 0) {
+            sticky.classList.add('is-visible');
+          }
+        }
+      });
+    }, { threshold: 0 });
+    io.observe(hero);
+  }
+
+  function setupScrollAnchor() {
+    document.querySelectorAll('.solara-landing a[href^="#"]').forEach(function (a) {
+      a.addEventListener('click', function (e) {
+        var hash = a.getAttribute('href');
+        if (!hash || hash.length < 2) return;
+        var target = document.querySelector(hash);
+        if (!target) return;
+        e.preventDefault();
+        var top = target.getBoundingClientRect().top + window.scrollY - 20;
+        window.scrollTo({ top: top, behavior: 'smooth' });
+      });
+    });
+  }
+
+  ready(function () {
+    mountSunRays();
+    setupFaq();
+    setupStickyCta();
+    setupScrollAnchor();
+  });
+})();

--- a/blocksy-child/inc/enqueue.php
+++ b/blocksy-child/inc/enqueue.php
@@ -226,8 +226,17 @@ function hu_enqueue_assets() {
 		hu_enqueue_css( 'nexus-agentur-css', 'agentur.css', [ 'nexus-home-css' ] );
 	}
 
-	// ── F1) Template: Energy Systems Landing + E3 Methodik-Case ───
-	if ( is_page( 'solar-waermepumpen-leadgenerierung' ) || is_page( 'website-fuer-solar-und-waermepumpen-anbieter' ) || is_page( 'e3-new-energy' ) || is_page_template( 'page-solar-waermepumpen-leadgenerierung.php' ) || is_page_template( 'page-website-fuer-solar-und-waermepumpen-anbieter.php' ) || is_page_template( 'page-e3-new-energy.php' ) || is_page_template( 'page-case-e3.php' ) ) {
+	// ── F1a) Solar-/Wärmepumpen-Leadgenerierung (SOLARA Redesign) ──
+	// Eigene CSS/JS-Stack; legacy energy-systems / review-funnel werden hier
+	// bewusst NICHT geladen, weil das Template ein eigenes Visual-System hat
+	// und keinen In-Page-Funnel mehr enthält (CTA → /system-diagnose/).
+	if ( is_page( 'solar-waermepumpen-leadgenerierung' ) || is_page_template( 'page-solar-waermepumpen-leadgenerierung.php' ) ) {
+		hu_enqueue_css( 'nexus-solar-leadgen-solara-css', 'solar-leadgenerierung-solara.css', [ 'nexus-design-system' ] );
+		hu_enqueue_js( 'nexus-solar-leadgen-solara-js', 'solar-leadgenerierung-solara.js', [ 'nexus-core-js' ] );
+	}
+
+	// ── F1b) Schwester-Templates (E3-Case, Service-Landing) ────────
+	if ( is_page( 'website-fuer-solar-und-waermepumpen-anbieter' ) || is_page( 'e3-new-energy' ) || is_page_template( 'page-website-fuer-solar-und-waermepumpen-anbieter.php' ) || is_page_template( 'page-e3-new-energy.php' ) || is_page_template( 'page-case-e3.php' ) ) {
 		hu_enqueue_css( 'nexus-review-funnel-css', 'review-funnel.css', [ 'nexus-design-system' ] );
 		hu_enqueue_css( 'nexus-energy-systems-css', 'energy-systems.css', [ 'nexus-review-funnel-css' ] );
 		hu_enqueue_js( 'nexus-solar-hero-js', 'solar-hero.js', [ 'nexus-core-js' ] );

--- a/blocksy-child/page-solar-waermepumpen-leadgenerierung.php
+++ b/blocksy-child/page-solar-waermepumpen-leadgenerierung.php
@@ -1,8 +1,9 @@
 <?php
 /**
- * /solar-waermepumpen-leadgenerierung/
- *
- * Ingenieur-Ästhetik. Kein Dekor. Nur Argument.
+ * Template Name: Solar & Wärmepumpen Leadgenerierung (SOLARA)
+ * Description: Premium · cinematic · minimalistisch. Hybrid-Theme (warm-cream + Copper).
+ *              Primärer CTA: /system-diagnose/. Zielgruppe: Solar-/Wärmepumpen-Anbieter
+ *              im DACH-Mittelstand (10–25 MA).
  *
  * @package Blocksy_Child
  */
@@ -11,258 +12,112 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-$diagnostic_anchor = '#energie-anfrage';
-$page_url          = function_exists( 'nexus_get_energy_systems_url' ) ? nexus_get_energy_systems_url() : home_url( '/solar-waermepumpen-leadgenerierung/' );
-$e3_url            = home_url( '/e3-new-energy/' );
-$e3_canon          = function_exists( 'hu_e3_canon' ) ? hu_e3_canon() : [];
-$e3_metrics        = isset( $e3_canon['metrics'] ) && is_array( $e3_canon['metrics'] ) ? $e3_canon['metrics'] : [];
+// ── URLs ───────────────────────────────────────────────────────
+$page_url     = function_exists( 'nexus_get_energy_systems_url' ) ? nexus_get_energy_systems_url() : home_url( '/solar-waermepumpen-leadgenerierung/' );
+$diagnose_url = function_exists( 'hu_get_request_analysis_url' ) ? hu_get_request_analysis_url() : home_url( '/system-diagnose/' );
+$e3_url       = home_url( '/e3-new-energy/' );
 
+// ── E3-Proof-Metriken (Canon) ───────────────────────────────────
+$e3_canon            = function_exists( 'hu_e3_canon' ) ? hu_e3_canon() : [];
+$e3_metrics          = isset( $e3_canon['metrics'] ) && is_array( $e3_canon['metrics'] ) ? $e3_canon['metrics'] : [];
 $e3_case_label       = isset( $e3_canon['case_label'] ) ? (string) $e3_canon['case_label'] : 'E3 New Energy';
 $e3_lead_count       = $e3_metrics['lead_count']['display'] ?? '1.750+';
 $e3_sales_conversion = $e3_metrics['sales_conversion']['display'] ?? '12 %';
-$e3_cpl_reduction    = $e3_metrics['cpl_reduction']['display'] ?? 'über 85 %';
+$e3_cpl_reduction    = $e3_metrics['cpl_reduction']['display'] ?? '> 85 %';
 $e3_cpl_before       = $e3_metrics['cpl_before']['display'] ?? '150 €';
 $e3_cpl_after        = $e3_metrics['cpl_after']['display'] ?? '22 €';
 $e3_timeframe        = $e3_metrics['timeframe']['display'] ?? '9 Monate';
 $e3_timeframe_dative = $e3_metrics['timeframe']['display_dative'] ?? '9 Monaten';
 
-$pain_items = [
-	[
-		'n'    => '01',
-		'lbl'  => 'Lead-Einkauf',
-		'q'    => '80–150 € pro Lead — und die Hälfte geht nicht ans Telefon.',
-		'd'    => 'Sie kaufen bei Aroundhome, Check24 oder DAA. Aber: Mieter ohne Dach, Preisvergleicher ohne Budget, Kontakte, die schon bei drei Mitbewerbern angefragt haben. Ihr Vertrieb verbrennt Stunden mit Leuten, die nie kaufen werden.',
-	],
-	[
-		'n'    => '02',
-		'lbl'  => 'Blindflug',
-		'q'    => 'Kein Überblick, welcher Kanal sich wirklich lohnt.',
-		'd'    => 'Google Ads, Portal-Leads, Empfehlungen — niemand kann sauber sagen, woher die guten Abschlüsse kommen. Ohne diese Klarheit investieren Sie blind. Und skalieren falsch.',
-	],
-	[
-		'n'    => '03',
-		'lbl'  => 'Marktwende',
-		'q'    => 'Seit 2024 kommen Anfragen nicht mehr von allein.',
-		'd'    => 'Der PV-Boom ist vorbei. Der Markt normalisiert sich. Wer jetzt keine eigene Anfrage-Infrastruktur hat, ist abhängig von Portalen — und deren Preisen.',
-	],
+// ── Inhaltsmodelle ──────────────────────────────────────────────
+$hero_metrics = [
+	[ 'n' => $e3_cpl_after,    'l' => 'CPL nach 9 Monaten · ' . $e3_case_label ],
+	[ 'n' => '< 7',            'l' => 'Werktage · schriftlicher Befund' ],
+	[ 'n' => '100 %',          'l' => 'Asset-Eigentum · Code · Tracking · Daten' ],
 ];
 
-$negative_filters = [
+$trust_items = [
+	'B2B · DACH · Mittelstand',
+	'Server in Frankfurt · DSGVO',
+	'Server-Side-Tracking · CAPI',
+	'Hardcoded WordPress · kein Page-Builder',
+	'1:1 Senior · keine Junior-Kette',
+	'Diagnose verrechenbar',
+];
+
+$cta_card_items = [
+	[ 'n' => '01', 't' => 'Anfrage-Quellen',    's' => 'Was kosten Leads tatsächlich — inkl. Folgekosten.' ],
+	[ 'n' => '02', 't' => 'Tracking & Daten',   's' => 'Können Sie überhaupt belastbar entscheiden — oder raten Sie?' ],
+	[ 'n' => '03', 't' => 'Funnel',             's' => 'Wo bricht es ab — technisch und inhaltlich.' ],
+	[ 'n' => '04', 't' => 'Vertriebsanschluss','s' => 'Speed-to-Lead, CRM, Conversion je Quelle.' ],
+];
+
+$problem_cards = [
 	[
 		'n' => '01',
-		't' => 'Weniger als 10 Mitarbeiter',
-		'd' => 'Ein eigenes Anfrage-System trägt sich wirtschaftlich erst ab einem Vertriebsvolumen, das den TCO-Vorteil über 24 Monate auffängt. Darunter ist ein schlanker Funnel mit sauberem Tracking der bessere Hebel — den biete ich hier aber nicht an.',
+		'l' => 'Lead-Einkauf',
+		't' => 'Portal-Leads kosten 80–150 €. Die Hälfte geht nicht ans Telefon.',
+		's' => 'Aroundhome, Check24, DAA: Mieter ohne Dach, Preisvergleicher ohne Budget, Anfragen, die bei drei Wettbewerbern parallel landen. Ihr Vertrieb verbrennt Stunden mit Leuten, die nie kaufen werden.',
 	],
 	[
 		'n' => '02',
-		't' => 'Weniger als 20 qualifizierte Anfragen pro Monat',
-		'd' => 'Server-Side Tracking, Lead-Scoring und ein Multi-Step-Funnel rechnen sich nur bei ausreichendem Anfragevolumen. Unter dieser Schwelle optimieren Sie ein Auto, das Sie nur einmal pro Woche fahren.',
+		'l' => 'Blindflug',
+		't' => 'Kein Überblick, welcher Kanal sich wirklich lohnt.',
+		's' => 'Google Ads, Portal-Leads, Empfehlungen — niemand kann sauber sagen, woher die guten Abschlüsse kommen. Ohne diese Klarheit investieren Sie blind. Und skalieren falsch.',
 	],
 	[
 		'n' => '03',
-		't' => 'Suche nach Leads in 2–4 Wochen',
-		'd' => 'Ein eigenes System braucht drei Monate Implementierung und sechs Monate Optimierung, bevor es seinen Vorteil ausspielt. Wer kurzfristig Termine braucht, ist bei einer Performance-Agentur oder bei Portal-Leads besser aufgehoben — auch wenn das teurer ist.',
-	],
-	[
-		'n' => '04',
-		't' => 'Keine Bereitschaft zur Daten-Offenlegung',
-		'd' => 'Eine Diagnose ohne Einblick in Anfrage-Quellen, Werbeaccounts und CRM-Daten ist ein Glücksspiel. Wenn diese Offenheit nicht da ist, hat eine Zusammenarbeit keinen Sinn.',
+		'l' => 'Marktwende',
+		't' => 'Seit 2024 kommen Anfragen nicht mehr von allein.',
+		's' => 'Der PV-Boom ist vorbei. Der Markt normalisiert sich. Wer jetzt keine eigene Anfrage-Infrastruktur hat, ist abhängig von Portalen — und deren Preisen.',
 	],
 ];
 
-$arch_full = [
+$method_cards = [
 	[
-		'n'   => '01',
-		't'   => 'Landingpage',
-		'd'   => 'Besucher kommt über Google, Ads oder Empfehlung. WordPress mit hardcoded HTML, kein Page-Builder, kein Plugin-Sumpf.',
-		'tag' => '8-Sekunden-Regel',
+		'n'  => 'I',
+		'p'  => 'Phase 01',
+		't'  => 'Diagnose & Fundament',
+		's'  => 'Wir prüfen Anfrage-Quellen, Tracking, Funnel und Vertriebsanschluss. Daraus entsteht ein schriftlicher Befund mit drei priorisierten Hebeln — auch dann, wenn Sie nicht mit mir weitermachen.',
+		'b'  => [ 'Module: Quellen · Daten · Funnel · Sales', 'Schriftlicher Befund · keine Folien', 'Auf Umsetzung 1:1 verrechenbar' ],
 	],
 	[
-		'n'   => '02',
-		't'   => 'Qualifizierung',
-		'd'   => '60-Sekunden-Funnel prüft Budget, Betriebsgröße und Bedarf. Mieter ohne Dach werden vor dem Anruf aussortiert.',
-		'tag' => 'React-Funnel',
+		'n'  => 'II',
+		'p'  => 'Phase 02',
+		't'  => 'Eigenes Anfrage-System',
+		's'  => 'WordPress hardcoded — kein Page-Builder, kein Plugin-Stack. Server-Side-Tracking auf eigenem Server. Smarte Vorqualifizierung. Conversion-Pfad ohne Mietsysteme.',
+		'b'  => [ 'Money-Page · Proof- & Angebotsseiten', 'Frankfurt-Server · CAPI · DSGVO', '60-Sek-Funnel mit Lead-Scoring' ],
 	],
 	[
-		'n'   => '03',
-		't'   => 'Segmentierung',
-		'd'   => 'n8n routet die Anfrage nach Region, Gewerk und Dringlichkeit in den richtigen Topf — automatisch.',
-		'tag' => 'n8n · Routing',
-	],
-	[
-		'n'   => '04',
-		't'   => 'Benachrichtigung',
-		'd'   => 'Vertrieb bekommt Slack oder Mail mit Lead-Score und Kontakt — in Echtzeit. Kein Lead liegt länger als 5 Minuten.',
-		'tag' => 'Realtime · CRM',
-	],
-	[
-		'n'   => '05',
-		't'   => 'Bewertung',
-		'd'   => 'Lead-Scoring priorisiert: heiß, warm, kalt. Ihr Vertrieb sieht auf einen Blick, wen er zuerst anruft.',
-		'tag' => 'Scoring-Engine',
+		'n'  => 'III',
+		'p'  => 'Phase 03',
+		't'  => 'Skalieren & Übergeben',
+		's'  => 'Mit sauberem Fundament rechnen sich Google Ads, Meta Ads und SEO endlich. Wöchentliches Reporting. Bei Vertragsende: dokumentierte Übergabe — Code, Tracking, Daten bleiben bei Ihnen.',
+		'b'  => [ 'Google Ads · Meta Ads · SEO-Anteil', 'Wöchentliches Reporting', 'Monatlich kündbar · 100 % Asset-Übergabe' ],
 	],
 ];
 
-$twoways_a = [
-	[ 'k' => 'bis 150 €',     'v' => 'pro Lead — und 50 % gehen nicht ans Telefon.' ],
-	[ 'k' => 'Kein Überblick', 'v' => 'Welcher Kanal lohnt sich wirklich? Niemand sagt es Ihnen.' ],
-	[ 'k' => 'Abhängigkeit',   'v' => 'Budget-Stopp = Nachfrage-Stopp. Sie mieten — Sie besitzen nichts.' ],
+$results_qualifiers = [
+	[ 'k' => 'Anfrage-Quellen',     'v' => 'Beziffert' ],
+	[ 'k' => 'Tracking & CAPI',     'v' => 'Auditiert' ],
+	[ 'k' => 'Funnel-Hebel',        'v' => 'Drei priorisiert' ],
+	[ 'k' => 'Wirtschaftlichkeit',  'v' => 'Einordnung' ],
+	[ 'k' => 'Nächster Schritt',    'v' => 'Konkret' ],
 ];
 
-$twoways_b = [
-	[ 'n' => '01', 'k' => 'Fundament ordnen',           'v' => 'Tracking & Datenebene · Privacy-first · saubere Entscheidungssignale.' ],
-	[ 'n' => '02', 'k' => 'Conversion-Pfade schärfen',  'v' => 'Formular · Call · Buchung · 8-Sekunden-Regel auf jeder Money-Page.' ],
-	[ 'n' => '03', 'k' => 'Skalieren',                  'v' => 'Money Pages & Proof · bleibende Assets · Unabhängigkeit von Portalen.' ],
-];
-
-$tco_rows = [
+$guarantee_points = [
 	[
-		'lbl' => 'Initiales Setup',
-		'a'   => [ '~ 2.000 €', 'Setup-Pauschale, Funnel-Lizenz' ],
-		'b'   => [ '12.000 – 18.000 €', 'einmalig — eigene Code-Basis' ],
+		't' => 'Diagnose-Honorar wird verrechnet',
+		's' => 'Bei anschließender Umsetzung wird die Diagnose 1:1 angerechnet. Sie zahlen sie nur dann, wenn Sie sich gegen die Umsetzung entscheiden.',
 	],
 	[
-		'lbl' => 'Monatlich (ohne Werbebudget)',
-		'a'   => [ '~ 850 € + 150 €', 'Honorar + SaaS / CRM-Lizenz' ],
-		'b'   => [ '~ 50 €', 'Hochleistungs-Hosting' ],
+		't' => 'Drei Hebel — auch bei Abrat',
+		's' => 'Wenn die Diagnose zum Ergebnis kommt, dass Sie das volle System nicht brauchen, bekommen Sie trotzdem drei priorisierte Hebel mit konkretem nächstem Schritt.',
 	],
 	[
-		'lbl' => 'TCO über 24 Monate',
-		'a'   => [ '~ 26.000 €', 'fließt durch die GuV ab' ],
-		'b'   => [ '13.200 – 19.200 €', 'günstiger UND aktivierbar' ],
+		't' => 'Keine Mindestlaufzeit',
+		's' => 'Monatlich kündbar. Vollständige Asset-Übergabe — Code, Tracking, Daten, Werbeaccounts bleiben bei Ihnen.',
 	],
-	[
-		'lbl' => 'Bilanzwirkung',
-		'a'   => [ 'OPEX', 'fließt vollständig durch die GuV' ],
-		'b'   => [ 'CAPEX', 'aktivierbares Asset' ],
-	],
-	[
-		'lbl' => 'Eigentum nach Kündigung',
-		'a'   => [ '0 %', 'Funnel · CRM · Tracking abgeschaltet' ],
-		'b'   => [ '100 %', 'Code · Tracking · Daten bleiben' ],
-	],
-];
-
-$owned_items = [
-	[
-		'n' => '01',
-		't' => 'Eigene WordPress-Assets',
-		'd' => 'Eine conversion-optimierte Money-Page sowie Proof- und Angebotsseiten. Hardcoded — kein Page-Builder, kein Plugin-Stack. Bleibt langfristig in Ihrem Eigentum.',
-	],
-	[
-		'n' => '02',
-		't' => 'Vorqualifizierung & Übergabe',
-		'd' => 'Smarte Formulare filtern unpassende Anfragen automatisch heraus. CRM-Anbindung folgt erst nach Contract, Consent und klarer Datenlogik.',
-	],
-	[
-		'n' => '03',
-		't' => 'Echtes Tracking',
-		'd' => 'Sie sehen, welche Kampagne welche Anfragen und Termine erzeugt. Volle Messbarkeit der Leadquellen — auf Ihrem Server, in Ihrem Account.',
-	],
-	[
-		'n' => '04',
-		't' => 'Grundlage für Skalierung',
-		'd' => 'Mit diesem Fundament skalieren Sie Google Ads, Meta Ads und SEO endlich wirtschaftlich. Mehr Reichweite zahlt jetzt aufs eigene System ein.',
-	],
-];
-
-$tracking_items = [
-	[
-		'k' => 'Frankfurt · DSGVO',
-		't' => 'First-Party-Kontext',
-		'd' => 'Der Tracking-Server läuft auf Ihrer Subdomain. Ad-Blocker und ITP erkennen keine blockierbaren Drittanbieter-Skripte — Ihre Conversion-Daten bleiben vollständig.',
-	],
-	[
-		'k' => 'S2S · CAPI',
-		't' => 'Algorithmisches Training',
-		'd' => 'Saubere, serverseitige Conversion-Signale fließen direkt per Server-to-Server-API an Meta und Google Ads. Die Algorithmen lernen präziser — und senken Ihren CPL.',
-	],
-	[
-		'k' => 'Privacy-First',
-		't' => 'DSGVO & Consent',
-		'd' => 'IP-Adressen werden auf Ihrem Server anonymisiert, bevor Daten externe Netzwerke erreichen. Conversion-Pfade bleiben auch bei Cookie-Ablehnung statistisch valide messbar.',
-	],
-];
-
-$proof_phases = [
-	[
-		'k' => 'Vorher',
-		'v' => 'Hohe Abhängigkeit von externen Leadquellen (~150 €/Lead). Leads schwer erreichbar, kaum qualifiziert. Kein Überblick, welche Kanäle Termine und Abschlüsse erzeugen.',
-	],
-	[
-		'k' => 'Umsetzung',
-		'v' => 'Tracking-Fundament aufgebaut, Anfragepfade optimiert, smarte Vorqualifizierung eingeführt. Saubere CRM-Übergabe vorbereitet.',
-	],
-	[
-		'k' => 'Ergebnis · 9 Monate',
-		'v' => '1.750+ qualifizierte Anfragen · 12 % Abschlussquote · über 85 % CPL-Reduktion (auf 22 € gesenkt).',
-	],
-];
-
-$risk_reversals = [
-	[
-		'n' => '01',
-		't' => 'Diagnose wird verrechnet',
-		'd' => 'Die System-Diagnose kostet [Preis wird ergänzt]. Bei einer anschließenden Umsetzung wird der volle Betrag 1:1 angerechnet. Sie zahlen die Diagnose also de facto nur dann, wenn Sie sich gegen die Umsetzung entscheiden.',
-	],
-	[
-		'n' => '02',
-		't' => 'Keine Mindestlaufzeit auf CRO oder Ads',
-		'd' => 'Wenn nach der Implementierung ein laufendes CRO- oder Ads-Mandat folgt, ist das monatlich kündbar. Keine 12-Monats-Verträge, keine Auflösungsgebühren.',
-	],
-	[
-		'n' => '03',
-		't' => 'Vollständige Asset-Übergabe',
-		'd' => 'Code, Tracking, Daten, Werbeaccounts — alles auf Ihren Konten, in Ihrer Domain, in Ihrem Eigentum. Bei Vertragsende übergebe ich dokumentiert. Sie können das System mit jedem anderen Dienstleister weiterführen.',
-	],
-	[
-		'n' => '04',
-		't' => 'Drei Hebel, auch bei Abrat',
-		'd' => 'Wenn die Diagnose zum Ergebnis kommt, dass Sie das volle System nicht brauchen, bekommen Sie trotzdem drei priorisierte Hebel mit konkretem nächstem Schritt — auch wenn das heißt, dass Sie nicht mit mir weitermachen.',
-	],
-];
-
-$diagnostic_modules = [
-	[
-		'n' => '01',
-		't' => 'Anfrage-Quellen',
-		'd' => 'Wo kommen Ihre Anfragen heute her, was kosten sie tatsächlich (inkl. nicht gemessener Folgekosten), welche Quellen tragen sich, welche nicht.',
-	],
-	[
-		'n' => '02',
-		't' => 'Tracking und Daten',
-		'd' => 'Was wird aktuell gemessen, was nicht. Server-Side-Status, Consent-Setup, Attribution-Kette. Kernfrage: Können Sie überhaupt belastbar entscheiden, oder raten Sie?',
-	],
-	[
-		'n' => '03',
-		't' => 'Funnel',
-		'd' => 'Weg vom Klick zur Anfrage. Wo bricht es ab — technisch (Speed, Mobile) und inhaltlich (Versprechen, Form-Reibung).',
-	],
-	[
-		'n' => '04',
-		't' => 'Vertriebsanschluss',
-		'd' => 'Speed-to-Lead, CRM-Anbindung, Qualifizierungs-Prozess, Conversion-Raten je Quelle.',
-	],
-];
-
-$diagnostic_results = [
-	'Schriftlicher Befund nach 7 Werktagen',
-	'Drei priorisierte Hebel mit konkretem nächsten Schritt',
-	'Wirtschaftlichkeits-Einordnung (Investition vs. erwarteter Effekt)',
-	'Übergabe-Call (30 Minuten, optional)',
-];
-
-$diagnostic_conditions = [
-	'[Preis wird ergänzt] einmalig',
-	'Wird auf eine spätere Umsetzung 1:1 verrechnet',
-	'Keine Mindestlaufzeit, kein Pflicht-Termin',
-	'Schriftlicher Befund als Deliverable, kein Folien-Pitch',
-];
-
-$about_metrics = [
-	[ 'v' => '9',   'l' => 'Jahre WordPress' ],
-	[ 'v' => 'B2B', 'l' => 'Ausschließlich' ],
-	[ 'v' => '1:1', 'l' => 'Einzelperson' ],
 ];
 
 $faq_items = [
@@ -300,6 +155,7 @@ $faq_items = [
 	],
 ];
 
+// ── Schema.org (Service + FAQPage) ─────────────────────────────
 $service_schema = [
 	'@context'    => 'https://schema.org',
 	'@type'       => 'Service',
@@ -347,831 +203,385 @@ foreach ( $faq_items as $faq_item ) {
 	];
 }
 
-$arch_steps = [
-	[ 'n' => '01', 'lbl' => 'Landing',        'note' => 'Google → WordPress' ],
-	[ 'n' => '02', 'lbl' => 'Qualifizierung', 'note' => '60s-Funnel · React' ],
-	[ 'n' => '03', 'lbl' => 'Segmentierung',  'note' => 'n8n · Routing' ],
-	[ 'n' => '04', 'lbl' => 'Scoring',        'note' => 'Heiß / Warm / Kalt' ],
-	[ 'n' => '05', 'lbl' => 'Vertrieb',       'note' => 'Slack · CRM · 5 Min.' ],
-];
-
-$energy_intake_flow = function_exists( 'nexus_get_energy_intake_flow_definition' ) ? nexus_get_energy_intake_flow_definition() : [];
-$form_page_url      = $page_url;
+// ── inline SVG-Pfeil ───────────────────────────────────────────
+$arrow_svg = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" focusable="false" aria-hidden="true"><path d="M5 12h14M13 5l7 7-7 7"/></svg>';
 
 get_header();
 ?>
+
 <main id="main" class="site-main">
-	<div class="energy-page-wrapper solar-page" data-track-section="energy_service_landing">
+	<div class="solara-landing" data-track-section="energy_service_landing">
 
-		<section class="nx-section solar-hero" id="hero">
-			<div class="solar-hero__inner">
-				<div class="solar-hero__eyebrow-row">
-					<span class="solar-hero__eyebrow">Für Solar- und Wärmepumpen-Betriebe · 10–25 Mitarbeiter</span>
-					<span class="solar-hero__meta">Pattensen · Region Hannover · Q2 / 2026</span>
-				</div>
-
-				<h1 class="solar-hero__headline">
-					Hören Sie auf, <em>Anfragen zu mieten.</em><br />
-					Bauen Sie eine, <span class="solar-hero__nowrap">die <em>Ihnen gehört.</em></span>
-				</h1>
-
-				<div class="solar-hero__grid">
-					<div class="solar-hero__lede-col">
-						<p class="solar-hero__lede">
-							Portal-Leads kosten 80–150 €. Die Hälfte geht nicht ans Telefon.
-							Wir bauen Ihrem Betrieb stattdessen ein eigenes Anfrage-System &mdash;
-							mit WordPress-Infrastruktur, serverseitigem Tracking und Vorqualifizierung.
-							Das System gehört Ihnen. Die Anfragen sind exklusiv.
-						</p>
-
-						<div class="solar-hero__cta-row">
-							<a href="<?php echo esc_url( $diagnostic_anchor ); ?>" class="solar-hero__btn" data-track-action="cta_solar_to_diagnostic_request" data-track-category="lead_gen" data-track-funnel-stage="form_open">
-								<span>System-Diagnose anfragen</span>
-								<span class="solar-hero__btn-arrow" aria-hidden="true">
-									<svg viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false">
-										<path d="M3 9h12m0 0l-5-5m5 5l-5 5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-									</svg>
-								</span>
-							</a>
-						</div>
-
-						<p class="solar-hero__micro">
-							<span class="solar-hero__dot" aria-hidden="true"></span>
-							4-Modul-Diagnose · schriftlicher Befund nach 7 Werktagen
-						</p>
-					</div>
-
-					<aside class="solar-arch" aria-label="System-Architektur — Vorschau">
-						<div class="solar-arch__head">
-							<span class="solar-arch__label">System · Live</span>
-							<span class="solar-arch__status">
-								<span class="solar-hero__dot solar-hero__dot--signal" aria-hidden="true"></span>
-								Routing OK
-							</span>
-						</div>
-
-						<div class="solar-arch__rows" data-solar-arch-rows>
-							<?php foreach ( $arch_steps as $i => $step ) : ?>
-								<div class="solar-arch__row<?php echo 0 === $i ? ' is-active' : ''; ?>">
-									<span class="solar-arch__num"><?php echo esc_html( $step['n'] ); ?></span>
-									<span class="solar-arch__name"><?php echo esc_html( $step['lbl'] ); ?></span>
-									<span class="solar-arch__note"><?php echo esc_html( $step['note'] ); ?></span>
-								</div>
-							<?php endforeach; ?>
-						</div>
-
-						<div class="solar-arch__foot">
-							<span class="solar-arch__label">Ø 4 Min · Anfrage → Anruf</span>
-							<span class="solar-arch__cpl"><?php echo esc_html( $e3_cpl_after ); ?><span>CPL</span></span>
-						</div>
-					</aside>
-				</div>
-
-				<div class="solar-hero__hairline" role="presentation"></div>
-
-				<div class="solar-proof">
-					<div class="solar-proof__cell">
-						<div class="solar-proof__num"><?php echo esc_html( $e3_lead_count ); ?></div>
-						<div class="solar-proof__lbl">qualifizierte Anfragen</div>
-						<div class="solar-proof__sub">in <?php echo esc_html( $e3_timeframe_dative ); ?></div>
-					</div>
-					<div class="solar-proof__cell">
-						<div class="solar-proof__num"><?php echo esc_html( $e3_sales_conversion ); ?></div>
-						<div class="solar-proof__lbl">Abschlussquote</div>
-						<div class="solar-proof__sub">von Anfrage zu Vertrag</div>
-					</div>
-					<div class="solar-proof__cell">
-						<div class="solar-proof__num"><?php echo esc_html( $e3_cpl_reduction ); ?></div>
-						<div class="solar-proof__lbl">Kosten pro Anfrage</div>
-						<div class="solar-proof__sub"><?php echo esc_html( $e3_cpl_before ); ?> &rarr; <?php echo esc_html( $e3_cpl_after ); ?></div>
-					</div>
-					<div class="solar-proof__cell">
-						<div class="solar-proof__num">100&nbsp;%</div>
-						<div class="solar-proof__lbl">Eigentum am System</div>
-						<div class="solar-proof__sub">Code · Tracking · Daten</div>
-					</div>
-				</div>
-				<p class="solar-hero__proof-note">
-					Mandat E3 New Energy · 9 Monate · Implementierung 3 Monate, Optimierung 6 Monate.
-					<a href="<?php echo esc_url( $e3_url ); ?>" data-track-action="cta_solar_hero_e3_methodology" data-track-category="trust">Vollständige Methodik im E3-Case</a> &rarr;
-				</p>
+		<!-- ════════════════════════════════════════════════════════════
+		     HERO
+		     ════════════════════════════════════════════════════════════ -->
+		<section class="sol-hero" id="hero" data-track-section="hero">
+			<div class="sol-hero-sky" aria-hidden="true"></div>
+			<div class="sol-hero-sun" aria-hidden="true">
+				<div class="sol-hero-sun-disc"></div>
+				<div class="sol-hero-sun-halo"></div>
+				<div class="sol-hero-sun-rays" data-sol-rays></div>
 			</div>
-		</section>
+			<div class="sol-hero-horizon" aria-hidden="true"></div>
 
-		<!-- 02 · Negativ-Filter (paper-2) ─────────────────────────── -->
-		<section class="solar-section solar-section--paper-2" id="negativ-filter" data-screen-label="02 Negativ-Filter" data-track-section="negative_filter" data-track-funnel-stage="qualification" aria-labelledby="negative-filter-title">
-			<div class="solar-section__inner">
-				<div class="solar-secthead">
-					<div class="solar-secthead__row">
-						<span class="solar-secnum">02 / Ehrlichkeit zuerst</span>
-						<span class="solar-secthead__rule" aria-hidden="true"></span>
-					</div>
-					<h2 id="negative-filter-title" class="solar-h2">Für wen das System nicht geeignet ist.</h2>
-					<p class="solar-lede">
-						Bevor wir über Investition und Aufbau reden — vier Situationen, in denen
-						Sie hier falsch sind. Das spart uns beiden Zeit.
+			<div class="sol-wrap sol-hero-inner">
+				<div class="sol-hero-left">
+					<div class="sol-eyebrow">Für Solar- &amp; Wärmepumpen-Anbieter · 10–25 MA · DACH</div>
+					<h1 class="sol-display sol-hero-h1">
+						Hören Sie auf,<br /><em>Anfragen zu mieten.</em><br />Bauen Sie eine,<br />die <em>Ihnen gehört.</em>
+					</h1>
+					<p class="sol-hero-sub">
+						Portal-Leads kosten 80–150 €. Die Hälfte geht nicht ans Telefon. Wir bauen Ihrem Betrieb ein eigenes Anfrage-System — WordPress hardcoded, Tracking auf eigenem Server, Vorqualifizierung mit Lead-Score. Das System gehört Ihnen. Die Anfragen sind exklusiv.
 					</p>
-				</div>
 
-				<div class="solar-owned solar-owned--filter">
-					<?php foreach ( $negative_filters as $item ) : ?>
-						<article class="solar-owned__cell" data-reveal>
-							<div class="solar-owned__head">
-								<span class="solar-owned__num"><?php echo esc_html( $item['n'] ); ?> / 04</span>
-								<span class="solar-dot solar-dot--warn" aria-hidden="true"></span>
+					<div class="sol-hero-metrics">
+						<?php foreach ( $hero_metrics as $m ) : ?>
+							<div class="sol-metric">
+								<div class="sol-metric-n sol-display"><?php echo esc_html( $m['n'] ); ?></div>
+								<div class="sol-metric-l sol-mono"><?php echo esc_html( $m['l'] ); ?></div>
 							</div>
-							<h3 class="solar-owned__t"><?php echo esc_html( $item['t'] ); ?></h3>
-							<p class="solar-owned__d"><?php echo esc_html( $item['d'] ); ?></p>
-						</article>
-					<?php endforeach; ?>
-				</div>
-
-				<p class="solar-grid-coda" data-reveal>
-					Trifft eines davon zu, sparen wir uns das Erstgespräch. Trifft keines davon zu,
-					weiter zum nächsten Punkt.
-				</p>
-			</div>
-		</section>
-
-		<!-- 03 · Pain (dark) ──────────────────────────────────────── -->
-		<section class="solar-section solar-section--dark" id="pain" data-screen-label="03 Pain" aria-labelledby="pain-title">
-			<div class="solar-section__inner">
-				<div class="solar-secthead">
-					<div class="solar-secthead__row">
-						<span class="solar-secnum">03 / Alltag im Vertrieb</span>
-						<span class="solar-secthead__rule" aria-hidden="true"></span>
-					</div>
-					<h2 id="pain-title" class="solar-h2">Kommt Ihnen das <em>bekannt vor?</em></h2>
-				</div>
-
-				<div class="solar-pain-grid">
-					<?php foreach ( $pain_items as $item ) : ?>
-						<article class="solar-pain-card" data-reveal>
-							<div class="solar-pain-card__num"><?php echo esc_html( $item['n'] ); ?></div>
-							<h3 class="solar-pain-card__q"><?php echo esc_html( $item['q'] ); ?></h3>
-							<p class="solar-pain-card__d"><?php echo esc_html( $item['d'] ); ?></p>
-						</article>
-					<?php endforeach; ?>
-				</div>
-			</div>
-		</section>
-
-		<!-- 04 · Architektur (paper) ─────────────────────────────── -->
-		<section class="solar-section solar-section--paper" id="system" data-screen-label="04 System" aria-labelledby="system-title">
-			<div class="solar-section__inner">
-				<div class="solar-secthead">
-					<div class="solar-secthead__row">
-						<span class="solar-secnum">04 / System-Architektur</span>
-						<span class="solar-secthead__rule" aria-hidden="true"></span>
-					</div>
-					<h2 id="system-title" class="solar-h2">Das ist keine Website. <em>Das ist eine Lead-Verarbeitungsmaschine.</em></h2>
-					<p class="solar-lede">Sehen Sie den kompletten Weg einer Anfrage — von der Landung bis zur priorisierten Vertriebsübergabe. Jede Stufe automatisiert. Jede Stufe in Ihrem Eigentum.</p>
-				</div>
-
-				<div class="solar-arch-list" role="list">
-					<?php foreach ( $arch_full as $step ) : ?>
-						<div class="solar-arch-list__row" role="listitem" data-reveal>
-							<div class="solar-arch-list__num"><?php echo esc_html( $step['n'] ); ?></div>
-							<div class="solar-arch-list__body">
-								<h3 class="solar-arch-list__t"><?php echo esc_html( $step['t'] ); ?></h3>
-								<p class="solar-arch-list__d"><?php echo esc_html( $step['d'] ); ?></p>
-							</div>
-							<div class="solar-arch-list__tag">
-								<span class="solar-tag"><?php echo esc_html( $step['tag'] ); ?></span>
-							</div>
-						</div>
-					<?php endforeach; ?>
-				</div>
-
-				<div class="solar-aha" data-reveal>
-					<div class="solar-aha__icon" aria-hidden="true">↺</div>
-					<div class="solar-aha__body">
-						<div class="solar-aha__kicker">Der Aha-Moment</div>
-						<p class="solar-aha__text">
-							Wettbewerber telefonieren jeden Lead einzeln ab und hoffen, dass er passt.
-							Ihr System sortiert vor. Sie rufen <em>nur noch die an, die wirklich kaufen wollen</em> &mdash;
-							und zwar in der richtigen Reihenfolge.
-						</p>
+						<?php endforeach; ?>
 					</div>
 				</div>
-			</div>
-		</section>
 
-		<!-- 05 · Zwei Wege (paper, main comparison) ───────────────── -->
-		<section class="solar-section solar-section--paper-2" id="modelle" data-screen-label="05 Zwei Wege" aria-labelledby="modelle-title">
-			<div class="solar-section__inner">
-				<div class="solar-secthead">
-					<div class="solar-secthead__row">
-						<span class="solar-secnum">05 / Zwei Wege</span>
-						<span class="solar-secthead__rule" aria-hidden="true"></span>
-					</div>
-					<h2 id="modelle-title" class="solar-h2">Nachfrage <em>mieten</em> &mdash; oder <em>eigene Anfrage-Infrastruktur</em> aufbauen.</h2>
-					<p class="solar-lede">Zwei Modelle, zwei Wirtschaftlichkeiten. Das eine zahlt jeden Monat neu auf Portal-Konten ein. Das andere baut ein Anfrage-System, das in 9 Monaten über 85&nbsp;% günstiger arbeitet.</p>
-				</div>
-
-				<div class="solar-ways">
-					<!-- Modell A -->
-					<div class="solar-way solar-way--a" data-reveal>
-						<div class="solar-way__head">
-							<span class="solar-way__label">Modell A</span>
-							<span class="solar-way__status solar-way__status--warn">
-								<span class="solar-dot solar-dot--warn" aria-hidden="true"></span>
-								Status Quo
+				<aside class="sol-hero-right" aria-labelledby="sol-cta-title">
+					<div class="sol-cta-card">
+						<div class="sol-cta-head">
+							<span class="sol-cta-tag sol-mono">
+								<span class="sol-cta-tag-dot" aria-hidden="true"></span>
+								System-Diagnose · 4 Module
 							</span>
-						</div>
-						<h3 class="solar-way__title">Nachfrage mieten</h3>
-						<div class="solar-way__sub">Aroundhome · Check24 · DAA</div>
-
-						<div class="solar-way__items">
-							<?php foreach ( $twoways_a as $idx => $row ) : ?>
-								<div class="solar-way__item solar-way__item--a<?php echo 0 === $idx ? ' is-first' : ''; ?>">
-									<div class="solar-way__k"><?php echo esc_html( $row['k'] ); ?></div>
-									<div class="solar-way__v"><?php echo esc_html( $row['v'] ); ?></div>
-								</div>
-							<?php endforeach; ?>
+							<span class="sol-cta-head-right sol-mono">Verrechenbar</span>
 						</div>
 
-						<div class="solar-pill solar-pill--warn">
-							<span class="solar-dot solar-dot--warn" aria-hidden="true"></span>
-							<span>Teuer · Kurzlebig</span>
-						</div>
-					</div>
-
-					<!-- Modell B -->
-					<div class="solar-way solar-way--b" data-reveal>
-						<div class="solar-way__glow" aria-hidden="true"></div>
-						<div class="solar-way__head">
-							<span class="solar-way__label">Modell B</span>
-							<span class="solar-way__status solar-way__status--signal">
-								<span class="solar-dot solar-dot--signal" aria-hidden="true"></span>
-								Empfohlen
-							</span>
-						</div>
-						<h3 class="solar-way__title solar-way__title--bone">Eigenes Anfrage-System</h3>
-						<div class="solar-way__sub solar-way__sub--bone">Fundament · Conversion · Skalierung</div>
-
-						<div class="solar-way__items">
-							<?php foreach ( $twoways_b as $idx => $row ) : ?>
-								<div class="solar-way__item solar-way__item--b<?php echo 0 === $idx ? ' is-first' : ''; ?>">
-									<span class="solar-way__num"><?php echo esc_html( $row['n'] ); ?></span>
-									<div>
-										<div class="solar-way__k solar-way__k--bone"><?php echo esc_html( $row['k'] ); ?></div>
-										<div class="solar-way__v solar-way__v--bone"><?php echo esc_html( $row['v'] ); ?></div>
-									</div>
-								</div>
-							<?php endforeach; ?>
-						</div>
-
-						<div class="solar-pill solar-pill--solar">
-							<span class="solar-dot solar-dot--signal" aria-hidden="true"></span>
-							<span>Bleibendes Anfrage-Asset</span>
-						</div>
-					</div>
-				</div>
-
-				<div class="solar-ref" data-reveal>
-					<div class="solar-ref__label">Referenz <?php echo esc_html( $e3_case_label ); ?> · <?php echo esc_html( $e3_timeframe ); ?></div>
-					<div class="solar-ref__stats">
-						<div class="solar-ref__stat">
-							<span class="solar-ref__num"><?php echo esc_html( $e3_cpl_reduction ); ?></span>
-							<span class="solar-ref__lbl">CPL</span>
-						</div>
-						<div class="solar-ref__stat">
-							<span class="solar-ref__num"><?php echo esc_html( $e3_lead_count ); ?></span>
-							<span class="solar-ref__lbl">Anfragen</span>
-						</div>
-						<div class="solar-ref__stat">
-							<span class="solar-ref__num"><?php echo esc_html( $e3_sales_conversion ); ?></span>
-							<span class="solar-ref__lbl">Abschluss</span>
-						</div>
-					</div>
-					<a href="<?php echo esc_url( $diagnostic_anchor ); ?>" class="solar-hero__btn" data-track-action="cta_solar_to_diagnostic_request" data-track-category="lead_gen" data-track-funnel-stage="form_open">
-						<span>System-Diagnose anfragen</span>
-						<span class="solar-hero__btn-arrow" aria-hidden="true">
-							<svg viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false"><path d="M3 9h12m0 0l-5-5m5 5l-5 5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-						</span>
-					</a>
-				</div>
-			</div>
-		</section>
-
-		<!-- 06 · TCO (dark, CAPEX vs OPEX) ───────────────────────── -->
-		<section class="solar-section solar-section--dark" id="tco" data-screen-label="06 TCO" aria-labelledby="tco-title">
-			<div class="solar-section__inner">
-				<div class="solar-secthead">
-					<div class="solar-secthead__row">
-						<span class="solar-secnum">06 / CAPEX statt OPEX</span>
-						<span class="solar-secthead__rule" aria-hidden="true"></span>
-					</div>
-					<h2 id="tco-title" class="solar-h2">Der gleiche Hebel &mdash; <em>zwei Bilanzwirkungen.</em></h2>
-					<p class="solar-lede">Performance-Agenturen verkaufen Ihnen Reichweite zur Miete: Funnel auf deren Server, CRM unter deren Lizenz, Tracking unter deren Account. Vertrag endet &mdash; Hebel weg. Der gleiche monatliche Betrag fließt 24 Monate in ein System, das Ihnen nicht gehört.</p>
-				</div>
-
-				<div class="solar-tco-wrap" data-reveal>
-					<table class="solar-tco">
-						<caption class="screen-reader-text">Kostenvergleich Mietsystem vs. Infrastruktur-Aufbau über 24 Monate.</caption>
-						<thead>
-							<tr>
-								<th scope="col" class="solar-tco__col-lbl">Kostenpunkt</th>
-								<th scope="col">
-									<span class="solar-tco__col-h">Mietsystem</span>
-									<span class="solar-tco__col-s">Performance-Agentur · Paket „Regio+"</span>
-								</th>
-								<th scope="col" class="solar-tco__col-own">
-									<span class="solar-tco__col-h">Infrastruktur-Aufbau</span>
-									<span class="solar-tco__col-s solar-tco__col-s--solar">WGOS · Code im Eigentum</span>
-								</th>
-							</tr>
-						</thead>
-						<tbody>
-							<?php foreach ( $tco_rows as $row ) : ?>
-								<tr>
-									<th scope="row" class="solar-tco__lbl"><?php echo esc_html( $row['lbl'] ); ?></th>
-									<td class="solar-tco__rent">
-										<span class="solar-tco__b"><?php echo esc_html( $row['a'][0] ); ?></span>
-										<span class="solar-tco__s"><?php echo esc_html( $row['a'][1] ); ?></span>
-									</td>
-									<td class="solar-tco__own">
-										<span class="solar-tco__b solar-tco__b--solar"><?php echo esc_html( $row['b'][0] ); ?></span>
-										<span class="solar-tco__s"><?php echo esc_html( $row['b'][1] ); ?></span>
-									</td>
-								</tr>
-							<?php endforeach; ?>
-						</tbody>
-					</table>
-				</div>
-
-				<p class="solar-tco-coda" data-reveal>
-					Nach 24 Monaten haben Sie im Mietmodell rund <span class="solar-tco-coda__warn">26.000&nbsp;€</span> ausgegeben und besitzen <em>nichts</em>.
-					Im Infrastruktur-Modell haben Sie <span class="solar-tco-coda__solar">weniger</span> ausgegeben und ein <em>laufendes System</em> in Ihrer Bilanz.
-				</p>
-			</div>
-		</section>
-
-		<!-- 07 · Owned Assets (paper-2) ──────────────────────────── -->
-		<section class="solar-section solar-section--paper-2" id="owned" data-screen-label="07 Owned" aria-labelledby="owned-title">
-			<div class="solar-section__inner">
-				<div class="solar-secthead">
-					<div class="solar-secthead__row">
-						<span class="solar-secnum">07 / Keine Miet-Leads</span>
-						<span class="solar-secthead__rule" aria-hidden="true"></span>
-					</div>
-					<h2 id="owned-title" class="solar-h2">Was Ihr Betrieb <em>danach besitzt.</em></h2>
-					<p class="solar-lede">Kein Lead-Paket. Keine gemietete Landingpage. Kein Agentur-Blindflug. Ein eigenes Anfrage-System &mdash; vier Bestandteile, alle in Ihrem Eigentum.</p>
-				</div>
-
-				<div class="solar-owned">
-					<?php foreach ( $owned_items as $item ) : ?>
-						<article class="solar-owned__cell" data-reveal>
-							<div class="solar-owned__head">
-								<span class="solar-owned__num"><?php echo esc_html( $item['n'] ); ?> / 04</span>
-								<span class="solar-dot solar-dot--signal" aria-hidden="true"></span>
-							</div>
-							<h3 class="solar-owned__t"><?php echo esc_html( $item['t'] ); ?></h3>
-							<p class="solar-owned__d"><?php echo esc_html( $item['d'] ); ?></p>
-						</article>
-					<?php endforeach; ?>
-				</div>
-			</div>
-		</section>
-
-		<!-- 08 · Server-Side Tracking (dark) ─────────────────────── -->
-		<section class="solar-section solar-section--dark" id="tracking" data-screen-label="08 Tracking" aria-labelledby="tracking-title">
-			<div class="solar-section__inner">
-				<div class="solar-secthead">
-					<div class="solar-secthead__row">
-						<span class="solar-secnum">08 / Unfairer Vorteil</span>
-						<span class="solar-secthead__rule" aria-hidden="true"></span>
-					</div>
-					<h2 id="tracking-title" class="solar-h2">
-						Server-Side Tracking:<br>
-						Der Unterschied zwischen <em>Blindflug</em> und <em>messbarem Wachstum.</em>
-					</h2>
-					<p class="solar-lede">Die meisten Agenturen tracken clientseitig &mdash; und verlieren bis zu 40&nbsp;% der Conversion-Daten an Ad-Blocker, ITP und Firmen-Firewalls. Ihr System bekommt eine eigene Tracking-Infrastruktur auf einem Server in Frankfurt. Die Daten gehören Ihnen.</p>
-				</div>
-
-				<div class="solar-track-grid">
-					<?php foreach ( $tracking_items as $item ) : ?>
-						<article class="solar-track-card" data-reveal>
-							<div class="solar-track-card__k"><?php echo esc_html( $item['k'] ); ?></div>
-							<h3 class="solar-track-card__t"><?php echo esc_html( $item['t'] ); ?></h3>
-							<p class="solar-track-card__d"><?php echo esc_html( $item['d'] ); ?></p>
-						</article>
-					<?php endforeach; ?>
-				</div>
-
-				<p class="solar-track-coda" data-reveal>
-					Wer im Jahr 2026 den Algorithmen von Meta und Google die <em>saubersten</em> Conversion-Signale liefert,
-					gewinnt die automatisierten Auktionen um die <em>günstigsten CPLs</em>.
-					Das ist kein technisches Detail &mdash; das ist Ihr geldwerter Vorteil gegenüber lokalen Mitbewerbern, die weiter blind kaufen.
-				</p>
-			</div>
-		</section>
-
-		<!-- 09 · Proof / E3 Case (paper) ─────────────────────────── -->
-		<section class="solar-section solar-section--paper" id="proof" data-screen-label="09 Proof" aria-labelledby="proof-title">
-			<div class="solar-section__inner">
-				<div class="solar-secthead">
-					<div class="solar-secthead__row">
-						<span class="solar-secnum">09 / Proof · Case Study</span>
-						<span class="solar-secthead__rule" aria-hidden="true"></span>
-					</div>
-					<h2 id="proof-title" class="solar-h2"><?php echo esc_html( $e3_case_label ); ?>. <em>Vorher → Nachher.</em></h2>
-				</div>
-
-				<div class="solar-proof-grid">
-					<div class="solar-proof-grid__col" data-reveal>
-						<div class="solar-proof-phases">
-							<?php foreach ( $proof_phases as $phase ) : ?>
-								<div class="solar-proof-phase">
-									<div class="solar-proof-phase__k"><?php echo esc_html( $phase['k'] ); ?></div>
-									<p class="solar-proof-phase__v"><?php echo esc_html( $phase['v'] ); ?></p>
-								</div>
-							<?php endforeach; ?>
-						</div>
-
-						<blockquote class="solar-quote">
-							<p>„Seit dem System sehen wir endlich, welche Kanäle wirklich Anfragen und Abschlüsse bringen. Wir konnten den teuren Lead-Einkauf massiv reduzieren &mdash; und haben jetzt eine eigene Pipeline."</p>
-							<footer class="solar-quote__cite">Geschäftsführung · <?php echo esc_html( $e3_case_label ); ?></footer>
-						</blockquote>
-
-						<a href="<?php echo esc_url( $e3_url ); ?>" class="solar-hero__btn solar-hero__btn--ghost" data-track-action="cta_solar_proof_e3_methodology" data-track-category="trust">
-							<span>Methodik im Detail lesen</span>
-							<span class="solar-hero__btn-arrow" aria-hidden="true">
-								<svg viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false"><path d="M3 9h12m0 0l-5-5m5 5l-5 5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-							</span>
-						</a>
-					</div>
-
-					<div class="solar-proof-grid__col" data-reveal>
-						<div class="solar-proof-cells">
-							<div class="solar-proof-cells__cell">
-								<div class="solar-proof-cells__num"><?php echo esc_html( $e3_lead_count ); ?></div>
-								<div class="solar-proof-cells__lbl">Qualifizierte Anfragen</div>
-							</div>
-							<div class="solar-proof-cells__cell">
-								<div class="solar-proof-cells__num"><?php echo esc_html( $e3_sales_conversion ); ?></div>
-								<div class="solar-proof-cells__lbl">Abschlussquote</div>
-							</div>
-							<div class="solar-proof-cells__cell solar-proof-cells__cell--hl">
-								<div class="solar-proof-cells__num solar-proof-cells__num--solar"><?php echo esc_html( $e3_cpl_reduction ); ?></div>
-								<div class="solar-proof-cells__lbl">CPL</div>
-							</div>
-							<div class="solar-proof-cells__cell">
-								<div class="solar-proof-cells__num"><?php echo esc_html( $e3_cpl_after ); ?></div>
-								<div class="solar-proof-cells__lbl">Ziel-CPL erreicht</div>
-							</div>
-						</div>
-
-						<div class="solar-cpl-curve">
-							<div class="solar-cpl-curve__lbl">CPL-Verlauf · <?php echo esc_html( $e3_timeframe ); ?></div>
-							<svg viewBox="0 0 400 120" preserveAspectRatio="none" aria-hidden="true">
-								<line x1="20" y1="100" x2="380" y2="100" stroke="rgba(12,13,14,0.14)"/>
-								<path d="M 20 20 Q 120 25, 200 60 T 380 95" fill="none" stroke="#c97a1a" stroke-width="2.5"/>
-								<circle cx="20" cy="20" r="5" fill="#0c0d0e"/>
-								<circle cx="380" cy="95" r="5" fill="#f0b540" stroke="#0c0d0e" stroke-width="1"/>
-							</svg>
-							<div class="solar-cpl-curve__ends">
-								<span><?php echo esc_html( $e3_cpl_before ); ?></span>
-								<span><?php echo esc_html( $e3_cpl_after ); ?></span>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-		</section>
-
-		<!-- 10 · Risikoumkehr (paper-2) ──────────────────────────── -->
-		<section class="solar-section solar-section--paper-2" id="risikoumkehr" data-screen-label="10 Risikoumkehr" data-track-section="risk_reversal" data-track-funnel-stage="conversion" aria-labelledby="risk-title">
-			<div class="solar-section__inner">
-				<div class="solar-secthead">
-					<div class="solar-secthead__row">
-						<span class="solar-secnum">10 / Risikoverteilung</span>
-						<span class="solar-secthead__rule" aria-hidden="true"></span>
-					</div>
-					<h2 id="risk-title" class="solar-h2">Was passiert, wenn es nicht funktioniert.</h2>
-					<p class="solar-lede">Vier Bedingungen, unter denen Sie das Risiko an mich zurückgeben können:</p>
-				</div>
-
-				<!-- TODO: Preis für System-Diagnose finalisieren, dann hier und in CTA-Sektion ersetzen -->
-				<div class="solar-owned solar-owned--risk">
-					<?php foreach ( $risk_reversals as $item ) : ?>
-						<article class="solar-owned__cell" data-reveal>
-							<div class="solar-owned__head">
-								<span class="solar-owned__num"><?php echo esc_html( $item['n'] ); ?> / 04</span>
-								<span class="solar-dot solar-dot--signal" aria-hidden="true"></span>
-							</div>
-							<h3 class="solar-owned__t"><?php echo esc_html( $item['t'] ); ?></h3>
-							<p class="solar-owned__d"><?php echo esc_html( $item['d'] ); ?></p>
-						</article>
-					<?php endforeach; ?>
-				</div>
-			</div>
-		</section>
-
-		<!-- 11 · FAQ (paper-2, objection handler before CTA) ────── -->
-		<section class="solar-section solar-section--paper-2" id="faq" data-screen-label="11 FAQ" aria-labelledby="faq-title">
-			<div class="solar-section__inner">
-				<div class="solar-secthead">
-					<div class="solar-secthead__row">
-						<span class="solar-secnum">11 / Häufige Fragen</span>
-						<span class="solar-secthead__rule" aria-hidden="true"></span>
-					</div>
-					<h2 id="faq-title" class="solar-h2">Was Solar- und Wärmepumpen-Betriebe <em>vor dem Erstgespräch wissen wollen.</em></h2>
-				</div>
-
-				<div class="solar-faq" data-solar-faq>
-					<?php foreach ( $faq_items as $idx => $faq_item ) : ?>
-						<details class="solar-faq__item"<?php echo 0 === $idx ? ' open' : ''; ?>>
-							<summary class="solar-faq__sum">
-								<span class="solar-faq__n"><?php echo esc_html( str_pad( (string) ( $idx + 1 ), 2, '0', STR_PAD_LEFT ) ); ?></span>
-								<span class="solar-faq__q"><?php echo esc_html( $faq_item['question'] ); ?></span>
-								<span class="solar-faq__plus" aria-hidden="true">
-									<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M12 5v14M5 12h14"/></svg>
-								</span>
-							</summary>
-							<div class="solar-faq__a"><p><?php echo esc_html( $faq_item['answer'] ); ?></p></div>
-						</details>
-					<?php endforeach; ?>
-				</div>
-			</div>
-		</section>
-
-		<!-- 12 · About Hasim (dark) ──────────────────────────────── -->
-		<section class="solar-section solar-section--dark" id="ueber" data-screen-label="12 About" aria-labelledby="about-title">
-			<div class="solar-section__inner">
-				<div class="solar-about">
-					<div class="solar-about__media" data-reveal>
-						<div class="solar-about__portrait">
-							<img class="solar-about__portrait-img" src="https://hasimuener.de/wp-content/uploads/2026/04/Hasim_Uener_Portrait.png" alt="Haşim Üner — Umsetzer für Anfrage-Systeme" loading="lazy" decoding="async" />
-							<div class="solar-about__portrait-inner" aria-hidden="true"></div>
-							<div class="solar-about__portrait-stamp">
-								<span>Profil · 2026</span>
-							</div>
-							<div class="solar-about__portrait-foot">
-								<div>
-									<div class="solar-about__portrait-kicker">Umsetzer</div>
-									<div class="solar-about__portrait-name">Haşim Üner</div>
-								</div>
-								<div class="solar-about__portrait-loc">Pattensen · Region Hannover</div>
-							</div>
-						</div>
-						<div class="solar-about__slot">
-							<div class="solar-about__slot-lbl">Verfügbare Slots</div>
-							<div class="solar-about__slot-num">3 / Q2</div>
-						</div>
-					</div>
-
-					<div class="solar-about__body" data-reveal>
-						<div class="solar-secnum solar-secnum--bone">12 / Über den Umsetzer</div>
-						<h2 id="about-title" class="solar-h2 solar-h2--bone">
-							Messbare Infrastruktur statt <em>digitaler Broschüren.</em>
+						<h2 id="sol-cta-title" class="sol-cta-title">
+							Wo verlieren Sie heute Anfragen — und wie viel kostet Sie das?
 						</h2>
-						<p class="solar-about__p">
-							Ich bin Haşim Üner und baue WordPress-basierte Anfrage-Systeme für Betriebe in der Erneuerbaren-Energien-Branche.
-							Mein Fokus liegt nicht auf „schönem Webdesign", sondern auf echter Nachfrage-Architektur:
-							Tracking, Vorqualifizierung, saubere Übergabe und Conversion-Optimierung.
+						<p class="sol-cta-hint">
+							Schriftlicher Befund nach 7 Werktagen. Drei priorisierte Hebel mit konkretem nächstem Schritt — auch wenn wir nicht zusammenarbeiten.
 						</p>
-						<p class="solar-about__p solar-about__p--strong">
-							Mit Sitz in Pattensen, Region Hannover. Spezialisiert auf <em>Lead-Autonomie</em> im B2B-Handwerk.
-						</p>
-						<div class="solar-about__metrics">
-							<?php foreach ( $about_metrics as $m ) : ?>
-								<div class="solar-about__metric">
-									<div class="solar-about__metric-v"><?php echo esc_html( $m['v'] ); ?></div>
-									<div class="solar-about__metric-l"><?php echo esc_html( $m['l'] ); ?></div>
-								</div>
+
+						<ul class="sol-cta-list">
+							<?php foreach ( $cta_card_items as $item ) : ?>
+								<li>
+									<span class="sol-cta-list-num"><?php echo esc_html( $item['n'] ); ?></span>
+									<span class="sol-cta-list-body">
+										<span class="sol-cta-list-t"><?php echo esc_html( $item['t'] ); ?></span>
+										<span class="sol-cta-list-s"><?php echo esc_html( $item['s'] ); ?></span>
+									</span>
+								</li>
 							<?php endforeach; ?>
-						</div>
+						</ul>
+
+						<a
+							class="sol-cta-submit"
+							href="<?php echo esc_url( $diagnose_url ); ?>"
+							data-track-action="cta_solar_to_diagnostic_request"
+							data-track-category="lead_funnel"
+							data-track-section="hero"
+							data-track-funnel-stage="diagnose_open"
+						>
+							<span>System-Diagnose starten</span>
+							<span class="sol-cta-submit-arrow" aria-hidden="true"><?php echo $arrow_svg; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></span>
+						</a>
+
+						<p class="sol-cta-fineprint">Schriftlicher Befund · 7 Werktage · Verrechenbar auf Umsetzung</p>
 					</div>
+				</aside>
+			</div>
+		</section>
+
+		<!-- ════════════════════════════════════════════════════════════
+		     TRUST STRIP
+		     ════════════════════════════════════════════════════════════ -->
+		<section class="sol-trust" aria-label="Vertrauenssignale" data-track-section="trust_strip">
+			<div class="sol-wrap">
+				<div class="sol-trust-row">
+					<?php foreach ( $trust_items as $t ) : ?>
+						<span class="sol-trust-item sol-mono">
+							<span class="sol-trust-dot" aria-hidden="true"></span>
+							<?php echo esc_html( $t ); ?>
+						</span>
+					<?php endforeach; ?>
 				</div>
 			</div>
 		</section>
 
-		<!-- 13 · System-Diagnose im Detail (paper-2) ─────────────── -->
-		<section class="solar-section solar-section--paper-2" id="abschluss" data-screen-label="13 Diagnose-Angebot" data-track-section="diagnostic_offer" data-track-funnel-stage="form_open" aria-labelledby="diagnostic-offer-title">
-			<div class="solar-section__inner">
-				<div class="solar-secthead">
-					<div class="solar-secthead__row">
-						<span class="solar-secnum">13 / Einstieg</span>
-						<span class="solar-secthead__rule" aria-hidden="true"></span>
-					</div>
-					<h2 id="diagnostic-offer-title" class="solar-h2">System-Diagnose — schriftlicher Befund in sieben Werktagen.</h2>
-					<p class="solar-lede">
-						Bevor wir Code schreiben, schauen wir auf das System, das Sie schon haben.
-						In sieben Werktagen erhalten Sie einen schriftlichen Befund zu vier Modulen:
-					</p>
-				</div>
-
-				<div class="solar-owned solar-owned--diagnostic">
-					<?php foreach ( $diagnostic_modules as $item ) : ?>
-						<article class="solar-owned__cell" data-reveal>
-							<div class="solar-owned__head">
-								<span class="solar-owned__num"><?php echo esc_html( $item['n'] ); ?> / 04</span>
-								<span class="solar-dot solar-dot--signal" aria-hidden="true"></span>
-							</div>
-							<h3 class="solar-owned__t"><?php echo esc_html( $item['t'] ); ?></h3>
-							<p class="solar-owned__d"><?php echo esc_html( $item['d'] ); ?></p>
+		<!-- ════════════════════════════════════════════════════════════
+		     PROBLEM
+		     ════════════════════════════════════════════════════════════ -->
+		<section class="sol-section" id="problem" data-track-section="problem">
+			<div class="sol-wrap">
+				<div class="sol-eyebrow">Der Status Quo</div>
+				<h2 class="sol-display sol-problem-h">
+					Sie zahlen für <em>Anfragen, die nicht Ihnen gehören</em> — und Vertriebsstunden, die niemand kauft.
+				</h2>
+				<div class="sol-problem-grid">
+					<?php foreach ( $problem_cards as $c ) : ?>
+						<article class="sol-problem-card">
+							<div class="sol-problem-card-n"><?php echo esc_html( $c['n'] ); ?> · <?php echo esc_html( $c['l'] ); ?></div>
+							<div class="sol-problem-card-t"><?php echo esc_html( $c['t'] ); ?></div>
+							<p class="sol-problem-card-s"><?php echo esc_html( $c['s'] ); ?></p>
 						</article>
 					<?php endforeach; ?>
 				</div>
+			</div>
+		</section>
 
-				<div class="solar-diagnostic-blocks" data-reveal>
-					<div class="solar-diagnostic-box solar-diagnostic-box--highlight">
-						<h3>Sie erhalten:</h3>
-						<ul>
-							<?php foreach ( $diagnostic_results as $item ) : ?>
-								<li><?php echo esc_html( $item ); ?></li>
-							<?php endforeach; ?>
-						</ul>
-					</div>
-					<div class="solar-diagnostic-box">
-						<!-- TODO: Preis für System-Diagnose finalisieren, dann hier und in CTA-Sektion ersetzen -->
-						<ul>
-							<?php foreach ( $diagnostic_conditions as $item ) : ?>
-								<li><?php echo esc_html( $item ); ?></li>
-							<?php endforeach; ?>
-						</ul>
-					</div>
+		<!-- ════════════════════════════════════════════════════════════
+		     METHOD / SYSTEM
+		     ════════════════════════════════════════════════════════════ -->
+		<section class="sol-section sol-method" id="system" data-track-section="method">
+			<div class="sol-wrap">
+				<div class="sol-method-head">
+					<div class="sol-eyebrow">Das System</div>
+					<h2 class="sol-display sol-method-h">
+						Diagnose. Aufbau. Eigentum.<br />Drei Phasen — <em>ein Ergebnis</em>: exklusive Anfragen.
+					</h2>
 				</div>
+				<div class="sol-method-grid">
+					<?php foreach ( $method_cards as $card ) : ?>
+						<article class="sol-method-card">
+							<div class="sol-method-card-top">
+								<div class="sol-method-card-n sol-display"><?php echo esc_html( $card['n'] ); ?></div>
+								<div class="sol-method-card-pill"><?php echo esc_html( $card['p'] ); ?></div>
+							</div>
+							<h3 class="sol-method-card-t"><?php echo esc_html( $card['t'] ); ?></h3>
+							<p class="sol-method-card-s"><?php echo esc_html( $card['s'] ); ?></p>
+							<ul class="sol-method-card-list">
+								<?php foreach ( $card['b'] as $b ) : ?>
+									<li><span class="sol-method-tick">+</span><?php echo esc_html( $b ); ?></li>
+								<?php endforeach; ?>
+							</ul>
+						</article>
+					<?php endforeach; ?>
+				</div>
+			</div>
+		</section>
 
-				<div class="solar-cta__actions solar-diagnostic-actions" data-reveal>
-					<a href="<?php echo esc_url( $diagnostic_anchor ); ?>" class="solar-hero__btn solar-cta__btn" data-track-action="cta_diagnostic_offer_to_form" data-track-category="lead_gen" data-track-funnel-stage="form_open">
-						<span>System-Diagnose anfragen</span>
-						<span class="solar-hero__btn-arrow" aria-hidden="true">
-							<svg viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false"><path d="M3 9h12m0 0l-5-5m5 5l-5 5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-						</span>
+		<!-- ════════════════════════════════════════════════════════════
+		     RESULTS — E3-Proof + Dashboard-Mock
+		     ════════════════════════════════════════════════════════════ -->
+		<section class="sol-section" id="ergebnisse" data-track-section="results">
+			<div class="sol-wrap sol-results-inner">
+				<div class="sol-results-text">
+					<div class="sol-eyebrow">Was Sie nach der Diagnose haben</div>
+					<h2 class="sol-display sol-results-h">
+						Klarheit, keine <em>Folien</em>.
+					</h2>
+					<p class="sol-results-sub">
+						Schriftlicher Befund nach 7 Werktagen. Vier Module, drei priorisierte Hebel, eine Wirtschaftlichkeits-Einordnung — als belastbare Entscheidungsgrundlage, nicht als Pitch-Deck.
+					</p>
+					<ul class="sol-results-list">
+						<?php foreach ( $results_qualifiers as $row ) : ?>
+							<li>
+								<span><?php echo esc_html( $row['k'] ); ?></span>
+								<span class="sol-mono sol-results-list-v"><?php echo esc_html( $row['v'] ); ?></span>
+							</li>
+						<?php endforeach; ?>
+					</ul>
+
+					<a
+						class="sol-btn sol-btn-ghost"
+						href="<?php echo esc_url( $e3_url ); ?>"
+						data-track-action="cta_solar_to_e3_case"
+						data-track-category="proof"
+						data-track-section="results"
+						style="margin-top:32px;"
+					>
+						Vollständige Methodik im <?php echo esc_html( $e3_case_label ); ?>-Case
+						<span class="sol-btn-arrow"><?php echo $arrow_svg; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></span>
 					</a>
 				</div>
-			</div>
-		</section>
 
-		<!-- 14 · Formular (dark) ─────────────────────────────────── -->
-		<section class="solar-section solar-section--dark solar-form-section" id="energie-anfrage" data-screen-label="14 Anfrage-Formular" data-track-section="energy_request_form" data-track-funnel-stage="form_submit" aria-labelledby="energy-form-title">
-			<div class="solar-section__inner">
-				<div class="review-box">
-					<div class="review-form-frame-head">
-						<div>
-							<p class="review-form-kicker">System-Diagnose anfragen</p>
-							<h2 id="energy-form-title">Standortdaten für die erste Einordnung.</h2>
+				<div class="sol-results-mock" aria-label="<?php echo esc_attr( $e3_case_label ); ?> — Methodik-Snapshot">
+					<div class="sol-results-mock-head">
+						<div class="sol-results-mock-dots" aria-hidden="true">
+							<span></span><span></span><span></span>
 						</div>
-						<div class="review-form-eta"><span>Antwort innerhalb 48 Werktagsstunden per E-Mail.</span></div>
+						<div class="sol-mono sol-results-mock-title"><?php echo esc_html( $e3_case_label ); ?> · Methodik-Snapshot</div>
+						<div class="sol-mono sol-results-mock-live">
+							<span class="sol-live-dot" aria-hidden="true"></span>
+							<?php echo esc_html( $e3_timeframe ); ?>
+						</div>
 					</div>
-
-					<?php if ( ! empty( $energy_intake_flow ) ) : ?>
-						<form id="review-request-form" class="review-funnel" method="post" novalidate>
-							<input type="hidden" name="audit_type" value="growth_audit" />
-							<input type="hidden" name="page_url" value="<?php echo esc_url( $form_page_url ); ?>" />
-							<input type="hidden" name="landing_page_url" value="<?php echo esc_url( $form_page_url ); ?>" />
-							<input type="hidden" name="entry_page_url" value="<?php echo esc_url( $form_page_url ); ?>" />
-							<input type="hidden" name="started_at" value="" />
-							<input type="hidden" id="ads_source" name="ads_source" value="" />
-							<input type="hidden" id="ads_keyword" name="ads_keyword" value="" />
-
-							<div class="review-progress">
-								<div class="review-progress-head">
-									<div class="review-progress-copy">
-										<span class="review-progress-eyebrow">System-Diagnose</span>
-										<strong id="review-progress-current">Schritt 1 von <?php echo esc_html( (string) count( $energy_intake_flow ) ); ?>: <?php echo esc_html( (string) ( $energy_intake_flow[0]['title_short'] ?? 'Start' ) ); ?></strong>
-									</div>
-									<span class="review-progress-meta">4 Module · schriftlicher Befund</span>
-								</div>
-								<div class="review-progress-track" aria-hidden="true">
-									<div class="review-progress-fill" id="review-progress-fill"></div>
-								</div>
-								<ol class="review-progress-steps">
-									<?php foreach ( $energy_intake_flow as $step_index => $step ) : ?>
-										<li>
-											<button type="button" data-review-step-target="<?php echo esc_attr( (string) $step_index ); ?>"<?php echo 0 === $step_index ? ' aria-current="step"' : ''; ?>>
-												<span class="review-progress-step-index"><?php echo esc_html( str_pad( (string) ( $step_index + 1 ), 2, '0', STR_PAD_LEFT ) ); ?></span>
-												<span class="review-progress-step-label"><?php echo esc_html( (string) ( $step['title_short'] ?? $step['summary_label'] ?? ( $step_index + 1 ) ) ); ?></span>
-											</button>
-										</li>
-									<?php endforeach; ?>
-								</ol>
+					<div class="sol-results-mock-body">
+						<div class="sol-results-mock-row">
+							<div class="sol-results-mock-stat">
+								<div class="sol-mono">Anfragen</div>
+								<div class="sol-display sol-results-mock-big"><?php echo esc_html( $e3_lead_count ); ?></div>
+								<div class="sol-results-mock-delta">qualifiziert · in <?php echo esc_html( $e3_timeframe_dative ); ?></div>
 							</div>
-
-							<?php foreach ( $energy_intake_flow as $step_index => $step ) : ?>
-								<?php
-								$step_kind = isset( $step['kind'] ) ? (string) $step['kind'] : 'single_choice';
-								?>
-								<section class="review-step" data-review-step="<?php echo esc_attr( (string) ( $step['id'] ?? $step_index ) ); ?>" data-review-radio-message="Bitte eine Option auswählen.">
-									<p class="review-step-kicker">Schritt <?php echo esc_html( (string) ( $step_index + 1 ) ); ?></p>
-									<h4><?php echo esc_html( (string) ( $step['question'] ?? '' ) ); ?></h4>
-									<?php if ( ! empty( $step['description'] ) ) : ?>
-										<p class="review-step-copy"><?php echo esc_html( (string) $step['description'] ); ?></p>
-									<?php endif; ?>
-
-									<?php if ( 'text_input' === $step_kind && ! empty( $step['field'] ) && is_array( $step['field'] ) ) : ?>
-										<?php $field = $step['field']; ?>
-										<div class="review-field">
-											<label for="review-field-<?php echo esc_attr( (string) $field['name'] ); ?>"><?php echo esc_html( (string) ( $field['label'] ?? '' ) ); ?></label>
-											<input
-												id="review-field-<?php echo esc_attr( (string) $field['name'] ); ?>"
-												name="<?php echo esc_attr( (string) $field['name'] ); ?>"
-												type="<?php echo esc_attr( (string) ( $field['type'] ?? 'text' ) ); ?>"
-												<?php echo ! empty( $field['inputmode'] ) ? 'inputmode="' . esc_attr( (string) $field['inputmode'] ) . '"' : ''; ?>
-												<?php echo ! empty( $field['autocomplete'] ) ? 'autocomplete="' . esc_attr( (string) $field['autocomplete'] ) . '"' : ''; ?>
-												<?php echo ! empty( $field['pattern'] ) ? 'pattern="' . esc_attr( (string) $field['pattern'] ) . '"' : ''; ?>
-												<?php echo ! empty( $field['maxlength'] ) ? 'maxlength="' . esc_attr( (string) $field['maxlength'] ) . '"' : ''; ?>
-												<?php echo ! empty( $field['placeholder'] ) ? 'placeholder="' . esc_attr( (string) $field['placeholder'] ) . '"' : ''; ?>
-												<?php echo ! empty( $field['required'] ) ? 'required' : ''; ?>
-											/>
-										</div>
-									<?php elseif ( 'single_choice' === $step_kind && ! empty( $step['options'] ) && is_array( $step['options'] ) ) : ?>
-										<fieldset class="review-choice-block">
-											<legend><?php echo esc_html( (string) ( $step['summary_label'] ?? $step['question'] ?? '' ) ); ?></legend>
-											<div class="review-option-group">
-												<?php foreach ( $step['options'] as $value => $option ) : ?>
-													<label class="review-option">
-														<input type="radio" name="<?php echo esc_attr( (string) ( $step['name'] ?? $step['id'] ?? '' ) ); ?>" value="<?php echo esc_attr( (string) $value ); ?>" required <?php echo ! empty( $step['auto_advance'] ) ? 'data-review-auto-advance="true"' : ''; ?> />
-														<span class="review-option-copy">
-															<strong><?php echo esc_html( (string) ( $option['label'] ?? $value ) ); ?></strong>
-															<?php if ( ! empty( $option['description'] ) ) : ?>
-																<span><?php echo esc_html( (string) $option['description'] ); ?></span>
-															<?php endif; ?>
-														</span>
-													</label>
-												<?php endforeach; ?>
-											</div>
-										</fieldset>
-									<?php elseif ( 'contact' === $step_kind && ! empty( $step['fields'] ) && is_array( $step['fields'] ) ) : ?>
-										<div class="review-field-grid">
-											<?php foreach ( $step['fields'] as $field ) : ?>
-												<?php if ( ! is_array( $field ) || empty( $field['name'] ) ) : ?>
-													<?php continue; ?>
-												<?php endif; ?>
-												<?php if ( 'checkbox' === ( $field['type'] ?? '' ) ) : ?>
-													<div class="review-consent-card review-field-full">
-														<label class="review-consent" for="review-field-<?php echo esc_attr( (string) $field['name'] ); ?>">
-															<input id="review-field-<?php echo esc_attr( (string) $field['name'] ); ?>" type="checkbox" name="<?php echo esc_attr( (string) $field['name'] ); ?>" value="<?php echo esc_attr( (string) ( $field['value'] ?? 'accepted' ) ); ?>" <?php echo ! empty( $field['required'] ) ? 'required' : ''; ?> />
-															<span><?php echo esc_html( (string) ( $field['label'] ?? '' ) ); ?></span>
-														</label>
-													</div>
-												<?php elseif ( 'textarea' === ( $field['type'] ?? '' ) ) : ?>
-													<div class="review-field review-field-full">
-														<label for="review-field-<?php echo esc_attr( (string) $field['name'] ); ?>"><?php echo esc_html( (string) ( $field['label'] ?? '' ) ); ?></label>
-														<textarea id="review-field-<?php echo esc_attr( (string) $field['name'] ); ?>" name="<?php echo esc_attr( (string) $field['name'] ); ?>" rows="<?php echo esc_attr( (string) ( $field['rows'] ?? 4 ) ); ?>" <?php echo ! empty( $field['maxlength'] ) ? 'maxlength="' . esc_attr( (string) $field['maxlength'] ) . '"' : ''; ?> <?php echo ! empty( $field['placeholder'] ) ? 'placeholder="' . esc_attr( (string) $field['placeholder'] ) . '"' : ''; ?> <?php echo ! empty( $field['required'] ) ? 'required' : ''; ?>></textarea>
-													</div>
-												<?php else : ?>
-													<div class="review-field">
-														<label for="review-field-<?php echo esc_attr( (string) $field['name'] ); ?>"><?php echo esc_html( (string) ( $field['label'] ?? '' ) ); ?></label>
-														<input
-															id="review-field-<?php echo esc_attr( (string) $field['name'] ); ?>"
-															name="<?php echo esc_attr( (string) $field['name'] ); ?>"
-															type="<?php echo esc_attr( (string) ( $field['type'] ?? 'text' ) ); ?>"
-															<?php echo ! empty( $field['inputmode'] ) ? 'inputmode="' . esc_attr( (string) $field['inputmode'] ) . '"' : ''; ?>
-															<?php echo ! empty( $field['autocomplete'] ) ? 'autocomplete="' . esc_attr( (string) $field['autocomplete'] ) . '"' : ''; ?>
-															<?php echo ! empty( $field['required'] ) ? 'required' : ''; ?>
-														/>
-														<?php if ( ! empty( $field['help'] ) ) : ?>
-															<p class="review-field-help"><?php echo esc_html( (string) $field['help'] ); ?></p>
-														<?php endif; ?>
-													</div>
-												<?php endif; ?>
-											<?php endforeach; ?>
-										</div>
-									<?php endif; ?>
-								</section>
-							<?php endforeach; ?>
-
-							<div id="review-form-feedback" class="review-form-feedback" aria-live="polite" aria-atomic="true"></div>
-							<div class="review-actions">
-								<button class="review-prev-btn" type="button" data-review-prev>Zurück</button>
-								<button class="audit-submit-btn" type="button" data-review-next>Weiter</button>
-								<button class="audit-submit-btn" type="submit" data-review-submit hidden>System-Diagnose anfragen</button>
+							<div class="sol-results-mock-stat">
+								<div class="sol-mono">Abschlussquote</div>
+								<div class="sol-display sol-results-mock-big"><?php echo esc_html( $e3_sales_conversion ); ?></div>
+								<div class="sol-results-mock-delta">Anfrage → Vertrag</div>
 							</div>
-						</form>
-
-						<div id="review-request-success" class="review-success" hidden>
-							<h3>Ihre Anfrage ist eingegangen.</h3>
-							<p id="review-success-message" class="review-success-copy">Danke. Sie erhalten eine Rückmeldung per E-Mail.</p>
-							<p id="review-success-url" class="review-output-note"></p>
+							<div class="sol-results-mock-stat">
+								<div class="sol-mono">CPL</div>
+								<div class="sol-display sol-results-mock-big"><?php echo esc_html( $e3_cpl_after ); ?></div>
+								<div class="sol-results-mock-delta">von <?php echo esc_html( $e3_cpl_before ); ?> · <?php echo esc_html( $e3_cpl_reduction ); ?></div>
+							</div>
 						</div>
-					<?php else : ?>
-						<p class="solar-lede">Das Formular ist aktuell nicht verfügbar.</p>
-					<?php endif; ?>
+						<div class="sol-results-mock-chart" aria-hidden="true">
+							<svg viewBox="0 0 400 120" preserveAspectRatio="none" width="100%" height="120">
+								<defs>
+									<linearGradient id="sol-rg" x1="0" x2="0" y1="0" y2="1">
+										<stop offset="0%" stop-color="currentColor" stop-opacity=".25" />
+										<stop offset="100%" stop-color="currentColor" stop-opacity="0" />
+									</linearGradient>
+								</defs>
+								<g style="color: var(--sol-accent);">
+									<path d="M0 96 L40 90 L80 80 L120 72 L160 66 L200 56 L240 46 L280 38 L320 30 L360 22 L400 16 L400 120 L0 120 Z" fill="url(#sol-rg)" />
+									<path d="M0 96 L40 90 L80 80 L120 72 L160 66 L200 56 L240 46 L280 38 L320 30 L360 22 L400 16" fill="none" stroke="currentColor" stroke-width="1.5" />
+									<circle cx="40"  cy="90" r="3" fill="currentColor" />
+									<circle cx="120" cy="72" r="3" fill="currentColor" />
+									<circle cx="200" cy="56" r="3" fill="currentColor" />
+									<circle cx="280" cy="38" r="3" fill="currentColor" />
+									<circle cx="360" cy="22" r="3" fill="currentColor" />
+								</g>
+							</svg>
+							<div class="sol-results-mock-axis sol-mono">
+								<span>Mon 1</span><span>Mon 3</span><span>Mon 5</span><span>Mon 7</span><span>Mon 9</span>
+							</div>
+						</div>
+						<div class="sol-results-mock-list">
+							<div class="sol-results-mock-item">
+								<span class="sol-results-mock-tag is-new">Neu</span>
+								<span>Anfrage-Quellen quantifiziert</span>
+								<span class="sol-results-mock-prod sol-mono">Modul 01</span>
+								<span class="sol-results-mock-time">7 d</span>
+							</div>
+							<div class="sol-results-mock-item">
+								<span class="sol-results-mock-tag is-call">Befund</span>
+								<span>Drei priorisierte Hebel</span>
+								<span class="sol-results-mock-prod sol-mono">Output</span>
+								<span class="sol-results-mock-time">7 d</span>
+							</div>
+							<div class="sol-results-mock-item">
+								<span class="sol-results-mock-tag is-booked">Übergabe</span>
+								<span>30-Min-Call · optional</span>
+								<span class="sol-results-mock-prod sol-mono">Wahlfrei</span>
+								<span class="sol-results-mock-time">+ 1 Wo</span>
+							</div>
+						</div>
+					</div>
 				</div>
 			</div>
 		</section>
 
-	</div>
-
-	<!-- Sticky CTA bar (mobile) -->
-	<div class="solar-sticky" data-solar-sticky aria-hidden="true">
-		<div class="solar-sticky__inner">
-			<div class="solar-sticky__copy">
-				<div class="solar-sticky__t">System-Diagnose</div>
-				<div class="solar-sticky__s">4 Module · schriftlicher Befund nach 7 Werktagen</div>
+		<!-- ════════════════════════════════════════════════════════════
+		     GUARANTEE — Risiko-Umkehr
+		     ════════════════════════════════════════════════════════════ -->
+		<section class="sol-section sol-guarantee" id="garantie" data-track-section="guarantee">
+			<div class="sol-wrap sol-guarantee-inner">
+				<div class="sol-guarantee-glow" aria-hidden="true"></div>
+				<div class="sol-eyebrow" style="justify-content:center;">Risiko-Umkehr</div>
+				<h2 class="sol-display sol-guarantee-h">
+					Drei Hebel — auch wenn wir <em>nicht zusammenarbeiten</em>.
+				</h2>
+				<p class="sol-guarantee-sub">
+					Die Diagnose ist kein Verkaufsritual. Sie ist ein schriftlicher Befund. Wenn sich aus der Analyse keine Umsetzung ergibt, bekommen Sie trotzdem drei priorisierte Hebel mit konkretem nächstem Schritt — auch dann, wenn das heißt, dass Sie nicht mit mir weitermachen.
+				</p>
+				<div class="sol-guarantee-points">
+					<?php foreach ( $guarantee_points as $p ) : ?>
+						<div class="sol-guarantee-point">
+							<div class="sol-guarantee-point-mark" aria-hidden="true">
+								<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" focusable="false">
+									<path d="M5 12l5 5L20 7" />
+								</svg>
+							</div>
+							<div>
+								<div class="sol-guarantee-point-t"><?php echo esc_html( $p['t'] ); ?></div>
+								<div class="sol-guarantee-point-s"><?php echo esc_html( $p['s'] ); ?></div>
+							</div>
+						</div>
+					<?php endforeach; ?>
+				</div>
 			</div>
-			<a href="<?php echo esc_url( $diagnostic_anchor ); ?>" class="solar-hero__btn solar-sticky__btn" data-track-action="cta_solar_to_diagnostic_request" data-track-category="lead_gen" data-track-funnel-stage="form_open">
-				<span>System-Diagnose anfragen</span>
-				<span class="solar-hero__btn-arrow" aria-hidden="true">
-					<svg viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false"><path d="M3 9h12m0 0l-5-5m5 5l-5 5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-				</span>
-			</a>
-		</div>
-	</div>
+		</section>
+
+		<!-- ════════════════════════════════════════════════════════════
+		     FAQ
+		     ════════════════════════════════════════════════════════════ -->
+		<section class="sol-section sol-faq" id="faq" data-track-section="faq">
+			<div class="sol-wrap sol-faq-inner">
+				<div class="sol-faq-left">
+					<div class="sol-eyebrow">Häufige Fragen</div>
+					<h2 class="sol-display sol-faq-h">
+						Bevor Sie <em>fragen</em>.
+					</h2>
+					<p class="sol-faq-sub">
+						Was hier nicht beantwortet wird, klären wir im Rahmen der System-Diagnose — schriftlich, nicht in einem Verkaufsgespräch.
+					</p>
+				</div>
+				<ul class="sol-faq-list">
+					<?php foreach ( $faq_items as $i => $item ) : ?>
+						<li class="sol-faq-item<?php echo 0 === $i ? ' is-open' : ''; ?>">
+							<button type="button" class="sol-faq-q" aria-expanded="<?php echo 0 === $i ? 'true' : 'false'; ?>">
+								<span class="sol-faq-q-n"><?php echo esc_html( sprintf( '%02d', $i + 1 ) ); ?></span>
+								<span class="sol-faq-q-t"><?php echo esc_html( $item['question'] ); ?></span>
+								<span class="sol-faq-q-mark" aria-hidden="true">
+									<span></span><span></span>
+								</span>
+							</button>
+							<div class="sol-faq-a-wrap">
+								<div class="sol-faq-a"><?php echo esc_html( $item['answer'] ); ?></div>
+							</div>
+						</li>
+					<?php endforeach; ?>
+				</ul>
+			</div>
+		</section>
+
+		<!-- ════════════════════════════════════════════════════════════
+		     FINAL CTA
+		     ════════════════════════════════════════════════════════════ -->
+		<section class="sol-section sol-final" data-track-section="final_cta">
+			<div class="sol-wrap">
+				<div class="sol-final-inner">
+					<div class="sol-final-sun" aria-hidden="true">
+						<div class="sol-final-sun-disc"></div>
+					</div>
+					<div class="sol-eyebrow" style="justify-content:center;">Letzter Schritt</div>
+					<h2 class="sol-display sol-final-h">
+						Anfragen <em>besitzen</em>,<br />nicht mieten.
+					</h2>
+					<p class="sol-final-sub">
+						4-Modul-Diagnose · schriftlicher Befund nach 7 Werktagen · auf Umsetzung verrechenbar.
+					</p>
+					<a
+						class="sol-btn sol-btn-primary sol-final-btn"
+						href="<?php echo esc_url( $diagnose_url ); ?>"
+						data-track-action="cta_solar_to_diagnostic_request"
+						data-track-category="lead_funnel"
+						data-track-section="final_cta"
+						data-track-funnel-stage="diagnose_open"
+					>
+						<span>System-Diagnose starten</span>
+						<span class="sol-btn-arrow"><?php echo $arrow_svg; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></span>
+					</a>
+					<div class="sol-final-micro">Kein Pitch · kein Folien-Deck · konkreter nächster Schritt</div>
+				</div>
+			</div>
+		</section>
+
+		<!-- ════════════════════════════════════════════════════════════
+		     STICKY MOBILE CTA
+		     ════════════════════════════════════════════════════════════ -->
+		<a
+			class="sol-sticky-cta"
+			href="<?php echo esc_url( $diagnose_url ); ?>"
+			data-track-action="cta_solar_to_diagnostic_request"
+			data-track-category="lead_funnel"
+			data-track-section="sticky_mobile"
+			data-track-funnel-stage="diagnose_open"
+		>
+			<span>System-Diagnose starten</span>
+			<span class="sol-sticky-cta-arrow" aria-hidden="true"><?php echo $arrow_svg; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></span>
+		</a>
+
+	</div><!-- /.solara-landing -->
 </main>
 
 <script type="application/ld+json"><?php echo wp_json_encode( $service_schema, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ); ?></script>


### PR DESCRIPTION
Rewrites /solar-waermepumpen-leadgenerierung/ along the SOLARA design language (premium · cinematic · minimal) but tuned for Mittelstand-B2B-Vertrauen: hybrides warm-cream-Theme mit Copper-Akzent, große Sonne nur als zentrales Visual statt durchgehend dunkler Bühne.

CRO-Architektur (von oben nach unten, single-purpose):
- Hero: Claim + Sonnenfeld + CTA-Card (4 Diagnose-Module) → /system-diagnose/
- Trust-Strip (DACH, DSGVO, Server-Side-Tracking, 1:1, Verrechenbarkeit)
- Problem (3 Karten: Lead-Einkauf, Blindflug, Marktwende)
- Method (3 Phasen: Diagnose, Aufbau, Skalieren + Übergabe)
- Results (E3-Proof als Methodik-Snapshot + Ergebnis-Liste)
- Guarantee (Risiko-Umkehr: Verrechnung, drei Hebel bei Abrat, Asset-Übergabe)
- FAQ (Hasims 8 Kernfragen, Accordion)
- Final-CTA (Sonnenfeld-Reim) + Sticky-Mobile-CTA

Alle primären CTAs zeigen auf /system-diagnose/ — der bestehende In-Page- Funnel mit Review-Form entfällt, weil die System-Diagnose dort als eigene React-Anwendung lebt. Inhalt (Pain-Punkte, E3-Metriken, FAQ, Schema.org) kommt vollständig aus dem bestehenden Canon, nur Form und Visual neu.