### PR TITLE
fix(header,footer): Mobile-Burger entdoppeln + Money-Page Minimal-Header

### DIFF
--- a/blocksy-child/assets/css/site-header.css
+++ b/blocksy-child/assets/css/site-header.css
@@ -3,6 +3,28 @@ body.nx-blog-header-active .ct-header {
     display: none !important;
 }
 
+/*
+ * Blocksy rendert die Offcanvas-Panels (Mobile-Burger-Inhalt) als Geschwister
+ * der .ct-header. Wenn der eigene Header aktiv ist, würde der alte
+ * Blocksy-Menüinhalt zusätzlich im Mobile-Burger erscheinen. Hier komplett
+ * ausblenden, inkl. Trigger-Buttons und Mega-Menü-Container.
+ */
+body.nx-custom-header-active .ct-panel,
+body.nx-blog-header-active .ct-panel,
+body.nx-custom-header-active .ct-panel-default,
+body.nx-blog-header-active .ct-panel-default,
+body.nx-custom-header-active .ct-header-trigger,
+body.nx-blog-header-active .ct-header-trigger,
+body.nx-custom-header-active [data-id="trigger"],
+body.nx-blog-header-active [data-id="trigger"],
+body.nx-custom-header-active .ct-toggle-close,
+body.nx-blog-header-active .ct-toggle-close,
+body.nx-custom-header-active .ct-mobile-menu,
+body.nx-blog-header-active .ct-mobile-menu {
+    display: none !important;
+    visibility: hidden !important;
+}
+
 .nx-site-header {
     --nx-site-header-shell-height: 85px;
     position: fixed;
@@ -129,6 +151,77 @@ body.nx-blog-header-active .ct-header {
     display: none !important;
 }
 
+/* ── Energy/Money-Page Minimal-Header ─────────────────────────── */
+/*
+ * Auf der Money-Page bleibt der Header dauerhaft eingeblendet — der CTA muss
+ * auch im unteren Drittel der 10-Sektionen-Seite jederzeit erreichbar sein.
+ * Hide-on-scroll-Logik aus site-header.js wird hier per CSS überstimmt.
+ */
+.nx-site-header--energy {
+    pointer-events: none;
+    opacity: 1 !important;
+    transform: translateY(0) !important;
+}
+
+.nx-site-header__shell--energy {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: center;
+    justify-items: start;
+    min-height: 74px;
+    column-gap: clamp(1rem, 2vw, 2rem);
+}
+
+.nx-site-header__shell--energy .nx-site-header__brand {
+    pointer-events: auto;
+}
+
+.nx-site-header__energy-cta {
+    pointer-events: auto;
+    justify-self: end;
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.5rem;
+    min-height: 40px;
+    padding: 0 18px;
+    border-radius: 999px;
+    background: linear-gradient(180deg, var(--accent-hover) 0%, var(--accent) 100%);
+    color: var(--text-inverse);
+    font-size: 0.92rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    text-decoration: none;
+    white-space: nowrap;
+    box-shadow: 0 16px 34px hsl(var(--accent-hsl) / 0.22);
+    transition: transform var(--nx-duration-fast) var(--nx-ease),
+                box-shadow var(--nx-duration-fast) var(--nx-ease),
+                background var(--nx-duration-fast) var(--nx-ease);
+}
+
+.nx-site-header__energy-cta:hover,
+.nx-site-header__energy-cta:focus-visible {
+    color: var(--text-inverse);
+    background: linear-gradient(180deg, color-mix(in srgb, var(--accent-hover) 82%, white) 0%, var(--accent-hover) 100%);
+    transform: translateY(-1px);
+    box-shadow: 0 18px 38px hsl(var(--accent-hsl) / 0.28);
+}
+
+.nx-site-header__energy-cta-label {
+    font-size: 0.95rem;
+}
+
+.nx-site-header__energy-cta-microcopy {
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    opacity: 0.78;
+    text-transform: uppercase;
+}
+
+.nx-site-header__energy-cta-microcopy::before {
+    content: "· ";
+    margin-right: 0.1rem;
+}
+
 .nx-site-header.nexus-flight-mode .nx-site-header__shell {
     min-height: 74px;
     transform: translateY(-4px);
@@ -151,6 +244,10 @@ body.nx-blog-header-active .ct-header {
     text-transform: uppercase;
     color: var(--nx-text-dim);
     white-space: nowrap;
+}
+
+.nx-site-header__eyebrow:empty {
+    display: none;
 }
 
 .nx-site-header__mobile-eyebrow {
@@ -360,12 +457,21 @@ body.nx-blog-header-active .ct-header {
         grid-template-columns: minmax(0, 1fr) auto;
     }
 
+    .nx-site-header__shell--energy {
+        grid-template-columns: minmax(0, 1fr) auto;
+    }
+
     .nx-site-header__nav {
         display: none;
     }
 
     .nx-site-header__toggle {
         display: inline-flex;
+    }
+
+    /* Auf der Money-Page wird die Hauptnav unterdrückt — kein Burger nötig. */
+    .nx-site-header--energy .nx-site-header__toggle {
+        display: none;
     }
 }
 
@@ -445,5 +551,24 @@ body.nx-blog-header-active .ct-header {
         min-height: 34px;
         padding: 0 12px;
         font-size: 0.78rem;
+    }
+
+    .nx-site-header__shell--energy {
+        grid-template-columns: minmax(0, 1fr) auto;
+        gap: 0.5rem;
+    }
+
+    .nx-site-header__energy-cta {
+        min-height: 36px;
+        padding: 0 14px;
+        font-size: 0.85rem;
+    }
+
+    .nx-site-header__energy-cta-label {
+        font-size: 0.85rem;
+    }
+
+    .nx-site-header__energy-cta-microcopy {
+        font-size: 0.62rem;
     }
 }

--- a/blocksy-child/inc/header.php
+++ b/blocksy-child/inc/header.php
@@ -117,7 +117,7 @@ function nexus_get_site_header_fallback_items() {
 	$solar_url    = $primary_urls['energy'] ?? home_url( '/solar-waermepumpen-leadgenerierung/' );
 	$agentur_url  = $primary_urls['agentur'] ?? home_url( '/wordpress-agentur-hannover/' );
 	$results_url  = $primary_urls['results'] ?? home_url( '/ergebnisse/' );
-	$request_cta  = 'Marktcheck';
+	$request_cta  = 'Marktcheck · 60 Sek.';
 
 	return [
 		[
@@ -142,7 +142,7 @@ function nexus_get_site_header_fallback_items() {
 			'track'  => 'results',
 		],
 		[
-			'label'  => __( 'Über mich', 'blocksy-child' ),
+			'label'  => __( 'Über Haşim', 'blocksy-child' ),
 			'url'    => $primary_urls['about'] ?? home_url( '/uber-mich/' ),
 			'active' => $about_page_id ? is_page( $about_page_id ) : false,
 			'class'  => '',
@@ -280,12 +280,12 @@ function nexus_energy_nav_cta_label( $items, $args ) {
 	}
 
 	$request_url = function_exists( 'hu_get_request_analysis_url' ) ? hu_get_request_analysis_url() : home_url( '/solar-waermepumpen-leadgenerierung/#marktcheck' );
-	$request_cta = 'Marktcheck';
+	$request_cta = 'Marktcheck · 60 Sek.';
 
 	foreach ( $items as $item ) {
 		$legacy_analysis_label = 'Analyse ' . 'starten';
 		$legacy_diagnose_label = 'System-Diagnose ' . 'starten';
-		if ( in_array( $item->title, [ $legacy_analysis_label, $legacy_diagnose_label, 'System-Diagnose', 'Marktcheck', 'Audit starten', 'System-Diagnose anfragen', 'Audit', 'AI-Audit', 'Anfrage stellen', 'Direkt anfragen' ], true ) ) {
+		if ( in_array( $item->title, [ $legacy_analysis_label, $legacy_diagnose_label, 'System-Diagnose', 'Marktcheck', 'Marktcheck · 60 Sek.', 'Audit starten', 'System-Diagnose anfragen', 'Audit', 'AI-Audit', 'Anfrage stellen', 'Direkt anfragen' ], true ) ) {
 			$item->title = $request_cta;
 			$item->url   = $request_url;
 			break;
@@ -303,6 +303,11 @@ add_filter( 'wp_nav_menu_objects', 'nexus_energy_nav_cta_label', 20, 2 );
  */
 function nexus_get_site_header_eyebrow() {
 	if ( function_exists( 'nexus_is_energy_systems_context' ) && nexus_is_energy_systems_context() ) {
+		return '';
+	}
+
+	// Auf der Homepage wiederholt der Hero die Positionierung — Tagline würde nur doppeln.
+	if ( is_front_page() ) {
 		return '';
 	}
 

--- a/blocksy-child/inc/menu-setup.php
+++ b/blocksy-child/inc/menu-setup.php
@@ -3,7 +3,7 @@
  * NEXUS MENU SETUP
  *
  * Erstellt das fokussierte Hauptmenü für die Neukunden-Navigation:
- * Solar & Wärmepumpen | WordPress Agentur | Ergebnisse | Über mich | Marktcheck
+ * Solar & Wärmepumpen | WordPress Agentur | Ergebnisse | Über Haşim | Marktcheck · 60 Sek.
  *
  * Einmal-Setup: Wird beim Theme-Switch oder manuell via ?nexus_rebuild_menu=1 ausgelöst.
  *
@@ -140,10 +140,10 @@ function nexus_setup_main_menu() {
 		'menu-item-classes'   => 'nav-results-link',
 	] );
 
-	// ── 4. Über mich (Top-Level) ──────────────────────────────────
+	// ── 4. Über Haşim (Top-Level) ─────────────────────────────────
 	$about_id = nexus_get_page_id( [ 'uber-mich' ] );
 	wp_update_nav_menu_item( $menu_id, 0, [
-		'menu-item-title'     => 'Über mich',
+		'menu-item-title'     => 'Über Haşim',
 		'menu-item-object'    => 'page',
 		'menu-item-object-id' => $about_id,
 		'menu-item-type'      => $about_id ? 'post_type' : 'custom',
@@ -154,7 +154,7 @@ function nexus_setup_main_menu() {
 	// ── 5. Marktcheck CTA (Top-Level) ──────────────────────────────
 	$analysis_url = function_exists( 'hu_get_request_analysis_url' ) ? hu_get_request_analysis_url() : home_url( '/solar-waermepumpen-leadgenerierung/#marktcheck' );
 	wp_update_nav_menu_item( $menu_id, 0, [
-		'menu-item-title'     => 'Marktcheck',
+		'menu-item-title'     => 'Marktcheck · 60 Sek.',
 		'menu-item-object'    => 'custom',
 		'menu-item-object-id' => 0,
 		'menu-item-type'      => 'custom',
@@ -293,11 +293,17 @@ add_filter( 'wp_nav_menu_objects', function ( $items, $args ) {
 			continue;
 		}
 
+		$item_title_raw = isset( $item->title ) ? wp_strip_all_tags( (string) $item->title ) : '';
+		if ( 'Über mich' === $item_title_raw ) {
+			$item->title = 'Über Haşim';
+			continue;
+		}
+
 		if ( ! nexus_is_audit_cta_menu_item( $item ) ) {
 			continue;
 		}
 
-		$item->title = 'Marktcheck';
+		$item->title = 'Marktcheck · 60 Sek.';
 		$item->url   = $analysis_url;
 
 		if ( ! isset( $item->classes ) || ! is_array( $item->classes ) ) {
@@ -328,6 +334,7 @@ add_filter( 'nav_menu_link_attributes', function ( $atts, $item ) {
 		'e3 proof'            => 'e3_proof',
 		'e3 new energy'       => 'e3_proof',
 		'über mich'           => 'about',
+		'über haşim'          => 'about',
 	];
 
 	foreach ( $track_map as $label => $track_key ) {

--- a/blocksy-child/template-parts/blog-header.php
+++ b/blocksy-child/template-parts/blog-header.php
@@ -94,7 +94,7 @@ $primary_items = [
 		'active' => nexus_is_results_context(),
 	],
 	[
-		'label'  => __( 'Über mich', 'blocksy-child' ),
+		'label'  => __( 'Über Haşim', 'blocksy-child' ),
 		'url'    => $about_url,
 		'active' => is_page( nexus_get_page_id( [ 'uber-mich' ] ) ),
 	],

--- a/blocksy-child/template-parts/site-footer.php
+++ b/blocksy-child/template-parts/site-footer.php
@@ -21,9 +21,6 @@ $e3_url       = $primary_urls['e3'] ?? home_url( '/e3-new-energy/' );
 $results_url  = $primary_urls['results'] ?? home_url( '/ergebnisse/' );
 $blog_url     = $primary_urls['blog'] ?? home_url( '/blog/' );
 $agentur_url  = $primary_urls['agentur'] ?? home_url( '/wordpress-agentur-hannover/' );
-$wgos_url     = $primary_urls['wgos'] ?? trailingslashit( $agentur_url ) . '#wgos';
-$asset_url    = $primary_urls['wgos_assets'] ?? trailingslashit( $agentur_url ) . '#asset-uebersicht';
-$seo_url      = $primary_urls['seo'] ?? trailingslashit( $agentur_url ) . '#technisches-seo';
 $about_url    = $primary_urls['about'] ?? home_url( '/uber-mich/' );
 $contact_url  = $primary_urls['contact'] ?? nexus_get_contact_url();
 $project_request_url = add_query_arg(
@@ -134,9 +131,6 @@ $footer_trust_items  = array_values(
 				<ul class="ft__list">
 					<li><a class="ft__link-strong" href="<?php echo esc_url( $blog_url ); ?>" data-track-action="cta_footer_nav_insights" data-track-category="navigation" data-track-section="footer">Insights</a></li>
 					<li><a href="<?php echo esc_url( $agentur_url ); ?>" data-track-action="cta_footer_nav_agentur" data-track-category="navigation" data-track-section="footer">WordPress Agentur Hannover</a></li>
-					<li><a href="<?php echo esc_url( $wgos_url ); ?>" data-track-action="cta_footer_nav_wgos" data-track-category="navigation" data-track-section="footer">WGOS-Arbeitsweise</a></li>
-					<li><a href="<?php echo esc_url( $seo_url ); ?>" data-track-action="cta_footer_nav_seo" data-track-category="navigation" data-track-section="footer">Technisches SEO</a></li>
-					<li><a href="<?php echo esc_url( $asset_url ); ?>" data-track-action="cta_footer_nav_assets" data-track-category="navigation" data-track-section="footer">WGOS-Assets</a></li>
 				</ul>
 			</section>
 
@@ -163,10 +157,6 @@ $footer_trust_items  = array_values(
 			<a href="https://www.linkedin.com/in/hasim-%C3%BCner/" aria-label="LinkedIn-Profil" rel="me noopener noreferrer" target="_blank">
 				<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20.5 2h-17A1.5 1.5 0 0 0 2 3.5v17A1.5 1.5 0 0 0 3.5 22h17a1.5 1.5 0 0 0 1.5-1.5v-17A1.5 1.5 0 0 0 20.5 2zM8 19H5v-9h3zM6.5 8.25A1.75 1.75 0 1 1 8.3 6.5a1.78 1.78 0 0 1-1.8 1.75zM19 19h-3v-4.74c0-1.42-.6-1.93-1.38-1.93A1.74 1.74 0 0 0 13 14.19V19h-3v-9h2.9v1.3a3.11 3.11 0 0 1 2.7-1.4c1.55 0 3.36.86 3.36 3.66z"/></svg>
 				LinkedIn
-			</a>
-			<a href="https://github.com/Hasim-hannover" aria-label="GitHub-Profil" rel="me noopener noreferrer" target="_blank">
-				<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 1.3a11 11 0 0 0-3.5 21.4c.5.1.7-.2.7-.5v-1.7C6 21.1 5.4 19 5.4 19a2.8 2.8 0 0 0-1.1-1.5c-.9-.6.1-.6.1-.6a2.1 2.1 0 0 1 1.5 1 2.1 2.1 0 0 0 2.9.8 2.1 2.1 0 0 1 .6-1.3c-2.2-.3-4.6-1.1-4.6-5a3.9 3.9 0 0 1 1-2.7 3.6 3.6 0 0 1 .1-2.7s.8-.3 2.8 1a9.7 9.7 0 0 1 5.1 0c2-1.3 2.8-1 2.8-1a3.6 3.6 0 0 1 .1 2.7 3.9 3.9 0 0 1 1 2.7c0 3.9-2.4 4.7-4.6 5a2.4 2.4 0 0 1 .7 1.8v2.7c0 .3.2.6.7.5A11 11 0 0 0 12 1.3z"/></svg>
-				GitHub
 			</a>
 		</div>
 	</div>

--- a/blocksy-child/template-parts/site-header.php
+++ b/blocksy-child/template-parts/site-header.php
@@ -67,6 +67,28 @@ if ( empty( $audit_header_meta_items ) ) {
 </header>
 <?php return; endif; ?>
 
+<?php if ( function_exists( 'nexus_is_energy_systems_context' ) && nexus_is_energy_systems_context() ) : ?>
+<header class="nx-site-header nx-site-header--energy" data-site-header role="banner">
+	<div class="nx-container">
+		<div class="nx-site-header__shell nx-site-header__shell--energy">
+			<a
+				class="site-logo nx-site-header__brand"
+				href="<?php echo esc_url( home_url( '/' ) ); ?>"
+				rel="home"
+				aria-label="<?php echo esc_attr( $home_label ); ?>"
+			>
+				<?php echo esc_html( $brand_text ); ?>
+			</a>
+
+			<a class="nx-site-header__energy-cta" href="<?php echo esc_url( $request_url ); ?>" data-track-action="cta_energy_header_analysis" data-track-category="lead_gen" data-track-section="energy_header" data-track-funnel-stage="energy_header">
+				<span class="nx-site-header__energy-cta-label">Marktcheck</span>
+				<span class="nx-site-header__energy-cta-microcopy" aria-hidden="true">60 Sek.</span>
+			</a>
+		</div>
+	</div>
+</header>
+<?php return; endif; ?>
+
 <header class="nx-site-header" data-site-header role="banner">
 	<div class="nx-container">
 		<div class="nx-site-header__shell">


### PR DESCRIPTION
Sechs Befunde aus dem CRO-Review umgesetzt:

* Mobile-Burger-Dedup: Blocksy-Offcanvas (.ct-panel) wird ausgeblendet, wenn der eigene Header aktiv ist — keine Doppel-Navigation mehr beim Erstkontakt.
* CTA-Microcopy: Nav-Button "Marktcheck" → "Marktcheck · 60 Sek." als Friction-Killer am Erstkontaktpunkt; greift sowohl im Datenbank-Seed als auch im Render-Filter (ohne Rebuild sofort wirksam).
* Money-Page Minimal-Header: Eigene Variante (.nx-site-header--energy) zeigt nur Logo + Marktcheck-CTA, kein Hauptnav. Dauerhaft pinned, damit der CTA auch in Sektion 7+ erreichbar bleibt.
* Footer "Wissen" konsolidiert: Anker-Spam auf /wordpress-agentur-hannover/ entfernt — bleibt Insights + WordPress Agentur Hannover.
* GitHub-Icon aus Footer entfernt: irrelevant für B2B-Solar-Zielgruppe.
* "Über mich" → "Über Haşim" durchgängig (Menu-DB, Render-Filter, Fallback, Blog-Header).
* Tagline auf Homepage unterdrückt: Hero kommuniziert die Positionierung bereits — Doppel-Botschaft entfernt.

https://claude.ai/code/session_01JFsWP3AF5gBvmiP7bD2J9x