### PR TITLE
feat(solar): CRO-Sektionen aus Solar-Leadgen-CRO-Design importiert

### DIFF
--- a/blocksy-child/assets/css/solar-leadgenerierung-solara.css
+++ b/blocksy-child/assets/css/solar-leadgenerierung-solara.css
@@ -1527,3 +1527,882 @@ body.page-template-page-solar-waermepumpen-leadgenerierung-php .entry-header,
 body.page-template-page-solar-waermepumpen-leadgenerierung-php .ct-page-title {
   display: none !important;
 }
+
+/* ══════════════════════════════════════════════════════════════
+   CRO ADD-ON (2026-05-15) — Design-Import aus Solar Leadgen CRO
+   Neue Sektionen: Section-Nav · Compare · System-Diagramm ·
+   CAPEX vs OPEX · Fit-Check.
+   Stilistisch eingebettet in das warm-creme SOLARA-Vokabular
+   (kein dark-mode-Bruch zum Bestand).
+   ══════════════════════════════════════════════════════════════ */
+
+/* ── In-Page Section Nav · sticky unter dem globalen Header ───
+   Position-Top wird durch sol-hero.js gesetzt (CSS-Var --sol-nav-top),
+   sodass der Blocksy-Sticky-Header nicht den In-Page-Nav verdeckt.
+   Fallback ohne JS: top:0. */
+.solara-landing .sol-section-nav {
+  position: sticky;
+  top: var(--sol-nav-top, 0px);
+  z-index: 28;
+  background: oklch(0.97 0.008 80 / 0.92);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  border-bottom: 1px solid var(--sol-line);
+  font-size: 12px;
+}
+.solara-landing .sol-section-nav-inner {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 10px 0;
+}
+.solara-landing .sol-section-nav-label {
+  color: var(--sol-fg-dim);
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+.solara-landing .sol-section-nav-list {
+  display: flex;
+  gap: 4px;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  overflow-x: auto;
+  scrollbar-width: none;
+  -webkit-overflow-scrolling: touch;
+  flex: 1;
+  min-width: 0;
+}
+.solara-landing .sol-section-nav-list::-webkit-scrollbar { display: none; }
+.solara-landing .sol-section-nav-list a {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 10px;
+  border-radius: 999px;
+  color: var(--sol-fg-mute);
+  text-decoration: none;
+  font-size: 11px;
+  letter-spacing: 0.05em;
+  white-space: nowrap;
+  transition: color var(--sol-t-fast), background var(--sol-t-fast);
+}
+.solara-landing .sol-section-nav-list a:hover {
+  color: var(--sol-accent);
+  background: var(--sol-accent-tint);
+}
+.solara-landing .sol-section-nav-cta {
+  flex-shrink: 0;
+  padding: 8px 14px;
+  border-radius: 999px;
+  background: var(--sol-accent);
+  color: var(--sol-accent-ink);
+  text-decoration: none;
+  font-size: 11px;
+  letter-spacing: 0.05em;
+  font-weight: 600;
+  transition: background var(--sol-t-fast), transform var(--sol-t-fast);
+}
+.solara-landing .sol-section-nav-cta:hover {
+  background: var(--sol-accent-2);
+  transform: translateY(-1px);
+}
+@media (max-width: 720px) {
+  .solara-landing .sol-section-nav-label { display: none; }
+}
+
+/* ── Compare · Markt-Standard vs Eigener Weg ────────────────── */
+.solara-landing .sol-compare-h {
+  font-size: clamp(34px, 4.5vw, 64px);
+  margin: 12px 0 14px;
+  max-width: 22ch;
+}
+.solara-landing .sol-compare-sub {
+  margin: 0 0 44px;
+  color: var(--sol-fg-mute);
+  max-width: 60ch;
+  font-size: clamp(15px, 1.1vw, 18px);
+}
+.solara-landing .sol-compare {
+  display: grid;
+  grid-template-columns: 1fr 64px 1fr;
+  align-items: stretch;
+  border: 1px solid var(--sol-line);
+  border-radius: 20px;
+  overflow: hidden;
+  background: #fff;
+  position: relative;
+}
+.solara-landing .sol-compare-col {
+  padding: 36px 32px;
+  position: relative;
+}
+.solara-landing .sol-compare-col--bad {
+  background:
+    repeating-linear-gradient(135deg, transparent 0 18px, rgba(199,112,95,.03) 18px 19px),
+    linear-gradient(180deg, rgba(199,112,95,.05), transparent 60%);
+}
+.solara-landing .sol-compare-col--good {
+  background:
+    radial-gradient(ellipse 60% 50% at 50% 0%, var(--sol-accent-tint-2), transparent 70%),
+    linear-gradient(180deg, var(--sol-accent-tint), transparent 60%);
+  box-shadow: inset 0 0 0 1px var(--sol-accent-tint-2);
+}
+.solara-landing .sol-compare-tag {
+  position: absolute;
+  top: 18px;
+  right: 22px;
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  color: #c25a48;
+  opacity: 0.7;
+}
+.solara-landing .sol-compare-tag--good {
+  color: var(--sol-accent);
+  opacity: 1;
+  font-weight: 600;
+}
+.solara-landing .sol-compare-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 700;
+  font-size: 17px;
+  color: var(--sol-fg);
+  margin-bottom: 26px;
+  font-family: var(--sol-font-display);
+}
+.solara-landing .sol-compare-icon {
+  width: 30px;
+  height: 30px;
+  display: grid;
+  place-items: center;
+  border-radius: 8px;
+  font-weight: 700;
+  font-size: 14px;
+  flex-shrink: 0;
+}
+.solara-landing .sol-compare-icon--bad {
+  background: rgba(199,112,95,.18);
+  color: #c25a48;
+}
+.solara-landing .sol-compare-icon--good {
+  background: var(--sol-accent);
+  color: var(--sol-accent-ink);
+  box-shadow: 0 0 0 4px var(--sol-accent-tint);
+}
+.solara-landing .sol-compare-icon--good svg { width: 16px; height: 16px; }
+.solara-landing .sol-compare-row {
+  padding: 16px 0;
+  border-top: 1px solid var(--sol-line);
+}
+.solara-landing .sol-compare-row:first-of-type {
+  border-top: 0;
+  padding-top: 0;
+}
+.solara-landing .sol-compare-row-t {
+  font-weight: 600;
+  color: var(--sol-fg);
+  font-size: 16px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.solara-landing .sol-compare-row-t::before {
+  content: "";
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.solara-landing .sol-compare-col--bad .sol-compare-row-t::before { background: #c25a48; opacity: 0.7; }
+.solara-landing .sol-compare-col--good .sol-compare-row-t::before {
+  background: var(--sol-accent);
+  box-shadow: 0 0 0 3px var(--sol-accent-tint);
+}
+.solara-landing .sol-compare-row-d {
+  font-size: 14px;
+  color: var(--sol-fg-mute);
+  margin-top: 6px;
+  line-height: 1.55;
+  padding-left: 17px;
+}
+.solara-landing .sol-compare-divider {
+  background: var(--sol-bg-2);
+  display: grid;
+  place-items: center;
+  position: relative;
+}
+.solara-landing .sol-compare-divider::before {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: linear-gradient(180deg, transparent, var(--sol-accent), transparent);
+  opacity: 0.5;
+}
+.solara-landing .sol-compare-divider-icon {
+  position: relative;
+  z-index: 2;
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  background: var(--sol-bg-2);
+  display: grid;
+  place-items: center;
+  color: var(--sol-accent);
+  border: 1px solid var(--sol-line);
+}
+.solara-landing .sol-compare-divider-icon svg { width: 16px; height: 16px; }
+@media (max-width: 880px) {
+  .solara-landing .sol-compare {
+    grid-template-columns: 1fr;
+  }
+  .solara-landing .sol-compare-col--bad {
+    border-bottom: 1px solid var(--sol-line);
+  }
+  .solara-landing .sol-compare-divider { display: none; }
+}
+
+/* ── System-Diagramm: 4 Layer (Fundament → Skalierung) ──────── */
+.solara-landing .sol-system-section { padding-top: clamp(80px, 11vw, 160px); }
+.solara-landing .sol-system-head {
+  text-align: center;
+  max-width: 760px;
+  margin: 0 auto 56px;
+}
+.solara-landing .sol-system-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 16px;
+  border-radius: 999px;
+  background: var(--sol-accent-tint);
+  border: 1px solid var(--sol-accent-tint-2);
+  color: var(--sol-accent);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+}
+.solara-landing .sol-system-badge-pulse {
+  width: 8px;
+  height: 8px;
+  background: var(--sol-accent);
+  border-radius: 50%;
+  animation: sol-pulse-dot 2s ease-in-out infinite;
+}
+.solara-landing .sol-system-h {
+  font-size: clamp(34px, 4.5vw, 58px);
+  margin: 18px 0 14px;
+}
+.solara-landing .sol-system-sub {
+  color: var(--sol-fg-mute);
+  font-size: clamp(15px, 1.1vw, 18px);
+  margin: 0;
+  line-height: 1.6;
+}
+
+.solara-landing .sol-system-canvas {
+  max-width: 980px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+}
+.solara-landing .sol-system-layer {
+  position: relative;
+  background: #fff;
+  border: 1px solid var(--sol-line);
+  border-radius: 18px;
+  padding: 30px 32px;
+  transition: border-color var(--sol-t-med), box-shadow var(--sol-t-med), transform var(--sol-t-med);
+  opacity: 0;
+  transform: translateY(20px);
+  animation: sol-layer-in 0.7s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+  animation-delay: var(--sol-delay, 0s);
+}
+@keyframes sol-layer-in {
+  to { opacity: 1; transform: translateY(0); }
+}
+.solara-landing .sol-system-layer:hover {
+  border-color: var(--sol-accent-tint-2);
+  box-shadow: 0 20px 50px -30px rgba(180,106,60,.35);
+  transform: translateX(6px);
+}
+.solara-landing .sol-system-layer-head {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 22px;
+}
+.solara-landing .sol-system-layer-n {
+  width: 44px;
+  height: 44px;
+  background: linear-gradient(135deg, var(--sol-accent), var(--sol-accent-2));
+  color: var(--sol-accent-ink);
+  border-radius: 12px;
+  display: grid;
+  place-items: center;
+  font-size: 17px;
+  font-weight: 700;
+  flex-shrink: 0;
+  box-shadow: 0 6px 18px -8px rgba(180,106,60,.55);
+}
+.solara-landing .sol-system-layer-name {
+  flex: 1;
+  font-family: var(--sol-font-display);
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--sol-fg);
+  letter-spacing: -0.01em;
+}
+.solara-landing .sol-system-layer-status {
+  padding: 5px 11px;
+  border: 1px solid var(--sol-line);
+  border-radius: 6px;
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  color: var(--sol-fg-dim);
+}
+.solara-landing .sol-system-layer:hover .sol-system-layer-status {
+  color: var(--sol-accent);
+  border-color: var(--sol-accent-tint-2);
+  background: var(--sol-accent-tint);
+}
+.solara-landing .sol-system-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 14px;
+}
+.solara-landing .sol-system-layer.is-three .sol-system-grid {
+  grid-template-columns: repeat(3, 1fr);
+}
+.solara-landing .sol-system-comp {
+  display: flex;
+  gap: 14px;
+  align-items: flex-start;
+  padding: 16px;
+  background: var(--sol-bg-2);
+  border: 1px solid var(--sol-line);
+  border-radius: 12px;
+  transition: background var(--sol-t-fast), border-color var(--sol-t-fast), transform var(--sol-t-fast);
+}
+.solara-landing .sol-system-comp:hover {
+  background: var(--sol-accent-tint);
+  border-color: var(--sol-accent-tint-2);
+  transform: translateY(-2px);
+}
+.solara-landing .sol-system-comp-icon {
+  width: 38px;
+  height: 38px;
+  border-radius: 10px;
+  background: #fff;
+  border: 1px solid var(--sol-line);
+  display: grid;
+  place-items: center;
+  color: var(--sol-accent);
+  flex-shrink: 0;
+}
+.solara-landing .sol-system-comp-icon svg { width: 18px; height: 18px; }
+.solara-landing .sol-system-comp-body { flex: 1; min-width: 0; }
+.solara-landing .sol-system-comp-t {
+  font-weight: 600;
+  font-size: 15px;
+  color: var(--sol-fg);
+  line-height: 1.3;
+}
+.solara-landing .sol-system-comp-s {
+  margin-top: 4px;
+  font-size: 13px;
+  color: var(--sol-fg-mute);
+  line-height: 1.5;
+}
+.solara-landing .sol-system-layer-connector {
+  position: absolute;
+  left: 50%;
+  bottom: -22px;
+  transform: translateX(-50%);
+  width: 2px;
+  height: 22px;
+  background: linear-gradient(180deg, var(--sol-accent), transparent);
+  border-radius: 1px;
+  pointer-events: none;
+}
+.solara-landing .sol-system-ownership {
+  display: flex;
+  gap: 22px;
+  align-items: flex-start;
+  max-width: 980px;
+  margin: 36px auto 0;
+  padding: 26px 30px;
+  background: linear-gradient(135deg, var(--sol-accent-tint-2), var(--sol-accent-tint));
+  border: 1px solid var(--sol-accent-tint-2);
+  border-radius: 16px;
+}
+.solara-landing .sol-system-ownership-mark {
+  width: 50px;
+  height: 50px;
+  background: var(--sol-accent);
+  color: var(--sol-accent-ink);
+  border-radius: 12px;
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+  box-shadow: 0 10px 24px -10px rgba(180,106,60,.5);
+}
+.solara-landing .sol-system-ownership-mark svg { width: 22px; height: 22px; }
+.solara-landing .sol-system-ownership-t {
+  font-family: var(--sol-font-display);
+  font-weight: 700;
+  font-size: 18px;
+  color: var(--sol-fg);
+  margin-bottom: 6px;
+}
+.solara-landing .sol-system-ownership-s {
+  font-size: 14px;
+  color: var(--sol-fg-mute);
+  line-height: 1.6;
+}
+@media (max-width: 720px) {
+  .solara-landing .sol-system-grid,
+  .solara-landing .sol-system-layer.is-three .sol-system-grid {
+    grid-template-columns: 1fr;
+  }
+  .solara-landing .sol-system-layer { padding: 22px; }
+  .solara-landing .sol-system-ownership { padding: 22px; flex-direction: column; gap: 14px; }
+}
+
+/* ── CAPEX vs OPEX · Bilanz-Vergleich mit Timeframe-Picker ──── */
+.solara-landing .sol-capex-head {
+  max-width: 760px;
+  margin: 0 0 40px;
+}
+.solara-landing .sol-capex-h {
+  font-size: clamp(34px, 4.5vw, 64px);
+  margin: 14px 0 14px;
+  max-width: 18ch;
+}
+.solara-landing .sol-capex-sub {
+  margin: 0;
+  color: var(--sol-fg-mute);
+  font-size: clamp(15px, 1.1vw, 18px);
+  max-width: 60ch;
+}
+.solara-landing .sol-capex-picker {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 18px;
+  margin-bottom: 36px;
+  flex-wrap: wrap;
+}
+.solara-landing .sol-capex-picker-label {
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  color: var(--sol-fg-dim);
+}
+.solara-landing .sol-capex-picker-buttons {
+  display: inline-flex;
+  gap: 4px;
+  padding: 4px;
+  background: var(--sol-bg-3);
+  border: 1px solid var(--sol-line);
+  border-radius: 12px;
+}
+.solara-landing .sol-capex-picker-btn {
+  appearance: none;
+  border: 1px solid transparent;
+  padding: 10px 18px;
+  border-radius: 9px;
+  background: transparent;
+  font-family: var(--sol-font-body);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--sol-fg);
+  cursor: pointer;
+  transition: background var(--sol-t-fast), color var(--sol-t-fast), box-shadow var(--sol-t-fast);
+}
+.solara-landing .sol-capex-picker-btn:hover { background: var(--sol-bg-2); }
+.solara-landing .sol-capex-picker-btn.is-active {
+  background: #fff;
+  border-color: var(--sol-accent-tint-2);
+  color: var(--sol-accent);
+  box-shadow: 0 2px 8px -2px rgba(0,0,0,.08);
+}
+
+.solara-landing .sol-capex-compare {
+  display: grid;
+  grid-template-columns: 1fr 56px 1fr;
+  gap: 0;
+  align-items: stretch;
+  margin-bottom: 36px;
+}
+.solara-landing .sol-capex-col {
+  background: #fff;
+  border-radius: 20px;
+  padding: 36px 32px;
+  border: 2px solid transparent;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+.solara-landing .sol-capex-col--opex {
+  border-color: rgba(199,112,95,.45);
+  background: linear-gradient(180deg, rgba(199,112,95,.05), #fff);
+}
+.solara-landing .sol-capex-col--capex {
+  border-color: var(--sol-accent-tint-2);
+  background: linear-gradient(180deg, var(--sol-accent-tint), #fff);
+  box-shadow: 0 18px 50px -30px rgba(180,106,60,.4);
+}
+.solara-landing .sol-capex-col-head { margin-bottom: 4px; }
+.solara-landing .sol-capex-col-badge {
+  display: inline-block;
+  padding: 5px 13px;
+  border-radius: 999px;
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  font-weight: 600;
+  margin-bottom: 14px;
+}
+.solara-landing .sol-capex-col-badge--opex {
+  background: rgba(199,112,95,.15);
+  color: #c25a48;
+}
+.solara-landing .sol-capex-col-badge--capex {
+  background: var(--sol-accent-tint-2);
+  color: var(--sol-accent);
+}
+.solara-landing .sol-capex-col-title {
+  font-family: var(--sol-font-display);
+  font-size: clamp(22px, 2.2vw, 28px);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin: 0 0 6px;
+  color: var(--sol-fg);
+}
+.solara-landing .sol-capex-col-sub {
+  color: var(--sol-fg-mute);
+  font-size: 15px;
+  margin: 0;
+}
+.solara-landing .sol-capex-breakdown {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding-bottom: 18px;
+  border-bottom: 1px solid var(--sol-line);
+}
+.solara-landing .sol-capex-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 14px;
+  padding: 12px 14px;
+  background: var(--sol-bg-2);
+  border: 1px solid var(--sol-line);
+  border-radius: 10px;
+}
+.solara-landing .sol-capex-row--issue {
+  background: rgba(199,112,95,.06);
+  border-color: rgba(199,112,95,.22);
+}
+.solara-landing .sol-capex-row--benefit {
+  background: var(--sol-accent-tint);
+  border-color: var(--sol-accent-tint-2);
+}
+.solara-landing .sol-capex-row-l {
+  font-size: 14px;
+  color: var(--sol-fg-mute);
+  flex: 1;
+}
+.solara-landing .sol-capex-row-v {
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--sol-fg);
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+.solara-landing .sol-capex-total {
+  background: var(--sol-fg);
+  color: #fff;
+  border-radius: 12px;
+  padding: 18px 20px;
+}
+.solara-landing .sol-capex-total-l {
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  color: oklch(0.78 0.014 60);
+  margin-bottom: 6px;
+}
+.solara-landing .sol-capex-total-v {
+  font-size: clamp(28px, 3.4vw, 40px);
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+.solara-landing .sol-capex-total-v--opex { color: #e6a394; }
+.solara-landing .sol-capex-total-v--capex { color: var(--sol-accent); }
+.solara-landing .sol-capex-result {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 16px 18px;
+  border-radius: 12px;
+  background: rgba(199,112,95,.08);
+  border: 1px solid rgba(199,112,95,.25);
+}
+.solara-landing .sol-capex-result--good {
+  background: var(--sol-accent-tint);
+  border-color: var(--sol-accent-tint-2);
+}
+.solara-landing .sol-capex-result-icon {
+  width: 38px;
+  height: 38px;
+  border-radius: 10px;
+  display: grid;
+  place-items: center;
+  font-size: 16px;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+.solara-landing .sol-capex-result-icon--bad {
+  background: rgba(199,112,95,.18);
+  color: #c25a48;
+}
+.solara-landing .sol-capex-result-icon--good {
+  background: var(--sol-accent);
+  color: var(--sol-accent-ink);
+}
+.solara-landing .sol-capex-result-icon--good svg { width: 18px; height: 18px; }
+.solara-landing .sol-capex-result-body strong {
+  display: block;
+  font-weight: 700;
+  font-size: 16px;
+  color: var(--sol-fg);
+  margin-bottom: 2px;
+}
+.solara-landing .sol-capex-result-body span {
+  font-size: 13px;
+  color: var(--sol-fg-mute);
+}
+.solara-landing .sol-capex-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.solara-landing .sol-capex-list li {
+  display: flex;
+  gap: 10px;
+  font-size: 14px;
+  color: var(--sol-fg);
+  line-height: 1.55;
+}
+.solara-landing .sol-capex-list-x,
+.solara-landing .sol-capex-list-v {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-size: 11px;
+  font-weight: 700;
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+.solara-landing .sol-capex-list-x {
+  background: rgba(199,112,95,.18);
+  color: #c25a48;
+}
+.solara-landing .sol-capex-list-v {
+  background: var(--sol-accent-tint-2);
+  color: var(--sol-accent);
+}
+
+.solara-landing .sol-capex-divider {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+}
+.solara-landing .sol-capex-divider-line {
+  width: 1px;
+  flex: 1;
+  background: linear-gradient(180deg, transparent, var(--sol-line-2), transparent);
+}
+.solara-landing .sol-capex-divider-tag {
+  padding: 8px 14px;
+  background: var(--sol-fg);
+  color: var(--sol-accent);
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+}
+
+.solara-landing .sol-capex-summary {
+  background: var(--sol-fg);
+  color: oklch(0.92 0.014 60);
+  border-radius: 18px;
+  padding: 32px 36px;
+  margin-bottom: 32px;
+}
+.solara-landing .sol-capex-summary-h {
+  font-family: var(--sol-font-display);
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--sol-accent);
+  margin: 0 0 12px;
+}
+.solara-landing .sol-capex-summary p {
+  margin: 0;
+  font-size: 15px;
+  line-height: 1.7;
+  max-width: 72ch;
+}
+.solara-landing .sol-capex-summary strong {
+  color: #fff;
+  font-weight: 600;
+}
+.solara-landing .sol-capex-cta {
+  text-align: center;
+}
+.solara-landing .sol-capex-cta-micro {
+  margin-top: 14px;
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  color: var(--sol-fg-dim);
+}
+@media (max-width: 920px) {
+  .solara-landing .sol-capex-compare {
+    grid-template-columns: 1fr;
+    gap: 22px;
+  }
+  .solara-landing .sol-capex-divider {
+    flex-direction: row;
+    width: 100%;
+  }
+  .solara-landing .sol-capex-divider-line {
+    width: auto;
+    flex: 1;
+    height: 1px;
+    background: linear-gradient(90deg, transparent, var(--sol-line-2), transparent);
+  }
+}
+@media (max-width: 560px) {
+  .solara-landing .sol-capex-col { padding: 26px 22px; }
+  .solara-landing .sol-capex-summary { padding: 24px 22px; }
+}
+
+/* ── Fit-Check (passt / passt nicht) ────────────────────────── */
+.solara-landing .sol-fit-section { padding-top: clamp(80px, 11vw, 160px); }
+.solara-landing .sol-fit-head {
+  text-align: center;
+  max-width: 720px;
+  margin: 0 auto 48px;
+}
+.solara-landing .sol-fit-head .sol-eyebrow { justify-content: center; }
+.solara-landing .sol-fit-h {
+  font-size: clamp(34px, 4.5vw, 58px);
+  margin: 16px 0 12px;
+}
+.solara-landing .sol-fit-sub {
+  color: var(--sol-fg-mute);
+  font-size: clamp(15px, 1.1vw, 18px);
+  margin: 0;
+}
+.solara-landing .sol-fit-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 22px;
+}
+.solara-landing .sol-fit-col {
+  background: #fff;
+  border: 1px solid var(--sol-line);
+  border-radius: 16px;
+  padding: 30px;
+}
+.solara-landing .sol-fit-col--yes { border-top: 3px solid var(--sol-accent); }
+.solara-landing .sol-fit-col--no  { border-top: 3px solid #c25a48; background: var(--sol-bg-warm); }
+.solara-landing .sol-fit-col-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-family: var(--sol-font-display);
+  font-weight: 700;
+  font-size: 18px;
+  color: var(--sol-fg);
+  margin-bottom: 22px;
+}
+.solara-landing .sol-fit-col-badge {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+  font-size: 14px;
+  font-weight: 700;
+}
+.solara-landing .sol-fit-col-badge--yes {
+  background: var(--sol-accent);
+  color: var(--sol-accent-ink);
+}
+.solara-landing .sol-fit-col-badge--yes svg { width: 16px; height: 16px; }
+.solara-landing .sol-fit-col-badge--no {
+  background: #c25a48;
+  color: #fff;
+}
+.solara-landing .sol-fit-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.solara-landing .sol-fit-list li {
+  padding: 14px 0;
+  border-top: 1px solid var(--sol-line);
+}
+.solara-landing .sol-fit-list li:first-child {
+  border-top: 0;
+  padding-top: 0;
+}
+.solara-landing .sol-fit-list-t {
+  font-weight: 600;
+  color: var(--sol-fg);
+  font-size: 15px;
+}
+.solara-landing .sol-fit-list-d {
+  margin-top: 4px;
+  color: var(--sol-fg-mute);
+  font-size: 13px;
+  line-height: 1.55;
+}
+.solara-landing .sol-fit-cta {
+  text-align: center;
+  margin-top: 40px;
+}
+.solara-landing .sol-fit-cta-micro {
+  margin-top: 14px;
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  color: var(--sol-fg-dim);
+}
+@media (max-width: 880px) {
+  .solara-landing .sol-fit-grid { grid-template-columns: 1fr; }
+}
+
+/* ── Reduced-Motion · neue Sektionen ─────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .solara-landing .sol-system-layer {
+    animation: none !important;
+    opacity: 1;
+    transform: none;
+  }
+  .solara-landing .sol-system-badge-pulse { animation: none !important; }
+}

--- a/blocksy-child/assets/js/solar-leadgenerierung-solara.js
+++ b/blocksy-child/assets/js/solar-leadgenerierung-solara.js
@@ -595,11 +595,113 @@
     }
   }
 
+  /* CAPEX vs OPEX · Timeframe-Picker.
+     Tauscht alle [data-sol-capex-out="key"] gegen die passende Zahl
+     für 12/24/36 Monate. Suffixe (" / Monat", " Stück") bleiben aus
+     dem statischen Markup erhalten. */
+  var CAPEX_DATA = {
+    12: {
+      portal_monthly: '~ 1.080 €',
+      portal_leads:   '~ 160',
+      portal_total:   '13.000 €',
+      portal_total2:  '13.000 €',
+      own_setup:      '12.000 – 18.000 €',
+      own_monthly:    '~ 50 €',
+      own_total:      '12.600 – 18.600 €',
+      own_total2:     '12.600 – 18.600 €'
+    },
+    24: {
+      portal_monthly: '~ 1.080 €',
+      portal_leads:   '~ 320',
+      portal_total:   '26.000 €',
+      portal_total2:  '26.000 €',
+      own_setup:      '12.000 – 18.000 €',
+      own_monthly:    '~ 50 €',
+      own_total:      '13.200 – 19.200 €',
+      own_total2:     '13.200 – 19.200 €'
+    },
+    36: {
+      portal_monthly: '~ 1.080 €',
+      portal_leads:   '~ 480',
+      portal_total:   '39.000 €',
+      portal_total2:  '39.000 €',
+      own_setup:      '12.000 – 18.000 €',
+      own_monthly:    '~ 50 €',
+      own_total:      '14.160 – 20.160 €',
+      own_total2:     '14.160 – 20.160 €'
+    }
+  };
+  var CAPEX_SUFFIX = {
+    portal_monthly: ' / Monat',
+    portal_leads:   ' Stück',
+    own_monthly:    ' / Monat'
+  };
+
+  function setupCapexPicker() {
+    var section = document.querySelector(ROOT_SELECTOR + ' [data-sol-capex-buttons]');
+    if (!section) return;
+    var btns = section.querySelectorAll('[data-sol-capex-tf]');
+    if (!btns.length) return;
+
+    function apply(tf) {
+      var data = CAPEX_DATA[tf];
+      if (!data) return;
+      btns.forEach(function (b) {
+        var on = String(b.getAttribute('data-sol-capex-tf')) === String(tf);
+        b.classList.toggle('is-active', on);
+        b.setAttribute('aria-selected', on ? 'true' : 'false');
+      });
+      var outs = document.querySelectorAll(ROOT_SELECTOR + ' [data-sol-capex-out]');
+      outs.forEach(function (el) {
+        var key = el.getAttribute('data-sol-capex-out');
+        if (key === 'tf' || key === 'tf2' || key === 'tf3' || key === 'tf4') {
+          el.textContent = String(tf);
+          return;
+        }
+        if (Object.prototype.hasOwnProperty.call(data, key)) {
+          el.textContent = data[key] + (CAPEX_SUFFIX[key] || '');
+        }
+      });
+    }
+
+    btns.forEach(function (b) {
+      b.addEventListener('click', function () {
+        var tf = b.getAttribute('data-sol-capex-tf');
+        apply(tf);
+        try { track('capex_timeframe_change', { tf: tf }); } catch (e) {}
+      });
+    });
+  }
+
+  /* Setzt --sol-nav-top auf die Höhe eines sticky Blocksy-Headers,
+     damit unsere In-Page-Section-Nav darunter andockt. Stiller no-op,
+     wenn kein sticky Header existiert. */
+  function setupSectionNavOffset() {
+    var landing = document.querySelector(ROOT_SELECTOR);
+    if (!landing) return;
+    var header = document.querySelector('header.ct-header, [data-header*="sticky"], #header, .ct-sticky-container');
+    function apply() {
+      var h = 0;
+      if (header) {
+        var rect = header.getBoundingClientRect();
+        var cs = window.getComputedStyle(header);
+        var isSticky = (cs.position === 'sticky' || cs.position === 'fixed') && rect.top <= 1;
+        if (isSticky) h = Math.round(rect.height);
+      }
+      landing.style.setProperty('--sol-nav-top', h + 'px');
+    }
+    apply();
+    window.addEventListener('resize', apply, { passive: true });
+    window.addEventListener('scroll', apply, { passive: true });
+  }
+
   ready(function () {
     mountSunRays();
     setupFaq();
     setupStickyCta();
     setupScrollAnchor();
     setupQuiz();
+    setupCapexPicker();
+    setupSectionNavOffset();
   });
 })();

--- a/blocksy-child/page-solar-waermepumpen-leadgenerierung.php
+++ b/blocksy-child/page-solar-waermepumpen-leadgenerierung.php
@@ -117,6 +117,121 @@ $guarantee_points = [
 	],
 ];
 
+// ── Sticky In-Page Section Nav (CRO: orientation + jump to relevant block) ─────
+$section_nav = [
+	[ 'h' => '#problem',     'l' => 'Status quo' ],
+	[ 'h' => '#vergleich',   'l' => 'Vergleich' ],
+	[ 'h' => '#system-bild', 'l' => 'System' ],
+	[ 'h' => '#capex',       'l' => 'CAPEX vs OPEX' ],
+	[ 'h' => '#ergebnisse',  'l' => 'Referenz' ],
+	[ 'h' => '#fit',         'l' => 'Passt es?' ],
+	[ 'h' => '#faq',         'l' => 'FAQ' ],
+];
+
+// ── Markt-Standard vs Eigener Weg (Compare-Section) ───────────────────────────
+$compare_bad = [
+	[ 't' => 'Portal-Leads',      's' => 'Drei Wettbewerber bekommen dieselbe Anfrage. Sie bieten gegen den Preis.' ],
+	[ 't' => 'Klickberichte',     's' => 'Reportings über Impressionen — nicht über Projektwert.' ],
+	[ 't' => '5-Felder-Formular', 's' => 'Verliert Interessenten, bevor sie qualifiziert sind.' ],
+	[ 't' => 'Black-Box-Agentur', 's' => 'Niemand weiß, woher die nächste Anfrage kommt — oder warum sie ausbleibt.' ],
+];
+$compare_good = [
+	[ 't' => 'Eigene Anfragestrecke',    's' => 'Anfragen, die Ihrem Betrieb gehören — nicht dem Portal.' ],
+	[ 't' => 'Anfragequalität messbar',  's' => 'Region, Heizart, Dach, Projektwert — vor dem Anruf.' ],
+	[ 't' => '60-Sek-Vorqualifizierung', 's' => 'Daten erst, wenn der Fit klar ist. Kein 5-Felder-Hürdenlauf.' ],
+	[ 't' => 'Dokumentiertes System',    's' => 'Sie verstehen, warum es funktioniert. Code, Tracking, Daten bleiben bei Ihnen.' ],
+];
+
+// ── System-Diagramm: 4 Layer · was Kunden konkret bekommen ─────────────────────
+$system_layers = [
+	[
+		'n'      => '01',
+		'name'   => 'Fundament',
+		'status' => 'DSGVO · Frankfurt',
+		'cols'   => 2,
+		'items'  => [
+			[ 'i' => 'M3 12l9-9 9 9M5 10v10h14V10', 't' => 'WordPress hardcoded',  's' => 'Kein Page-Builder, kein Plugin-Stack.' ],
+			[ 'i' => 'M3 5h18v12H3zM3 21h18',       't' => 'Frankfurt-Server',     's' => 'DSGVO-konform · eigenes Hosting.' ],
+		],
+	],
+	[
+		'n'      => '02',
+		'name'   => 'Daten & Tracking',
+		'status' => 'Server-Side · CAPI',
+		'cols'   => 2,
+		'items'  => [
+			[ 'i' => 'M4 19V5m0 14h16m-12-7v7m4-12v12m4-9v9', 't' => 'Server-Side Tracking', 's' => 'GA4 · CAPI · eigener Container.' ],
+			[ 'i' => 'M10 14l4-4m-7-3a5 5 0 017-7l3 3m1 11a5 5 0 01-7 7l-3-3', 't' => 'Saubere Attribution', 's' => 'Welcher Kanal bringt zahlende Aufträge?' ],
+		],
+	],
+	[
+		'n'      => '03',
+		'name'   => 'Conversion-Pfad',
+		'status' => 'Vorqualifizierung · Score',
+		'cols'   => 3,
+		'items'  => [
+			[ 'i' => 'M12 2l3 7h7l-5.5 4.5L18 21l-6-4-6 4 1.5-7.5L2 9h7z', 't' => 'Money Page',           's' => 'Solar/WP-spezifisch · Proof.' ],
+			[ 'i' => 'M13 2L4 14h7v8l9-12h-7z',                              't' => '60-Sek-Qualifizierung', 's' => 'Region · Heizart · Projektwert.' ],
+			[ 'i' => 'M12 2l3.09 6.26L22 9.27l-5 4.87L18.18 22 12 18.27 5.82 22 7 14.14l-5-4.87 6.91-1.01z', 't' => 'Lead-Scoring', 's' => 'Grün, gelb, rot — vor dem Anruf.' ],
+		],
+	],
+	[
+		'n'      => '04',
+		'name'   => 'Skalierung',
+		'status' => 'Multi-Channel · messbar',
+		'cols'   => 3,
+		'items'  => [
+			[ 'i' => 'M11 4a7 7 0 100 14 7 7 0 000-14zM21 21l-5.2-5.2', 't' => 'Google Ads', 's' => 'Lokal · hoher Intent.' ],
+			[ 'i' => 'M7 2h10a2 2 0 012 2v16a2 2 0 01-2 2H7a2 2 0 01-2-2V4a2 2 0 012-2zm5 17v.01', 't' => 'Meta Ads', 's' => 'Facebook · Instagram · Retargeting.' ],
+			[ 'i' => 'M12 2a10 10 0 100 20 10 10 0 000-20zM2 12h20M12 2a15.3 15.3 0 010 20m0-20a15.3 15.3 0 000 20', 't' => 'SEO-Anteil', 's' => 'Basis-Optimierung · Indexierung.' ],
+		],
+	],
+];
+
+// ── CAPEX vs OPEX · Zahlen aus dem messaging-canon ─────────────────────────────
+$capex_timeframes = [
+	12 => [
+		'portal_monthly' => '~ 1.080 €',
+		'portal_leads'   => '~ 160',
+		'portal_total'   => '13.000 €',
+		'own_setup'      => '12.000 – 18.000 €',
+		'own_monthly'    => '~ 50 €',
+		'own_total'      => '12.600 – 18.600 €',
+	],
+	24 => [
+		'portal_monthly' => '~ 1.080 €',
+		'portal_leads'   => '~ 320',
+		'portal_total'   => '26.000 €',
+		'own_setup'      => '12.000 – 18.000 €',
+		'own_monthly'    => '~ 50 €',
+		'own_total'      => '13.200 – 19.200 €',
+	],
+	36 => [
+		'portal_monthly' => '~ 1.080 €',
+		'portal_leads'   => '~ 480',
+		'portal_total'   => '39.000 €',
+		'own_setup'      => '12.000 – 18.000 €',
+		'own_monthly'    => '~ 50 €',
+		'own_total'      => '14.160 – 20.160 €',
+	],
+];
+$capex_default = 24;
+
+// ── Fit-Check (passt / passt nicht) ────────────────────────────────────────────
+$fit_yes = [
+	[ 't' => 'Solar oder Wärmepumpe im DACH-Mittelstand', 's' => 'Mit eigenem Vertrieb, nicht reine Vermittlung.' ],
+	[ 't' => 'Klares Zielgebiet',                          's' => 'Region oder Bundesland definiert — kein „bundesweit, alles".' ],
+	[ 't' => 'Hohe Projektwerte',                          's' => 'B2C ab ~ 15 k €, B2B ab ~ 50 k € pro Projekt.' ],
+	[ 't' => 'Geschäftsführung entscheidet',               's' => 'Über Aufbau, Marke und Positionierung — kurze Wege.' ],
+	[ 't' => '24-Monate-Horizont',                         's' => 'Bereit, ein Asset aufzubauen statt nur Anfragen einzukaufen.' ],
+];
+$fit_no = [
+	[ 't' => 'Reines Vermittlungsgeschäft',                's' => 'Wer Leads weiterverkauft, braucht kein eigenes System.' ],
+	[ 't' => '„Nächste Woche brauchen wir Leads."',        's' => 'Tragfähige Pipelines wachsen über Monate, nicht Tage.' ],
+	[ 't' => 'Kein Vertrieb am Telefon',                   's' => 'Anfragen sterben, wenn niemand zurückruft.' ],
+	[ 't' => 'Keine Marke gewollt',                        's' => 'Eigener Anfrageweg lebt davon, dass Sie sichtbar werden.' ],
+];
+
 $faq_items = [
 	[
 		'question' => 'Was passiert nach dem Marktcheck?',
@@ -325,6 +440,33 @@ get_header();
 		</section>
 
 		<!-- ════════════════════════════════════════════════════════════
+		     STICKY IN-PAGE SECTION NAV
+		     Wird nach dem Hero sticky · CRO: schnelle Orientierung,
+		     ohne den globalen Header zu ersetzen (SEO/Brand bleibt).
+		     ════════════════════════════════════════════════════════════ -->
+		<nav class="sol-section-nav" aria-label="Sektionen dieser Seite" data-track-section="section_nav">
+			<div class="sol-wrap">
+				<div class="sol-section-nav-inner">
+					<span class="sol-section-nav-label sol-mono" aria-hidden="true">Auf dieser Seite</span>
+					<ul class="sol-section-nav-list">
+						<?php foreach ( $section_nav as $n ) : ?>
+							<li><a href="<?php echo esc_attr( $n['h'] ); ?>" class="sol-mono"
+								data-track-action="section_nav_jump"
+								data-track-category="navigation"
+								data-track-section="section_nav"
+							><?php echo esc_html( $n['l'] ); ?></a></li>
+						<?php endforeach; ?>
+					</ul>
+					<a class="sol-section-nav-cta sol-mono" href="#marktcheck"
+						data-track-action="cta_solar_section_nav_to_marktcheck"
+						data-track-category="lead_funnel"
+						data-track-section="section_nav"
+					>Marktcheck →</a>
+				</div>
+			</div>
+		</nav>
+
+		<!-- ════════════════════════════════════════════════════════════
 		     PROBLEM
 		     ════════════════════════════════════════════════════════════ -->
 		<section class="sol-section" id="problem" data-track-section="problem">
@@ -341,6 +483,117 @@ get_header();
 							<p class="sol-problem-card-s"><?php echo esc_html( $c['s'] ); ?></p>
 						</article>
 					<?php endforeach; ?>
+				</div>
+			</div>
+		</section>
+
+		<!-- ════════════════════════════════════════════════════════════
+		     COMPARE — Markt-Standard vs Eigener Weg
+		     Konturiert die strategische Alternative zum Status quo.
+		     ════════════════════════════════════════════════════════════ -->
+		<section class="sol-section sol-compare-section" id="vergleich" data-track-section="compare">
+			<div class="sol-wrap">
+				<div class="sol-eyebrow">Markt vs Eigener Weg</div>
+				<h2 class="sol-display sol-compare-h">
+					Sie kaufen keine Leads mehr. Sie bauen <em>den Weg</em>, auf dem sie entstehen.
+				</h2>
+				<p class="sol-compare-sub">
+					Der Ausweg ist nicht ein besseres Portal. Es ist ein Anfrageweg, der Ihnen gehört — und sich messen lässt.
+				</p>
+
+				<div class="sol-compare">
+					<div class="sol-compare-col sol-compare-col--bad">
+						<div class="sol-compare-tag sol-mono" aria-hidden="true">Aktuell · kostet</div>
+						<div class="sol-compare-head">
+							<span class="sol-compare-icon sol-compare-icon--bad" aria-hidden="true">✕</span>
+							<span>Markt-Standard</span>
+						</div>
+						<?php foreach ( $compare_bad as $row ) : ?>
+							<div class="sol-compare-row">
+								<div class="sol-compare-row-t"><?php echo esc_html( $row['t'] ); ?></div>
+								<div class="sol-compare-row-d"><?php echo esc_html( $row['s'] ); ?></div>
+							</div>
+						<?php endforeach; ?>
+					</div>
+
+					<div class="sol-compare-divider" aria-hidden="true">
+						<span class="sol-compare-divider-icon"><?php echo $arrow_svg; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></span>
+					</div>
+
+					<div class="sol-compare-col sol-compare-col--good">
+						<div class="sol-compare-tag sol-mono sol-compare-tag--good" aria-hidden="true">Empfohlen · bleibt</div>
+						<div class="sol-compare-head">
+							<span class="sol-compare-icon sol-compare-icon--good" aria-hidden="true">
+								<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12l5 5L20 7"/></svg>
+							</span>
+							<span>Eigener Weg</span>
+						</div>
+						<?php foreach ( $compare_good as $row ) : ?>
+							<div class="sol-compare-row">
+								<div class="sol-compare-row-t"><?php echo esc_html( $row['t'] ); ?></div>
+								<div class="sol-compare-row-d"><?php echo esc_html( $row['s'] ); ?></div>
+							</div>
+						<?php endforeach; ?>
+					</div>
+				</div>
+			</div>
+		</section>
+
+		<!-- ════════════════════════════════════════════════════════════
+		     SYSTEM-DIAGRAMM — 4 Layer · was Kunden konkret bekommen
+		     "Ihr eigenes System — was Sie genau bekommen"
+		     ════════════════════════════════════════════════════════════ -->
+		<section class="sol-section sol-section--tinted sol-system-section" id="system-bild" data-track-section="system_diagram">
+			<div class="sol-wrap">
+				<div class="sol-system-head">
+					<span class="sol-system-badge sol-mono">
+						<span class="sol-system-badge-pulse" aria-hidden="true"></span>
+						Ihr eigenes System
+					</span>
+					<h2 class="sol-display sol-system-h">
+						Was Sie <em>genau</em> bekommen.
+					</h2>
+					<p class="sol-system-sub">
+						Kein Blackbox-Setup. Jede Komponente ist dokumentiert, gehört Ihnen und wird 1:1 übergeben — inklusive Zugang zu allen Accounts.
+					</p>
+				</div>
+
+				<div class="sol-system-canvas">
+					<?php foreach ( $system_layers as $layer_index => $layer ) : ?>
+						<article class="sol-system-layer<?php echo 3 === $layer['cols'] ? ' is-three' : ''; ?>" style="--sol-delay:<?php echo (float) ( $layer_index * 0.12 ); ?>s;">
+							<header class="sol-system-layer-head">
+								<div class="sol-system-layer-n sol-display"><?php echo esc_html( $layer['n'] ); ?></div>
+								<div class="sol-system-layer-name"><?php echo esc_html( $layer['name'] ); ?></div>
+								<div class="sol-system-layer-status sol-mono"><?php echo esc_html( $layer['status'] ); ?></div>
+							</header>
+							<div class="sol-system-grid">
+								<?php foreach ( $layer['items'] as $item ) : ?>
+									<div class="sol-system-comp">
+										<span class="sol-system-comp-icon" aria-hidden="true">
+											<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" focusable="false"><path d="<?php echo esc_attr( $item['i'] ); ?>"/></svg>
+										</span>
+										<div class="sol-system-comp-body">
+											<div class="sol-system-comp-t"><?php echo esc_html( $item['t'] ); ?></div>
+											<div class="sol-system-comp-s"><?php echo esc_html( $item['s'] ); ?></div>
+										</div>
+									</div>
+								<?php endforeach; ?>
+							</div>
+							<?php if ( $layer_index < count( $system_layers ) - 1 ) : ?>
+								<div class="sol-system-layer-connector" aria-hidden="true"></div>
+							<?php endif; ?>
+						</article>
+					<?php endforeach; ?>
+				</div>
+
+				<div class="sol-system-ownership" role="note">
+					<div class="sol-system-ownership-mark" aria-hidden="true">
+						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" focusable="false"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+					</div>
+					<div class="sol-system-ownership-body">
+						<div class="sol-system-ownership-t">100 % Asset-Eigentum</div>
+						<div class="sol-system-ownership-s">Code, Tracking-Accounts, Server-Zugang, Datenhoheit — alles dokumentiert übergeben. Das System bleibt bei Ihnen, auch wenn die Zusammenarbeit endet.</div>
+					</div>
 				</div>
 			</div>
 		</section>
@@ -372,6 +625,163 @@ get_header();
 							</ul>
 						</article>
 					<?php endforeach; ?>
+				</div>
+			</div>
+		</section>
+
+		<!-- ════════════════════════════════════════════════════════════
+		     CAPEX vs OPEX — Bilanzielle Entscheidung
+		     Interaktiver Zeitraum-Picker (12 · 24 · 36 Monate).
+		     ════════════════════════════════════════════════════════════ -->
+		<section class="sol-section sol-capex-section" id="capex" data-track-section="capex_opex">
+			<div class="sol-wrap">
+				<div class="sol-capex-head">
+					<div class="sol-eyebrow">CAPEX statt OPEX</div>
+					<h2 class="sol-display sol-capex-h">
+						Mieten oder besitzen. Eine <em>Bilanz-Entscheidung</em>.
+					</h2>
+					<p class="sol-capex-sub">
+						Beide Wege kosten Geld. Nur einer hinterlässt am Ende ein Asset, das Ihnen gehört.
+					</p>
+				</div>
+
+				<div class="sol-capex-picker" role="tablist" aria-label="Zeitraum auswählen">
+					<span class="sol-capex-picker-label sol-mono">Zeitraum</span>
+					<div class="sol-capex-picker-buttons" data-sol-capex-buttons>
+						<?php foreach ( [ 12, 24, 36 ] as $tf ) : ?>
+							<button type="button"
+								class="sol-capex-picker-btn<?php echo $tf === $capex_default ? ' is-active' : ''; ?>"
+								data-sol-capex-tf="<?php echo esc_attr( (string) $tf ); ?>"
+								role="tab"
+								aria-selected="<?php echo $tf === $capex_default ? 'true' : 'false'; ?>"
+								data-track-action="capex_timeframe"
+								data-track-category="engagement"
+								data-track-section="capex_opex"
+							><?php echo esc_html( (string) $tf ); ?> Monate</button>
+						<?php endforeach; ?>
+					</div>
+				</div>
+
+				<div class="sol-capex-compare" data-sol-capex>
+					<!-- OPEX · Portal-Leads -->
+					<article class="sol-capex-col sol-capex-col--opex">
+						<header class="sol-capex-col-head">
+							<span class="sol-capex-col-badge sol-capex-col-badge--opex sol-mono">OPEX</span>
+							<h3 class="sol-capex-col-title">Portal-Leads mieten</h3>
+							<p class="sol-capex-col-sub">Monatlich zahlen, nichts besitzen.</p>
+						</header>
+						<div class="sol-capex-breakdown">
+							<div class="sol-capex-row">
+								<span class="sol-capex-row-l">Lead-Kosten (Ø 80 €/Stk)</span>
+								<span class="sol-capex-row-v" data-sol-capex-out="portal_monthly"><?php echo esc_html( $capex_timeframes[ $capex_default ]['portal_monthly'] ); ?> / Monat</span>
+							</div>
+							<div class="sol-capex-row">
+								<span class="sol-capex-row-l">Erwartete Leads</span>
+								<span class="sol-capex-row-v" data-sol-capex-out="portal_leads"><?php echo esc_html( $capex_timeframes[ $capex_default ]['portal_leads'] ); ?> Stück</span>
+							</div>
+							<div class="sol-capex-row sol-capex-row--issue">
+								<span class="sol-capex-row-l">Qualität</span>
+								<span class="sol-capex-row-v">~ 50 % gehen nicht ans Telefon</span>
+							</div>
+							<div class="sol-capex-row sol-capex-row--issue">
+								<span class="sol-capex-row-l">Exklusivität</span>
+								<span class="sol-capex-row-v">3–4 Wettbewerber parallel</span>
+							</div>
+						</div>
+						<div class="sol-capex-total">
+							<div class="sol-capex-total-l sol-mono">Gesamt (<span data-sol-capex-out="tf"><?php echo esc_html( (string) $capex_default ); ?></span> Monate)</div>
+							<div class="sol-capex-total-v sol-capex-total-v--opex sol-display" data-sol-capex-out="portal_total"><?php echo esc_html( $capex_timeframes[ $capex_default ]['portal_total'] ); ?></div>
+						</div>
+						<div class="sol-capex-result">
+							<div class="sol-capex-result-icon sol-capex-result-icon--bad" aria-hidden="true">✕</div>
+							<div class="sol-capex-result-body">
+								<strong>0 € Asset am Ende</strong>
+								<span>Budget aus = Anfragen aus.</span>
+							</div>
+						</div>
+						<ul class="sol-capex-list">
+							<li><span class="sol-capex-list-x" aria-hidden="true">✕</span>Portal behält die Daten</li>
+							<li><span class="sol-capex-list-x" aria-hidden="true">✕</span>Keine Kontrolle über Qualität</li>
+							<li><span class="sol-capex-list-x" aria-hidden="true">✕</span>Preiserhöhungen jederzeit möglich</li>
+							<li><span class="sol-capex-list-x" aria-hidden="true">✕</span>Vertrieb verbrennt Zeit mit Nicht-Käufern</li>
+						</ul>
+					</article>
+
+					<div class="sol-capex-divider" aria-hidden="true">
+						<span class="sol-capex-divider-line"></span>
+						<span class="sol-capex-divider-tag sol-mono">VS</span>
+						<span class="sol-capex-divider-line"></span>
+					</div>
+
+					<!-- CAPEX · Eigenes System -->
+					<article class="sol-capex-col sol-capex-col--capex">
+						<header class="sol-capex-col-head">
+							<span class="sol-capex-col-badge sol-capex-col-badge--capex sol-mono">CAPEX</span>
+							<h3 class="sol-capex-col-title">Eigenes System besitzen</h3>
+							<p class="sol-capex-col-sub">Einmalig investieren, langfristig skalieren.</p>
+						</header>
+						<div class="sol-capex-breakdown">
+							<div class="sol-capex-row">
+								<span class="sol-capex-row-l">Setup (einmalig)</span>
+								<span class="sol-capex-row-v" data-sol-capex-out="own_setup"><?php echo esc_html( $capex_timeframes[ $capex_default ]['own_setup'] ); ?></span>
+							</div>
+							<div class="sol-capex-row">
+								<span class="sol-capex-row-l">Hosting + Wartung</span>
+								<span class="sol-capex-row-v" data-sol-capex-out="own_monthly"><?php echo esc_html( $capex_timeframes[ $capex_default ]['own_monthly'] ); ?> / Monat</span>
+							</div>
+							<div class="sol-capex-row sol-capex-row--benefit">
+								<span class="sol-capex-row-l">Datenhoheit</span>
+								<span class="sol-capex-row-v">100 % bei Ihnen</span>
+							</div>
+							<div class="sol-capex-row sol-capex-row--benefit">
+								<span class="sol-capex-row-l">Vorqualifizierung</span>
+								<span class="sol-capex-row-v">Region · Projektwert · Fit-Score</span>
+							</div>
+						</div>
+						<div class="sol-capex-total">
+							<div class="sol-capex-total-l sol-mono">Gesamt (<span data-sol-capex-out="tf2"><?php echo esc_html( (string) $capex_default ); ?></span> Monate)</div>
+							<div class="sol-capex-total-v sol-capex-total-v--capex sol-display" data-sol-capex-out="own_total"><?php echo esc_html( $capex_timeframes[ $capex_default ]['own_total'] ); ?></div>
+						</div>
+						<div class="sol-capex-result sol-capex-result--good">
+							<div class="sol-capex-result-icon sol-capex-result-icon--good" aria-hidden="true">
+								<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" focusable="false"><path d="M5 12l5 5L20 7"/></svg>
+							</div>
+							<div class="sol-capex-result-body">
+								<strong>Aktiviertes Asset</strong>
+								<span>Code, Tracking, Daten bleiben bei Ihnen.</span>
+							</div>
+						</div>
+						<ul class="sol-capex-list">
+							<li><span class="sol-capex-list-v" aria-hidden="true">✓</span>Exklusive Anfragen — nur für Sie</li>
+							<li><span class="sol-capex-list-v" aria-hidden="true">✓</span>Volle Transparenz über Herkunft</li>
+							<li><span class="sol-capex-list-v" aria-hidden="true">✓</span>Skaliert ohne Kostenexplosion</li>
+							<li><span class="sol-capex-list-v" aria-hidden="true">✓</span>System bleibt — auch ohne laufende Kosten</li>
+						</ul>
+					</article>
+				</div>
+
+				<aside class="sol-capex-summary">
+					<h3 class="sol-capex-summary-h">Bilanziell: CAPEX statt OPEX</h3>
+					<p>
+						Ein eigenes Anfrage-System ist eine <strong>aktivierbare Investition</strong> (CAPEX), kein wiederkehrender Kostenfaktor (OPEX). Portal-Leads sind Betriebsausgaben ohne Restwert.
+						Nach <span data-sol-capex-out="tf3"><?php echo esc_html( (string) $capex_default ); ?></span> Monaten haben Sie entweder
+						<strong><span data-sol-capex-out="portal_total2"><?php echo esc_html( $capex_timeframes[ $capex_default ]['portal_total'] ); ?></span> ausgegeben und besitzen nichts</strong> —
+						oder Sie haben <strong><span data-sol-capex-out="own_total2"><?php echo esc_html( $capex_timeframes[ $capex_default ]['own_total'] ); ?></span> investiert und ein skalierbares Asset</strong>
+						(Setup einmalig + <span data-sol-capex-out="tf4"><?php echo esc_html( (string) $capex_default ); ?></span> × Hosting/Wartung).
+					</p>
+				</aside>
+
+				<div class="sol-capex-cta">
+					<a class="sol-btn sol-btn-primary" href="#marktcheck"
+						data-track-action="cta_solar_capex_to_marktcheck"
+						data-track-category="lead_funnel"
+						data-track-section="capex_opex"
+						data-track-funnel-stage="quiz_open"
+					>
+						<span>Marktcheck starten · 60 Sek</span>
+						<span class="sol-btn-arrow"><?php echo $arrow_svg; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></span>
+					</a>
+					<div class="sol-capex-cta-micro sol-mono">TCO-Rechnung · 1:1 verrechenbar bei Umsetzung</div>
 				</div>
 			</div>
 		</section>
@@ -483,6 +893,69 @@ get_header();
 							</div>
 						</div>
 					</div>
+				</div>
+			</div>
+		</section>
+
+		<!-- ════════════════════════════════════════════════════════════
+		     FIT — passt / passt nicht (ehrliche Vorauswahl)
+		     ════════════════════════════════════════════════════════════ -->
+		<section class="sol-section sol-section--tinted sol-fit-section" id="fit" data-track-section="fit_check">
+			<div class="sol-wrap">
+				<div class="sol-fit-head">
+					<div class="sol-eyebrow">Wann es sich lohnt</div>
+					<h2 class="sol-display sol-fit-h">
+						Ehrliche Vorauswahl, <em>bevor wir reden</em>.
+					</h2>
+					<p class="sol-fit-sub">
+						Lieber jetzt klären, ob es passt — als später ein Setup zu bauen, das ins Leere läuft.
+					</p>
+				</div>
+
+				<div class="sol-fit-grid">
+					<article class="sol-fit-col sol-fit-col--yes">
+						<header class="sol-fit-col-head">
+							<span class="sol-fit-col-badge sol-fit-col-badge--yes" aria-hidden="true">
+								<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" focusable="false"><path d="M5 12l5 5L20 7"/></svg>
+							</span>
+							<span>Passt, wenn …</span>
+						</header>
+						<ul class="sol-fit-list">
+							<?php foreach ( $fit_yes as $row ) : ?>
+								<li>
+									<div class="sol-fit-list-t"><?php echo esc_html( $row['t'] ); ?></div>
+									<div class="sol-fit-list-d"><?php echo esc_html( $row['s'] ); ?></div>
+								</li>
+							<?php endforeach; ?>
+						</ul>
+					</article>
+					<article class="sol-fit-col sol-fit-col--no">
+						<header class="sol-fit-col-head">
+							<span class="sol-fit-col-badge sol-fit-col-badge--no" aria-hidden="true">✕</span>
+							<span>Passt nicht, wenn …</span>
+						</header>
+						<ul class="sol-fit-list">
+							<?php foreach ( $fit_no as $row ) : ?>
+								<li>
+									<div class="sol-fit-list-t"><?php echo esc_html( $row['t'] ); ?></div>
+									<div class="sol-fit-list-d"><?php echo esc_html( $row['s'] ); ?></div>
+								</li>
+							<?php endforeach; ?>
+						</ul>
+					</article>
+				</div>
+
+				<div class="sol-fit-cta">
+					<a class="sol-btn sol-btn-primary" href="#marktcheck"
+						data-track-action="cta_solar_fit_to_marktcheck"
+						data-track-category="lead_funnel"
+						data-track-section="fit_check"
+						data-track-funnel-stage="quiz_open"
+					>
+						<span>Prüfen, ob es passt</span>
+						<span class="sol-btn-arrow"><?php echo $arrow_svg; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></span>
+					</a>
+					<div class="sol-fit-cta-micro sol-mono">Erst Marktcheck · dann Entscheidung · keine Verkaufspräsentation</div>
 				</div>
 			</div>
 		</section>


### PR DESCRIPTION
- Section-Nav (sticky, andockt unter Blocksy-Sticky-Header über --sol-nav-top)
- Vergleich (Markt-Standard vs Eigener Weg, 4 Zeilen je Seite)
- System-Diagramm (4 Layer: Fundament → Daten → Conversion → Skalierung)
  + Asset-Eigentum Hinweisblock
- CAPEX vs OPEX (Timeframe-Picker 12/24/36 Monate, OPEX/CAPEX Bilanz)
- Fit-Check (passt / passt nicht, 5+4 Qualifizierungs-Kriterien)

Globalen Blocksy-Header und Footer bewusst behalten (sitewide internal links + GTM/Consent-Pipeline; Replacement schadet SEO mehr als der CRO-Gewinn). Stattdessen in-page Section-Nav als CRO-Brücke.

Bestehender 5-Schritte-Marktcheck (Hero), Tracking, Schema.org und data-track-* Hooks bleiben unverändert. Neue Sektionen stylistisch in das warm-cream SOLARA-Vokabular eingebettet — kein Dark-Mode-Bruch.

https://claude.ai/code/session_0127obQTgjFPnGnFVxfiiPDA