### PR TITLE
feat(seo-cockpit): Dashboard-UX umgebaut — Prio-Queue & Insights nach…

### DIFF
--- a/blocksy-child/assets/css/seo-cockpit-admin.css
+++ b/blocksy-child/assets/css/seo-cockpit-admin.css
@@ -1,59 +1,202 @@
+/*
+ * SEO Cockpit admin styles.
+ * Hierarchie: Hero-Toolbar > KPI > Action-Hub (Prio + Insights) > Trend > Tabellen > Technik.
+ */
+
 .nexus-seo-cockpit {
-    max-width: 1380px;
+    --nsc-bg: #f5f6f9;
+    --nsc-surface: #ffffff;
+    --nsc-surface-muted: #f7f8fb;
+    --nsc-border: #dde2ea;
+    --nsc-border-strong: #c8cfd9;
+    --nsc-ink: #121920;
+    --nsc-ink-muted: #4a5462;
+    --nsc-ink-soft: #6b7684;
+    --nsc-accent: #9f6c39;
+    --nsc-accent-soft: #f4efe9;
+    --nsc-accent-ink: #463226;
+    --nsc-success: #0f7a3c;
+    --nsc-success-soft: #e7f4ec;
+    --nsc-warning: #915500;
+    --nsc-warning-soft: #fff1d8;
+    --nsc-danger: #8f1d1d;
+    --nsc-danger-soft: #fde8e8;
+    --nsc-info: #1e527e;
+    --nsc-info-soft: #e6f0f9;
+    --nsc-radius: 18px;
+    --nsc-radius-sm: 12px;
+    --nsc-shadow: 0 1px 2px rgba(18, 25, 35, 0.04), 0 12px 28px rgba(18, 25, 35, 0.05);
+    --nsc-shadow-sm: 0 1px 2px rgba(18, 25, 35, 0.05);
+
+    max-width: 1440px;
+    color: var(--nsc-ink);
+}
+
+.nexus-seo-cockpit h1 {
+    margin: 4px 0 18px;
+    font-size: 26px;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+}
+
+.nexus-seo-cockpit h2 {
+    margin: 0;
+    font-size: 17px;
+    font-weight: 700;
+    letter-spacing: -0.005em;
 }
 
 .nexus-seo-cockpit__eyebrow {
-    margin: 0 0 10px;
-    color: #5e6977;
-    font-size: 12px;
-    letter-spacing: 0.08em;
+    margin: 0 0 8px;
+    color: var(--nsc-ink-soft);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.1em;
     text-transform: uppercase;
 }
 
-.nexus-seo-cockpit__header {
-    padding-bottom: 18px;
+/* --- Toolbar / Header --------------------------------------------------- */
+
+.nexus-seo-cockpit__toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 14px 18px;
+    padding: 14px 20px;
+    margin: 0 0 14px;
+    border: 1px solid var(--nsc-border);
+    border-radius: var(--nsc-radius);
+    background: var(--nsc-surface);
+    box-shadow: var(--nsc-shadow-sm);
+    position: sticky;
+    top: 32px;
+    z-index: 30;
 }
 
-.nexus-seo-cockpit__header-grid {
-    display: grid;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-    gap: 14px;
+.nexus-seo-cockpit__toolbar-meta {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 10px 16px;
+    color: var(--nsc-ink-muted);
+    font-size: 13px;
 }
 
-.nexus-seo-cockpit__header-grid div {
-    padding: 14px 16px;
-    border: 1px solid #e3e7ed;
-    border-radius: 16px;
-    background: #f7f8fb;
-}
-
-.nexus-seo-cockpit__header-grid strong,
-.nexus-seo-cockpit__header-grid span {
-    display: block;
-}
-
-.nexus-seo-cockpit__header-grid strong {
-    margin-bottom: 8px;
-    color: #55616f;
-    font-size: 12px;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-}
-
-.nexus-seo-cockpit__header-grid span {
-    color: #121920;
-    font-size: 15px;
+.nexus-seo-cockpit__toolbar-meta strong {
+    color: var(--nsc-ink);
     font-weight: 700;
 }
 
-.nexus-seo-cockpit__grid {
-    display: grid;
-    gap: 18px;
-    margin: 18px 0;
+.nexus-seo-cockpit__toolbar-meta code {
+    padding: 2px 6px;
+    border-radius: 6px;
+    background: var(--nsc-surface-muted);
+    font-size: 12px;
 }
 
-.nexus-seo-cockpit__grid--top {
-    grid-template-columns: minmax(0, 2fr) minmax(320px, 1fr);
+.nexus-seo-cockpit__toolbar-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 10px;
+}
+
+.nexus-seo-cockpit__toolbar-actions form {
+    margin: 0;
+}
+
+/* Status dot */
+.nexus-seo-cockpit__status-dot {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 12px 4px 10px;
+    border-radius: 999px;
+    background: var(--nsc-surface-muted);
+    border: 1px solid var(--nsc-border);
+    font-weight: 600;
+    font-size: 12px;
+    line-height: 1.1;
+    color: var(--nsc-ink);
+}
+
+.nexus-seo-cockpit__status-dot::before {
+    content: "";
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--nsc-ink-soft);
+}
+
+.nexus-seo-cockpit__status-dot.is-connected {
+    background: var(--nsc-success-soft);
+    border-color: rgba(15, 122, 60, 0.22);
+    color: var(--nsc-success);
+}
+
+.nexus-seo-cockpit__status-dot.is-connected::before {
+    background: var(--nsc-success);
+    box-shadow: 0 0 0 3px rgba(15, 122, 60, 0.15);
+}
+
+.nexus-seo-cockpit__status-dot.is-warning {
+    background: var(--nsc-warning-soft);
+    border-color: rgba(145, 85, 0, 0.22);
+    color: var(--nsc-warning);
+}
+
+.nexus-seo-cockpit__status-dot.is-warning::before {
+    background: var(--nsc-warning);
+}
+
+/* --- Status strip (compact info row) ----------------------------------- */
+
+.nexus-seo-cockpit__strip {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 1px;
+    margin: 0 0 18px;
+    padding: 0;
+    border: 1px solid var(--nsc-border);
+    border-radius: var(--nsc-radius);
+    background: var(--nsc-border);
+    overflow: hidden;
+}
+
+.nexus-seo-cockpit__strip-cell {
+    padding: 12px 16px;
+    background: var(--nsc-surface);
+}
+
+.nexus-seo-cockpit__strip-cell strong {
+    display: block;
+    margin-bottom: 4px;
+    color: var(--nsc-ink-soft);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.nexus-seo-cockpit__strip-cell span {
+    display: block;
+    color: var(--nsc-ink);
+    font-size: 14px;
+    font-weight: 700;
+}
+
+/* --- Grids -------------------------------------------------------------- */
+
+.nexus-seo-cockpit__grid {
+    display: grid;
+    gap: 16px;
+    margin: 16px 0;
+}
+
+.nexus-seo-cockpit__grid--hero {
+    grid-template-columns: minmax(0, 2.1fr) minmax(280px, 1fr);
 }
 
 .nexus-seo-cockpit__grid--reports,
@@ -61,123 +204,193 @@
     grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
+.nexus-seo-cockpit__grid--triple {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+/* --- Panel base --------------------------------------------------------- */
+
 .nexus-seo-cockpit__panel {
     padding: 22px;
-    border: 1px solid #d9dde3;
-    border-radius: 20px;
-    background: #ffffff;
-    box-shadow: 0 14px 34px rgba(18, 25, 35, 0.05);
+    border: 1px solid var(--nsc-border);
+    border-radius: var(--nsc-radius);
+    background: var(--nsc-surface);
+    box-shadow: var(--nsc-shadow);
 }
 
 .nexus-seo-cockpit__panel--setup {
-    border-color: #eadacc;
-    background: linear-gradient(180deg, #fffaf5 0%, #fffefe 100%);
+    border-color: rgba(145, 85, 0, 0.28);
+    background: linear-gradient(180deg, #fffaf0 0%, #fffefb 100%);
 }
 
 .nexus-seo-cockpit__panel--detail {
-    margin-top: 18px;
+    margin-top: 16px;
+}
+
+.nexus-seo-cockpit__panel--primary {
+    border-color: rgba(159, 108, 57, 0.32);
+    background:
+        radial-gradient(ellipse 80% 50% at 0% 0%, rgba(159, 108, 57, 0.06) 0%, transparent 60%),
+        var(--nsc-surface);
+}
+
+.nexus-seo-cockpit__panel--compact {
+    padding: 18px;
 }
 
 .nexus-seo-cockpit__panel-head {
     display: flex;
     align-items: flex-start;
     justify-content: space-between;
-    gap: 16px;
-    margin-bottom: 18px;
+    flex-wrap: wrap;
+    gap: 14px;
+    margin-bottom: 16px;
 }
 
-.nexus-seo-cockpit__panel-head h2 {
-    margin: 0;
+.nexus-seo-cockpit__panel-head > div {
+    min-width: 0;
 }
 
 .nexus-seo-cockpit__actions {
     display: flex;
     flex-wrap: wrap;
-    gap: 10px;
+    gap: 8px;
 }
+
+.nexus-seo-cockpit__actions form {
+    margin: 0;
+}
+
+/* --- Range switcher ----------------------------------------------------- */
 
 .nexus-seo-cockpit__range-switcher {
     display: inline-flex;
-    flex-wrap: wrap;
-    gap: 8px;
+    padding: 3px;
+    border: 1px solid var(--nsc-border);
+    border-radius: 999px;
+    background: var(--nsc-surface-muted);
+    gap: 2px;
 }
 
 .nexus-seo-cockpit__range-pill {
     display: inline-flex;
     align-items: center;
-    min-height: 34px;
+    min-height: 30px;
     padding: 0 14px;
-    border: 1px solid #d7dde4;
     border-radius: 999px;
-    background: #ffffff;
-    color: #24303c;
+    color: var(--nsc-ink-muted);
+    font-size: 13px;
     font-weight: 600;
     text-decoration: none;
+    transition: background 0.15s ease, color 0.15s ease;
+}
+
+.nexus-seo-cockpit__range-pill:hover {
+    background: var(--nsc-surface);
+    color: var(--nsc-ink);
 }
 
 .nexus-seo-cockpit__range-pill.is-active {
-    border-color: #121920;
-    background: #121920;
+    background: var(--nsc-ink);
+    color: #ffffff;
+    box-shadow: 0 2px 6px rgba(18, 25, 35, 0.18);
+}
+
+.nexus-seo-cockpit__range-pill.is-active:hover {
+    background: var(--nsc-ink);
     color: #ffffff;
 }
+
+/* --- Meta lists --------------------------------------------------------- */
 
 .nexus-seo-cockpit__meta-list {
     margin: 0;
     padding: 0;
     list-style: none;
     display: grid;
-    gap: 10px;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px 18px;
+    font-size: 13px;
+    color: var(--nsc-ink-muted);
+}
+
+.nexus-seo-cockpit__meta-list--single {
+    grid-template-columns: 1fr;
 }
 
 .nexus-seo-cockpit__meta-list li {
     margin: 0;
+    padding: 6px 0;
+    border-bottom: 1px dashed var(--nsc-border);
+}
+
+.nexus-seo-cockpit__meta-list li:last-child {
+    border-bottom: 0;
+}
+
+.nexus-seo-cockpit__meta-list strong {
+    color: var(--nsc-ink);
+    font-weight: 600;
 }
 
 .nexus-seo-cockpit__hint {
     margin: 0;
-    color: #5e6977;
+    color: var(--nsc-ink-soft);
+    font-size: 13px;
+    line-height: 1.5;
 }
 
 .nexus-seo-cockpit__steps {
     margin: 14px 0 0;
-    padding-left: 18px;
-    color: #24303c;
+    padding-left: 20px;
+    color: var(--nsc-ink-muted);
+    font-size: 14px;
+    line-height: 1.6;
 }
 
 .nexus-seo-cockpit__steps li + li {
     margin-top: 8px;
 }
 
+/* --- Status text -------------------------------------------------------- */
+
 .nexus-seo-cockpit__status {
     margin: 0 0 10px;
     font-weight: 700;
+    font-size: 14px;
 }
 
 .nexus-seo-cockpit__status.is-positive {
-    color: #0f7a3c;
+    color: var(--nsc-success);
 }
 
 .nexus-seo-cockpit__status.is-neutral {
-    color: #915500;
+    color: var(--nsc-warning);
 }
+
+/* --- Chips -------------------------------------------------------------- */
 
 .nexus-seo-cockpit__chips {
     display: flex;
     flex-wrap: wrap;
-    gap: 10px;
+    gap: 8px;
+    margin: 14px 0 0;
 }
 
 .nexus-seo-cockpit__chip {
     display: inline-flex;
     align-items: center;
-    min-height: 34px;
+    min-height: 28px;
     padding: 0 12px;
     border-radius: 999px;
-    background: #f4efe9;
-    border: 1px solid #eadacc;
-    color: #463226;
+    background: var(--nsc-accent-soft);
+    border: 1px solid rgba(159, 108, 57, 0.22);
+    color: var(--nsc-accent-ink);
     font-weight: 600;
+    font-size: 12px;
 }
+
+/* --- Hero KPI cards ----------------------------------------------------- */
 
 .nexus-seo-cockpit__metrics {
     display: grid;
@@ -186,257 +399,391 @@
 }
 
 .nexus-seo-cockpit__metric-card {
-    padding: 18px;
-    border-radius: 18px;
-    background: linear-gradient(180deg, #121920 0%, #1a232d 100%);
+    position: relative;
+    padding: 20px 20px 18px;
+    border-radius: var(--nsc-radius);
+    background: linear-gradient(135deg, #121920 0%, #1f2a36 100%);
     color: #f7f3ee;
+    overflow: hidden;
+}
+
+.nexus-seo-cockpit__metric-card::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(ellipse 60% 40% at 100% 0%, rgba(159, 108, 57, 0.18) 0%, transparent 70%);
+    pointer-events: none;
 }
 
 .nexus-seo-cockpit__metric-label {
     display: block;
     margin-bottom: 12px;
     color: #c5ced7;
-    font-size: 12px;
-    letter-spacing: 0.08em;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.1em;
     text-transform: uppercase;
+    position: relative;
 }
 
 .nexus-seo-cockpit__metric-value {
     display: block;
-    font-size: 28px;
-    line-height: 1.15;
+    font-size: 30px;
+    font-weight: 700;
+    line-height: 1.1;
+    letter-spacing: -0.02em;
+    position: relative;
 }
 
 .nexus-seo-cockpit__metric-delta,
 .nexus-seo-cockpit__delta-inline {
     display: inline-flex;
-    margin-top: 10px;
-    padding: 4px 10px;
+    align-items: center;
+    gap: 4px;
+    padding: 3px 10px;
     border-radius: 999px;
     background: rgba(255, 255, 255, 0.08);
     color: #c5ced7;
     font-weight: 700;
+    font-size: 12px;
+    line-height: 1.2;
+    position: relative;
+}
+
+.nexus-seo-cockpit__metric-delta {
+    margin-top: 12px;
 }
 
 .nexus-seo-cockpit__delta-inline {
-    margin-top: 0;
     background: #eef2f6;
-    color: #24303c;
+    color: var(--nsc-ink);
 }
 
-.nexus-seo-cockpit__metric-delta.is-positive,
-.nexus-seo-cockpit__delta-inline.is-positive {
+.nexus-seo-cockpit__metric-delta.is-positive {
+    background: rgba(139, 224, 162, 0.12);
     color: #8be0a2;
 }
 
-.nexus-seo-cockpit__metric-delta.is-negative,
-.nexus-seo-cockpit__delta-inline.is-negative {
+.nexus-seo-cockpit__metric-delta.is-negative {
+    background: rgba(255, 181, 181, 0.12);
     color: #ffb5b5;
 }
 
-.nexus-seo-cockpit__metric-delta.is-neutral,
-.nexus-seo-cockpit__delta-inline.is-neutral {
+.nexus-seo-cockpit__metric-delta.is-neutral {
+    background: rgba(224, 214, 203, 0.1);
     color: #e0d6cb;
 }
 
+.nexus-seo-cockpit__delta-inline.is-positive {
+    background: var(--nsc-success-soft);
+    color: var(--nsc-success);
+}
+
+.nexus-seo-cockpit__delta-inline.is-negative {
+    background: var(--nsc-danger-soft);
+    color: var(--nsc-danger);
+}
+
+.nexus-seo-cockpit__delta-inline.is-neutral {
+    background: var(--nsc-surface-muted);
+    color: var(--nsc-ink-muted);
+}
+
+/* --- Trend cards -------------------------------------------------------- */
+
 .nexus-seo-cockpit__trend-grid {
     display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 14px;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 12px;
 }
 
 .nexus-seo-cockpit__trend-card {
-    padding: 16px;
-    border: 1px solid #dfe4ea;
-    border-radius: 18px;
-    background: #f9fafc;
+    padding: 14px 16px;
+    border: 1px solid var(--nsc-border);
+    border-radius: var(--nsc-radius-sm);
+    background: var(--nsc-surface-muted);
+    transition: border-color 0.15s ease, transform 0.15s ease;
+}
+
+.nexus-seo-cockpit__trend-card:hover {
+    border-color: var(--nsc-border-strong);
+    transform: translateY(-1px);
 }
 
 .nexus-seo-cockpit__trend-head {
     display: flex;
     align-items: baseline;
     justify-content: space-between;
-    gap: 12px;
-    margin-bottom: 10px;
+    gap: 8px;
+    margin-bottom: 6px;
 }
 
 .nexus-seo-cockpit__trend-head span {
-    color: #55616f;
-    font-size: 12px;
+    color: var(--nsc-ink-soft);
+    font-size: 11px;
     font-weight: 700;
     letter-spacing: 0.08em;
     text-transform: uppercase;
 }
 
 .nexus-seo-cockpit__trend-head strong {
-    color: #121920;
+    color: var(--nsc-ink);
     font-size: 18px;
+    font-weight: 700;
+    letter-spacing: -0.01em;
 }
 
 .nexus-seo-cockpit__trend-card svg {
     width: 100%;
-    height: 88px;
+    height: 64px;
     overflow: visible;
 }
 
 .nexus-seo-cockpit__trend-card polyline {
     fill: none;
-    stroke: #9f6c39;
+    stroke: var(--nsc-accent);
     stroke-linecap: round;
     stroke-linejoin: round;
-    stroke-width: 3;
+    stroke-width: 2.5;
 }
+
+/* --- Insights ----------------------------------------------------------- */
 
 .nexus-seo-cockpit__insights {
     display: grid;
-    gap: 12px;
+    gap: 10px;
 }
 
 .nexus-seo-cockpit__insight-card {
-    padding: 16px;
-    border: 1px solid #e1e6ec;
-    border-radius: 18px;
-    background: #fafbfd;
+    padding: 14px 16px;
+    border: 1px solid var(--nsc-border);
+    border-radius: var(--nsc-radius-sm);
+    background: var(--nsc-surface);
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.nexus-seo-cockpit__insight-card:hover {
+    border-color: var(--nsc-border-strong);
+    box-shadow: var(--nsc-shadow-sm);
 }
 
 .nexus-seo-cockpit__insight-card p {
-    margin: 0 0 8px;
+    margin: 0 0 6px;
+    font-size: 13px;
+    line-height: 1.55;
+    color: var(--nsc-ink-muted);
+}
+
+.nexus-seo-cockpit__insight-card p:last-child {
+    margin-bottom: 0;
 }
 
 .nexus-seo-cockpit__insight-sublist {
-    margin: 10px 0 12px;
-    padding: 12px 14px;
-    border-radius: 14px;
-    background: #f2f5f8;
+    margin: 10px 0;
+    padding: 10px 12px;
+    border-radius: 10px;
+    background: var(--nsc-surface-muted);
+    font-size: 12px;
 }
 
 .nexus-seo-cockpit__insight-sublist strong {
     display: block;
-    margin-bottom: 8px;
-    color: #24303c;
+    margin-bottom: 6px;
+    color: var(--nsc-ink);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
 }
 
 .nexus-seo-cockpit__competing-urls {
     margin: 0;
-    padding-left: 18px;
+    padding-left: 16px;
 }
 
 .nexus-seo-cockpit__competing-urls li {
-    margin: 0 0 6px;
+    margin: 0 0 4px;
 }
 
 .nexus-seo-cockpit__competing-urls span {
     display: inline-block;
-    margin-left: 8px;
-    color: #5e6977;
-    font-size: 12px;
+    margin-left: 6px;
+    color: var(--nsc-ink-soft);
+    font-size: 11px;
 }
 
 .nexus-seo-cockpit__insight-head {
     display: flex;
     align-items: center;
-    gap: 10px;
-    margin-bottom: 10px;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 8px;
+}
+
+.nexus-seo-cockpit__insight-head strong {
+    font-size: 14px;
+    line-height: 1.3;
+    color: var(--nsc-ink);
 }
 
 .nexus-seo-cockpit__insight-meta {
     display: flex;
     flex-wrap: wrap;
-    gap: 10px 16px;
-    color: #55616f;
-    font-size: 13px;
+    gap: 6px 14px;
+    margin-top: 8px;
+    padding-top: 8px;
+    border-top: 1px dashed var(--nsc-border);
+    color: var(--nsc-ink-soft);
+    font-size: 12px;
 }
+
+/* --- Badges ------------------------------------------------------------- */
 
 .nexus-seo-cockpit__badge {
     display: inline-flex;
     align-items: center;
-    min-height: 24px;
+    min-height: 22px;
     padding: 0 10px;
     border-radius: 999px;
-    background: #eef2f6;
-    color: #24303c;
+    background: var(--nsc-surface-muted);
+    color: var(--nsc-ink);
     font-size: 11px;
     font-weight: 700;
     text-transform: uppercase;
-    letter-spacing: 0.08em;
+    letter-spacing: 0.06em;
+    line-height: 1.2;
+    white-space: nowrap;
 }
 
 .nexus-seo-cockpit__badge.is-critical {
-    background: #fde8e8;
-    color: #8f1d1d;
+    background: var(--nsc-danger-soft);
+    color: var(--nsc-danger);
 }
 
 .nexus-seo-cockpit__badge.is-high {
-    background: #fff1d8;
-    color: #915500;
+    background: var(--nsc-warning-soft);
+    color: var(--nsc-warning);
 }
 
 .nexus-seo-cockpit__badge.is-medium {
-    background: #eef2f6;
-    color: #24303c;
+    background: var(--nsc-info-soft);
+    color: var(--nsc-info);
 }
 
 .nexus-seo-cockpit__badge.is-low {
-    background: #eef6ef;
-    color: #0f7a3c;
+    background: var(--nsc-success-soft);
+    color: var(--nsc-success);
 }
 
 .nexus-seo-cockpit__badge.is-ok {
-    background: #eef6ef;
-    color: #0f7a3c;
+    background: var(--nsc-success-soft);
+    color: var(--nsc-success);
 }
 
 .nexus-seo-cockpit__badge.is-warning {
-    background: #fff1d8;
-    color: #915500;
+    background: var(--nsc-warning-soft);
+    color: var(--nsc-warning);
 }
 
 .nexus-seo-cockpit__badge.is-error {
-    background: #fde8e8;
-    color: #8f1d1d;
+    background: var(--nsc-danger-soft);
+    color: var(--nsc-danger);
 }
+
+/* --- Koko + Lead metric tiles ------------------------------------------ */
 
 .nexus-seo-cockpit__koko-metrics {
     display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 12px;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 10px;
     margin: 14px 0 0;
+}
+
+.nexus-seo-cockpit__koko-metrics--two {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .nexus-seo-cockpit__koko-card {
     padding: 14px 16px;
-    border: 1px solid #e1e6ec;
-    border-radius: 16px;
-    background: #f9fafc;
+    border: 1px solid var(--nsc-border);
+    border-radius: var(--nsc-radius-sm);
+    background: var(--nsc-surface-muted);
 }
 
 .nexus-seo-cockpit__koko-value {
     display: block;
     margin-top: 4px;
-    color: #121920;
-    font-size: 24px;
+    color: var(--nsc-ink);
+    font-size: 22px;
+    font-weight: 700;
     line-height: 1.15;
+    letter-spacing: -0.01em;
 }
+
+.nexus-seo-cockpit__metric-label {
+    color: var(--nsc-ink-soft);
+}
+
+.nexus-seo-cockpit__koko-card .nexus-seo-cockpit__metric-label {
+    margin-bottom: 0;
+    font-size: 11px;
+}
+
+/* --- Diagnostics -------------------------------------------------------- */
 
 .nexus-seo-cockpit__diagnostics {
     display: grid;
-    gap: 12px;
+    gap: 10px;
 }
 
 .nexus-seo-cockpit__diagnostic-card {
-    padding: 14px 16px;
-    border: 1px solid #e1e6ec;
-    border-radius: 16px;
-    background: #fafbfd;
+    padding: 12px 14px;
+    border: 1px solid var(--nsc-border);
+    border-radius: var(--nsc-radius-sm);
+    background: var(--nsc-surface-muted);
+}
+
+.nexus-seo-cockpit__diagnostic-card p {
+    margin: 6px 0 0;
+    font-size: 12px;
+    line-height: 1.5;
+}
+
+/* --- Tables ------------------------------------------------------------- */
+
+.nexus-seo-cockpit__table-wrap {
+    overflow-x: auto;
+    border-radius: var(--nsc-radius-sm);
+    border: 1px solid var(--nsc-border);
+}
+
+.nexus-seo-cockpit__table {
+    border: 0;
+    border-radius: 0;
+}
+
+.nexus-seo-cockpit__table th,
+.nexus-seo-cockpit__table td {
+    vertical-align: top;
+}
+
+.nexus-seo-cockpit__table thead th {
+    background: var(--nsc-surface-muted);
+    color: var(--nsc-ink-muted);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
 }
 
 .nexus-seo-cockpit__table code {
     font-size: 12px;
+    word-break: break-all;
 }
 
 .nexus-seo-cockpit__table-note {
     margin: 6px 0 0;
-    color: #5e6977;
+    color: var(--nsc-ink-soft);
     font-size: 12px;
     line-height: 1.5;
 }
@@ -445,9 +792,98 @@
     margin-top: 10px;
 }
 
+/* --- Settings form ------------------------------------------------------ */
+
 .nexus-seo-cockpit__settings-form .form-table th {
     width: 220px;
 }
+
+/* --- Section separator -------------------------------------------------- */
+
+.nexus-seo-cockpit__section-title {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin: 26px 0 14px;
+    color: var(--nsc-ink);
+    font-size: 13px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.nexus-seo-cockpit__section-title::after {
+    content: "";
+    flex: 1;
+    height: 1px;
+    background: var(--nsc-border);
+}
+
+.nexus-seo-cockpit__section-title span {
+    color: var(--nsc-ink-soft);
+    font-weight: 600;
+    text-transform: none;
+    letter-spacing: 0;
+    font-size: 12px;
+}
+
+/* --- Disclosure (Technik / Verbindung) ---------------------------------- */
+
+.nexus-seo-cockpit__disclosure {
+    margin: 16px 0;
+    border: 1px solid var(--nsc-border);
+    border-radius: var(--nsc-radius);
+    background: var(--nsc-surface);
+    box-shadow: var(--nsc-shadow-sm);
+}
+
+.nexus-seo-cockpit__disclosure[open] {
+    box-shadow: var(--nsc-shadow);
+}
+
+.nexus-seo-cockpit__disclosure > summary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 16px 20px;
+    cursor: pointer;
+    list-style: none;
+    font-weight: 700;
+    color: var(--nsc-ink);
+}
+
+.nexus-seo-cockpit__disclosure > summary::-webkit-details-marker {
+    display: none;
+}
+
+.nexus-seo-cockpit__disclosure > summary::after {
+    content: "+";
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background: var(--nsc-surface-muted);
+    color: var(--nsc-ink-muted);
+    font-size: 16px;
+    line-height: 1;
+}
+
+.nexus-seo-cockpit__disclosure[open] > summary::after {
+    content: "\2212";
+}
+
+.nexus-seo-cockpit__disclosure-body {
+    padding: 0 20px 20px;
+}
+
+.nexus-seo-cockpit__disclosure-body .nexus-seo-cockpit__grid {
+    margin-top: 0;
+}
+
+/* --- Dashboard widget --------------------------------------------------- */
 
 .nexus-seo-widget__status,
 .nexus-seo-widget__hint {
@@ -469,40 +905,94 @@
 
 .nexus-seo-widget__metric {
     padding: 12px;
-    border: 1px solid #dde2e8;
-    border-radius: 14px;
-    background: #f7f8fa;
+    border: 1px solid var(--nsc-border);
+    border-radius: 12px;
+    background: var(--nsc-surface-muted);
 }
 
 .nexus-seo-widget__metric span {
     display: block;
     margin-bottom: 6px;
-    color: #5e6977;
-    font-size: 12px;
+    color: var(--nsc-ink-soft);
+    font-size: 11px;
     text-transform: uppercase;
     letter-spacing: 0.08em;
+    font-weight: 700;
 }
 
 .nexus-seo-widget__metric strong {
     display: block;
-    color: #121920;
+    color: var(--nsc-ink);
     font-size: 20px;
     line-height: 1.15;
+    font-weight: 700;
 }
 
 .nexus-seo-widget__insights {
     margin: 0 0 12px;
     padding-left: 18px;
+    color: var(--nsc-ink-muted);
 }
 
-@media (max-width: 1180px) {
-    .nexus-seo-cockpit__grid--top,
-    .nexus-seo-cockpit__grid--reports,
-    .nexus-seo-cockpit__grid--detail,
-    .nexus-seo-cockpit__metrics,
-    .nexus-seo-cockpit__koko-metrics,
-    .nexus-seo-cockpit__trend-grid,
-    .nexus-seo-cockpit__header-grid {
+/* --- Responsive --------------------------------------------------------- */
+
+@media (max-width: 1280px) {
+    .nexus-seo-cockpit__trend-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .nexus-seo-cockpit__koko-metrics {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@media (max-width: 1100px) {
+    .nexus-seo-cockpit__grid--hero,
+    .nexus-seo-cockpit__grid--triple {
         grid-template-columns: 1fr;
+    }
+
+    .nexus-seo-cockpit__metrics {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@media (max-width: 860px) {
+    .nexus-seo-cockpit__toolbar {
+        position: static;
+    }
+
+    .nexus-seo-cockpit__strip {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .nexus-seo-cockpit__grid--reports,
+    .nexus-seo-cockpit__grid--detail {
+        grid-template-columns: 1fr;
+    }
+
+    .nexus-seo-cockpit__meta-list {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 560px) {
+    .nexus-seo-cockpit__metrics,
+    .nexus-seo-cockpit__trend-grid,
+    .nexus-seo-cockpit__koko-metrics,
+    .nexus-seo-cockpit__strip {
+        grid-template-columns: 1fr;
+    }
+
+    .nexus-seo-cockpit__metric-card {
+        padding: 16px;
+    }
+
+    .nexus-seo-cockpit__metric-value {
+        font-size: 26px;
+    }
+
+    .nexus-seo-cockpit__panel {
+        padding: 16px;
     }
 }

--- a/blocksy-child/inc/seo-cockpit/seo-cockpit-ui.php
+++ b/blocksy-child/inc/seo-cockpit/seo-cockpit-ui.php
@@ -966,41 +966,49 @@ function nexus_render_seo_cockpit_dashboard() {
 		<h1>SEO Cockpit</h1>
 		<?php nexus_render_seo_cockpit_notice(); ?>
 
-		<section class="nexus-seo-cockpit__panel nexus-seo-cockpit__header">
-			<div class="nexus-seo-cockpit__panel-head">
-				<div>
-					<h2>SEO Operating Layer</h2>
-					<p class="nexus-seo-cockpit__hint">Property: <code><?php echo esc_html( $config['property'] ?: 'Noch nicht gesetzt' ); ?></code></p>
-				</div>
-				<div class="nexus-seo-cockpit__actions">
-					<?php nexus_render_seo_cockpit_range_switcher( $range_days, $detail_url ); ?>
-					<?php if ( $can_manage && $is_connected ) : ?>
-						<form method="post" action="<?php echo esc_url( nexus_get_seo_cockpit_admin_action_url( 'nexus_seo_cockpit_refresh' ) ); ?>">
-							<?php wp_nonce_field( 'nexus_seo_cockpit_refresh' ); ?>
-							<input type="hidden" name="range" value="<?php echo esc_attr( (string) $range_days ); ?>">
-							<input type="hidden" name="detail_url" value="<?php echo esc_attr( $detail_url ); ?>">
-							<button type="submit" class="button button-primary">Jetzt synchronisieren</button>
-						</form>
-						<form method="post" action="<?php echo esc_url( nexus_get_seo_cockpit_admin_action_url( 'nexus_seo_cockpit_disconnect' ) ); ?>">
-							<?php wp_nonce_field( 'nexus_seo_cockpit_disconnect' ); ?>
-							<button type="submit" class="button button-secondary">Verbindung trennen</button>
-						</form>
-					<?php elseif ( $can_manage ) : ?>
-						<form method="post" action="<?php echo esc_url( nexus_get_seo_cockpit_admin_action_url( 'nexus_seo_cockpit_connect' ) ); ?>">
-							<?php wp_nonce_field( 'nexus_seo_cockpit_connect' ); ?>
-							<button type="submit" class="button button-primary" <?php disabled( ! nexus_has_seo_cockpit_search_console_credentials() ); ?>>Mit Google verbinden</button>
-						</form>
-					<?php endif; ?>
-				</div>
+		<div class="nexus-seo-cockpit__toolbar">
+			<div class="nexus-seo-cockpit__toolbar-meta">
+				<span class="nexus-seo-cockpit__status-dot <?php echo esc_attr( $is_connected ? 'is-connected' : 'is-warning' ); ?>">
+					<?php echo esc_html( $is_connected ? 'Verbunden' : 'Nicht verbunden' ); ?>
+				</span>
+				<span><strong>Property:</strong> <code><?php echo esc_html( $config['property'] ?: 'Noch nicht gesetzt' ); ?></code></span>
 			</div>
+			<div class="nexus-seo-cockpit__toolbar-actions">
+				<?php nexus_render_seo_cockpit_range_switcher( $range_days, $detail_url ); ?>
+				<?php if ( $can_manage && $is_connected ) : ?>
+					<form method="post" action="<?php echo esc_url( nexus_get_seo_cockpit_admin_action_url( 'nexus_seo_cockpit_refresh' ) ); ?>">
+						<?php wp_nonce_field( 'nexus_seo_cockpit_refresh' ); ?>
+						<input type="hidden" name="range" value="<?php echo esc_attr( (string) $range_days ); ?>">
+						<input type="hidden" name="detail_url" value="<?php echo esc_attr( $detail_url ); ?>">
+						<button type="submit" class="button button-primary">Jetzt synchronisieren</button>
+					</form>
+				<?php elseif ( $can_manage ) : ?>
+					<form method="post" action="<?php echo esc_url( nexus_get_seo_cockpit_admin_action_url( 'nexus_seo_cockpit_connect' ) ); ?>">
+						<?php wp_nonce_field( 'nexus_seo_cockpit_connect' ); ?>
+						<button type="submit" class="button button-primary" <?php disabled( ! nexus_has_seo_cockpit_search_console_credentials() ); ?>>Mit Google verbinden</button>
+					</form>
+				<?php endif; ?>
+			</div>
+		</div>
 
-			<div class="nexus-seo-cockpit__header-grid">
-				<div><strong>Status</strong><span><?php echo esc_html( $is_connected ? 'Verbunden' : 'Noch nicht verbunden' ); ?></span></div>
-				<div><strong>Letzter Sync</strong><span><?php echo esc_html( ! empty( $runtime['last_sync_at'] ) ? wp_date( 'd.m.Y H:i', (int) $runtime['last_sync_at'] ) : 'n/a' ); ?></span></div>
-				<div><strong>Nächster Sync</strong><span><?php echo esc_html( ! empty( $runtime['next_sync_at'] ) ? wp_date( 'd.m.Y H:i', (int) $runtime['next_sync_at'] ) : 'n/a' ); ?></span></div>
-				<div><strong>Cache bis</strong><span><?php echo esc_html( ! empty( $runtime['cache_expires_at'] ) ? wp_date( 'd.m.Y H:i', (int) $runtime['cache_expires_at'] ) : 'n/a' ); ?></span></div>
+		<div class="nexus-seo-cockpit__strip">
+			<div class="nexus-seo-cockpit__strip-cell">
+				<strong>Letzter Sync</strong>
+				<span><?php echo esc_html( ! empty( $runtime['last_sync_at'] ) ? wp_date( 'd.m.Y H:i', (int) $runtime['last_sync_at'] ) : 'n/a' ); ?></span>
 			</div>
-		</section>
+			<div class="nexus-seo-cockpit__strip-cell">
+				<strong>Nächster Sync</strong>
+				<span><?php echo esc_html( ! empty( $runtime['next_sync_at'] ) ? wp_date( 'd.m.Y H:i', (int) $runtime['next_sync_at'] ) : 'n/a' ); ?></span>
+			</div>
+			<div class="nexus-seo-cockpit__strip-cell">
+				<strong>Cache bis</strong>
+				<span><?php echo esc_html( ! empty( $runtime['cache_expires_at'] ) ? wp_date( 'd.m.Y H:i', (int) $runtime['cache_expires_at'] ) : 'n/a' ); ?></span>
+			</div>
+			<div class="nexus-seo-cockpit__strip-cell">
+				<strong>Koko Analytics</strong>
+				<span><?php echo esc_html( $koko['active'] ? 'Aktiv' : 'Nicht aktiv' ); ?></span>
+			</div>
+		</div>
 
 		<?php if ( ! $setup['is_ready'] ) : ?>
 			<section class="nexus-seo-cockpit__panel nexus-seo-cockpit__panel--setup">
@@ -1032,48 +1040,6 @@ function nexus_render_seo_cockpit_dashboard() {
 			</section>
 		<?php endif; ?>
 
-		<div class="nexus-seo-cockpit__grid nexus-seo-cockpit__grid--top">
-			<section class="nexus-seo-cockpit__panel">
-				<div class="nexus-seo-cockpit__panel-head">
-					<h2>Verbindung & Technik</h2>
-					<?php if ( $can_manage ) : ?>
-						<a class="button button-secondary" href="<?php echo esc_url( nexus_get_seo_cockpit_settings_url() ); ?>">Einstellungen</a>
-					<?php endif; ?>
-				</div>
-				<ul class="nexus-seo-cockpit__meta-list">
-					<li><strong>Property:</strong> <?php echo esc_html( $config['property'] ?: 'Noch nicht gesetzt' ); ?></li>
-					<li><strong>Redirect URI:</strong> <code><?php echo esc_html( $config['redirect_uri'] ); ?></code></li>
-					<li><strong>Token aktualisiert:</strong> <?php echo esc_html( ! empty( $tokens['updated_at'] ) ? wp_date( 'd.m.Y H:i', (int) $tokens['updated_at'] ) : 'n/a' ); ?></li>
-					<li><strong>Sync-Quelle:</strong> <?php echo esc_html( (string) ( $runtime['last_sync_source'] ?? 'n/a' ) ); ?></li>
-					<li><strong>Letzter Status:</strong> <?php echo esc_html( (string) ( $runtime['last_sync_status'] ?? 'n/a' ) ); ?></li>
-				</ul>
-				<?php if ( is_wp_error( $site_list ) ) : ?>
-					<p class="nexus-seo-cockpit__hint"><?php echo esc_html( $site_list->get_error_message() ); ?></p>
-				<?php elseif ( ! empty( $site_list ) ) : ?>
-					<div class="nexus-seo-cockpit__chips">
-						<?php foreach ( array_slice( $site_list, 0, 8 ) as $site_entry ) : ?>
-							<span class="nexus-seo-cockpit__chip"><?php echo esc_html( (string) ( $site_entry['siteUrl'] ?? '' ) ); ?></span>
-						<?php endforeach; ?>
-					</div>
-				<?php endif; ?>
-			</section>
-
-			<section class="nexus-seo-cockpit__panel">
-				<h2>Koko Analytics</h2>
-				<p class="nexus-seo-cockpit__status <?php echo esc_attr( $koko['active'] ? 'is-positive' : 'is-neutral' ); ?>">
-					<?php echo esc_html( $koko['label'] ); ?>
-				</p>
-				<?php if ( ! empty( $koko['note'] ) ) : ?>
-					<p class="nexus-seo-cockpit__hint"><?php echo esc_html( (string) $koko['note'] ); ?></p>
-				<?php endif; ?>
-				<div class="nexus-seo-cockpit__chips">
-					<span class="nexus-seo-cockpit__chip">Totals: <?php echo esc_html( ! empty( $koko['endpoints']['totals'] ) ? 'ja' : 'nein' ); ?></span>
-					<span class="nexus-seo-cockpit__chip">Stats: <?php echo esc_html( ! empty( $koko['endpoints']['stats'] ) ? 'ja' : 'nein' ); ?></span>
-					<span class="nexus-seo-cockpit__chip">Posts: <?php echo esc_html( ! empty( $koko['endpoints']['posts'] ) ? 'ja' : 'nein' ); ?></span>
-				</div>
-			</section>
-		</div>
-
 		<?php if ( is_wp_error( $snapshot ) ) : ?>
 			<section class="nexus-seo-cockpit__panel">
 				<h2>Noch kein SEO-Snapshot</h2>
@@ -1087,15 +1053,17 @@ function nexus_render_seo_cockpit_dashboard() {
 			$koko_snapshot = is_array( $snapshot['koko'] ?? null ) ? $snapshot['koko'] : [];
 			$lead_snapshot = is_array( $snapshot['leads'] ?? null ) ? $snapshot['leads'] : [];
 			?>
+
 			<section class="nexus-seo-cockpit__panel">
 				<div class="nexus-seo-cockpit__panel-head">
 					<div>
-						<h2>SEO-Lage</h2>
+						<p class="nexus-seo-cockpit__eyebrow">SEO-Lage · Letzte <?php echo esc_html( $range_days ); ?> Tage</p>
+						<h2>Performance-Überblick</h2>
 						<p class="nexus-seo-cockpit__hint">
 							<?php
 							echo esc_html(
 								sprintf(
-									'Vergleich %s bis %s gegen %s bis %s. Stand: %s',
+									'Vergleich %s – %s gegen %s – %s. Stand: %s',
 									(string) $snapshot['ranges']['current_start'],
 									(string) $snapshot['ranges']['current_end'],
 									(string) $snapshot['ranges']['previous_start'],
@@ -1111,11 +1079,35 @@ function nexus_render_seo_cockpit_dashboard() {
 				<?php nexus_render_seo_cockpit_metric_cards( (array) $current, (array) $previous ); ?>
 			</section>
 
+			<h3 class="nexus-seo-cockpit__section-title">Wichtigste Aufgaben <span>Was jetzt Aufmerksamkeit braucht</span></h3>
+
+			<div class="nexus-seo-cockpit__grid nexus-seo-cockpit__grid--hero">
+				<section class="nexus-seo-cockpit__panel nexus-seo-cockpit__panel--primary">
+					<div class="nexus-seo-cockpit__panel-head">
+						<div>
+							<h2>Prioritäts-Queue</h2>
+							<p class="nexus-seo-cockpit__hint">Sortiert nach SEO-Chance, Business-Wert, Funnel-Nähe und Datensicherheit.</p>
+						</div>
+					</div>
+					<div class="nexus-seo-cockpit__table-wrap">
+						<?php nexus_render_seo_cockpit_priority_queue( (array) ( $snapshot['insights'] ?? [] ), 10 ); ?>
+					</div>
+				</section>
+
+				<section class="nexus-seo-cockpit__panel">
+					<div class="nexus-seo-cockpit__panel-head">
+						<div>
+							<h2>Top Hinweise</h2>
+							<p class="nexus-seo-cockpit__hint">Detail-Insights mit Nächstem Schritt.</p>
+						</div>
+					</div>
+					<?php nexus_render_seo_cockpit_insights_list( (array) ( $snapshot['insights'] ?? [] ), 4 ); ?>
+				</section>
+			</div>
+
+			<h3 class="nexus-seo-cockpit__section-title">Trend <span>Tagesauflösung über den gewählten Zeitraum</span></h3>
+
 			<section class="nexus-seo-cockpit__panel">
-				<div class="nexus-seo-cockpit__panel-head">
-					<h2>Trend</h2>
-					<p class="nexus-seo-cockpit__hint"><?php echo esc_html( $range_days ); ?> Tage mit Tagesauflösung</p>
-				</div>
 				<div class="nexus-seo-cockpit__trend-grid">
 					<?php
 					nexus_render_seo_cockpit_trend_card( (array) $snapshot['trend'], 'clicks', 'Klicks' );
@@ -1126,14 +1118,108 @@ function nexus_render_seo_cockpit_dashboard() {
 				</div>
 			</section>
 
+			<h3 class="nexus-seo-cockpit__section-title">Probleme & Chancen <span>Seiten mit kritischem Handlungsbedarf</span></h3>
+
 			<section class="nexus-seo-cockpit__panel">
-				<div class="nexus-seo-cockpit__panel-head">
-					<h2>Lead-Kontext</h2>
-					<p class="nexus-seo-cockpit__hint">Audit-Leads aus dem internen WordPress-CRM. Die interne Seitenzuordnung nutzt Einstieg, letzte interne Seite und Formular-Landing.</p>
-				</div>
+				<?php if ( empty( $snapshot['problem_pages'] ) ) : ?>
+					<p class="nexus-seo-cockpit__hint">Für dieses Zeitfenster wurden keine priorisierten Problemseiten erkannt.</p>
+				<?php else : ?>
+					<div class="nexus-seo-cockpit__table-wrap">
+						<table class="widefat striped nexus-seo-cockpit__table">
+							<thead>
+								<tr>
+									<th>Prio</th>
+									<th>Segment</th>
+									<th>URL</th>
+									<th>Typ</th>
+									<th>Impressionen</th>
+									<th>Position</th>
+									<th>SEO</th>
+									<th>Koko</th>
+									<th>Leads</th>
+									<th>Primärer Hinweis</th>
+								</tr>
+							</thead>
+							<tbody>
+								<?php foreach ( (array) $snapshot['problem_pages'] as $page ) : ?>
+									<?php
+									$context = is_array( $page['context'] ?? null ) ? $page['context'] : [];
+									$primary = is_array( $page['primary'] ?? null ) ? $page['primary'] : [];
+									$lead_page = is_array( $lead_snapshot['page_map'][ (string) $page['url'] ] ?? null ) ? $lead_snapshot['page_map'][ (string) $page['url'] ] : [];
+									?>
+									<tr>
+										<td>
+											<span class="nexus-seo-cockpit__badge is-<?php echo esc_attr( (string) ( $primary['priority_bucket'] ?? 'low' ) ); ?>">
+												<?php
+												echo esc_html(
+													sprintf(
+														'%s · %d',
+														(string) ( $primary['priority_label'] ?? 'P4' ),
+														(int) ( $primary['priority_score'] ?? 0 )
+													)
+												);
+												?>
+											</span>
+										</td>
+										<td><?php echo esc_html( (string) ( $primary['page_role_label'] ?? '—' ) ); ?></td>
+										<td><a href="<?php echo esc_url( (string) $page['detail_url'] ); ?>"><code><?php echo esc_html( (string) $page['url'] ); ?></code></a></td>
+										<td><?php echo esc_html( (string) ( $context['post_type'] ?? '—' ) ); ?></td>
+										<td><?php echo esc_html( number_format_i18n( (float) ( $page['row']['impressions'] ?? 0 ) ) ); ?></td>
+										<td><?php echo esc_html( number_format_i18n( (float) ( $page['row']['position'] ?? 0 ), 1 ) ); ?></td>
+										<td>
+											<?php
+											echo esc_html(
+												sprintf(
+													'Title: %s / Desc: %s / noindex: %s',
+													! empty( $context['seo_title_present'] ) ? 'Ja' : 'Nein',
+													! empty( $context['seo_description_present'] ) ? 'Ja' : 'Nein',
+													! empty( $context['noindex'] ) ? 'Ja' : 'Nein'
+												)
+											);
+											?>
+										</td>
+										<td>
+											<?php
+											$koko_page = is_array( $koko_snapshot['page_map'][ (string) $page['url'] ] ?? null ) ? $koko_snapshot['page_map'][ (string) $page['url'] ] : [];
+											echo esc_html(
+												! empty( $koko_page )
+													? sprintf(
+														'%s / %s',
+														number_format_i18n( (float) ( $koko_page['visitors'] ?? 0 ) ),
+														number_format_i18n( (float) ( $koko_page['pageviews'] ?? 0 ) )
+													)
+													: '—'
+											);
+											?>
+										</td>
+										<td>
+											<?php
+											echo esc_html(
+												! empty( $lead_page )
+													? sprintf(
+														'%d / %d',
+														(int) ( $lead_page['current']['requests'] ?? 0 ),
+														(int) ( $lead_page['lifetime']['requests'] ?? 0 )
+													)
+													: '—'
+											);
+											?>
+										</td>
+										<td><?php echo esc_html( (string) ( $primary['label'] ?? '' ) ); ?></td>
+									</tr>
+								<?php endforeach; ?>
+							</tbody>
+						</table>
+					</div>
+				<?php endif; ?>
+			</section>
+
+			<h3 class="nexus-seo-cockpit__section-title">Business Impact <span>Lead-Performance pro Landingpage</span></h3>
+
+			<section class="nexus-seo-cockpit__panel">
 				<?php if ( ! empty( $lead_snapshot['available'] ) ) : ?>
 					<?php nexus_render_seo_cockpit_lead_metrics( (array) ( $lead_snapshot['overview']['current'] ?? [] ), (array) ( $lead_snapshot['overview']['previous'] ?? [] ) ); ?>
-					<p class="nexus-seo-cockpit__hint">
+					<p class="nexus-seo-cockpit__hint" style="margin-top:14px;">
 						<?php
 						echo esc_html(
 							sprintf(
@@ -1152,61 +1238,145 @@ function nexus_render_seo_cockpit_dashboard() {
 							<?php endforeach; ?>
 						</div>
 					<?php endif; ?>
-					<?php nexus_render_seo_cockpit_lead_pages_table( (array) ( $lead_snapshot['top_pages'] ?? [] ), 6, 'current' ); ?>
+					<div class="nexus-seo-cockpit__table-wrap" style="margin-top:14px;">
+						<?php nexus_render_seo_cockpit_lead_pages_table( (array) ( $lead_snapshot['top_pages'] ?? [] ), 6, 'current' ); ?>
+					</div>
 				<?php else : ?>
 					<p class="nexus-seo-cockpit__hint"><?php echo esc_html( (string) ( $lead_snapshot['note'] ?? 'Lead-Daten sind derzeit nicht verfügbar.' ) ); ?></p>
 				<?php endif; ?>
 			</section>
 
+			<h3 class="nexus-seo-cockpit__section-title">Performance-Verteilung <span>Top Pages & Top Queries im Zeitfenster</span></h3>
+
 			<div class="nexus-seo-cockpit__grid nexus-seo-cockpit__grid--reports">
 				<section class="nexus-seo-cockpit__panel">
-					<h2>Prioritäts-Queue</h2>
-					<p class="nexus-seo-cockpit__hint">Sortiert nach SEO-Chance, Business-Wert, Funnel-Nähe und Datensicherheit.</p>
-					<?php nexus_render_seo_cockpit_priority_queue( (array) ( $snapshot['insights'] ?? [] ), 10 ); ?>
+					<h2>Top Pages</h2>
+					<div class="nexus-seo-cockpit__table-wrap">
+						<table class="widefat striped nexus-seo-cockpit__table">
+							<thead>
+								<tr>
+									<th>URL</th>
+									<th>Klicks</th>
+									<th>Impressionen</th>
+									<th>CTR</th>
+									<th>Position</th>
+									<th>Koko</th>
+									<th>Leads</th>
+									<th>WP-Kontext</th>
+								</tr>
+							</thead>
+							<tbody>
+								<?php foreach ( (array) $snapshot['top_pages'] as $row ) : ?>
+									<?php
+									$url     = nexus_normalize_seo_cockpit_url( nexus_get_seo_cockpit_row_label( $row ) );
+									$context = $snapshot['page_contexts'][ $url ] ?? nexus_get_seo_cockpit_wp_context_for_url( $url );
+									$lead_page = is_array( $lead_snapshot['page_map'][ $url ] ?? null ) ? $lead_snapshot['page_map'][ $url ] : [];
+									?>
+									<tr>
+										<td><a href="<?php echo esc_url( nexus_get_seo_cockpit_detail_url( $url ) ); ?>"><code><?php echo esc_html( $url ); ?></code></a></td>
+										<td><?php echo esc_html( number_format_i18n( (float) ( $row['clicks'] ?? 0 ) ) ); ?></td>
+										<td><?php echo esc_html( number_format_i18n( (float) ( $row['impressions'] ?? 0 ) ) ); ?></td>
+										<td><?php echo esc_html( number_format_i18n( (float) ( ( $row['ctr'] ?? 0 ) * 100 ), 1 ) . '%' ); ?></td>
+										<td><?php echo esc_html( number_format_i18n( (float) ( $row['position'] ?? 0 ), 1 ) ); ?></td>
+										<td>
+											<?php
+											$koko_page = is_array( $koko_snapshot['page_map'][ $url ] ?? null ) ? $koko_snapshot['page_map'][ $url ] : [];
+											echo esc_html(
+												! empty( $koko_page )
+													? sprintf(
+														'%s / %s',
+														number_format_i18n( (float) ( $koko_page['visitors'] ?? 0 ) ),
+														number_format_i18n( (float) ( $koko_page['pageviews'] ?? 0 ) )
+													)
+													: '—'
+											);
+											?>
+										</td>
+										<td>
+											<?php
+											echo esc_html(
+												! empty( $lead_page )
+													? sprintf(
+														'%d / %d',
+														(int) ( $lead_page['current']['requests'] ?? 0 ),
+														(int) ( $lead_page['lifetime']['requests'] ?? 0 )
+													)
+													: '—'
+											);
+											?>
+										</td>
+										<td><?php echo esc_html( (string) ( $context['post_type'] ?? 'nicht zugeordnet' ) ); ?></td>
+									</tr>
+								<?php endforeach; ?>
+							</tbody>
+						</table>
+					</div>
 				</section>
 
 				<section class="nexus-seo-cockpit__panel">
-					<h2>Runtime-Diagnostik</h2>
-					<?php nexus_render_seo_cockpit_diagnostics_list( $diagnostics, 6 ); ?>
+					<h2>Top Queries</h2>
+					<div class="nexus-seo-cockpit__table-wrap">
+						<table class="widefat striped nexus-seo-cockpit__table">
+							<thead>
+								<tr>
+									<th>Query</th>
+									<th>Klicks</th>
+									<th>Impressionen</th>
+									<th>CTR</th>
+									<th>Position</th>
+								</tr>
+							</thead>
+							<tbody>
+								<?php foreach ( (array) $snapshot['top_queries'] as $row ) : ?>
+									<tr>
+										<td><?php echo esc_html( nexus_get_seo_cockpit_row_label( $row ) ); ?></td>
+										<td><?php echo esc_html( number_format_i18n( (float) ( $row['clicks'] ?? 0 ) ) ); ?></td>
+										<td><?php echo esc_html( number_format_i18n( (float) ( $row['impressions'] ?? 0 ) ) ); ?></td>
+										<td><?php echo esc_html( number_format_i18n( (float) ( ( $row['ctr'] ?? 0 ) * 100 ), 1 ) . '%' ); ?></td>
+										<td><?php echo esc_html( number_format_i18n( (float) ( $row['position'] ?? 0 ), 1 ) ); ?></td>
+									</tr>
+								<?php endforeach; ?>
+							</tbody>
+						</table>
+					</div>
 				</section>
 			</div>
 
-			<section class="nexus-seo-cockpit__panel">
-				<h2>Top Hinweise</h2>
-				<?php nexus_render_seo_cockpit_insights_list( (array) ( $snapshot['insights'] ?? [] ), 6 ); ?>
-			</section>
+			<h3 class="nexus-seo-cockpit__section-title">Onsite & Index <span>Koko-Nutzung und Sitemap-Status</span></h3>
 
 			<div class="nexus-seo-cockpit__grid nexus-seo-cockpit__grid--reports">
 				<section class="nexus-seo-cockpit__panel">
 					<h2>Koko-Kontext</h2>
-					<p class="nexus-seo-cockpit__hint">Onsite-Nutzung für denselben Zeitraum. Das ist ein Kontextlayer für Nachfrage, nicht der Ersatz für Search Console.</p>
+					<p class="nexus-seo-cockpit__hint">Onsite-Nutzung für denselben Zeitraum. Kontextlayer für Nachfrage, kein Ersatz für Search Console.</p>
 					<?php if ( ! empty( $koko_snapshot['available'] ) ) : ?>
 						<?php nexus_render_seo_cockpit_koko_metrics( (array) ( $koko_snapshot['overview']['current'] ?? [] ), (array) ( $koko_snapshot['overview']['previous'] ?? [] ) ); ?>
 						<?php if ( ! empty( $koko_snapshot['top_pages'] ) ) : ?>
-							<table class="widefat striped nexus-seo-cockpit__table">
-								<thead>
-									<tr>
-										<th>Seite</th>
-										<th>Besucher</th>
-										<th>Pageviews</th>
-									</tr>
-								</thead>
-								<tbody>
-									<?php foreach ( (array) $koko_snapshot['top_pages'] as $row ) : ?>
+							<div class="nexus-seo-cockpit__table-wrap" style="margin-top:14px;">
+								<table class="widefat striped nexus-seo-cockpit__table">
+									<thead>
 										<tr>
-											<td>
-												<?php if ( ! empty( $row['url'] ) ) : ?>
-													<a href="<?php echo esc_url( nexus_get_seo_cockpit_detail_url( (string) $row['url'] ) ); ?>"><code><?php echo esc_html( (string) ( $row['title'] ?: $row['url'] ) ); ?></code></a>
-												<?php else : ?>
-													<?php echo esc_html( (string) ( $row['title'] ?? '—' ) ); ?>
-												<?php endif; ?>
-											</td>
-											<td><?php echo esc_html( number_format_i18n( (float) ( $row['visitors'] ?? 0 ) ) ); ?></td>
-											<td><?php echo esc_html( number_format_i18n( (float) ( $row['pageviews'] ?? 0 ) ) ); ?></td>
+											<th>Seite</th>
+											<th>Besucher</th>
+											<th>Pageviews</th>
 										</tr>
-									<?php endforeach; ?>
-								</tbody>
-							</table>
+									</thead>
+									<tbody>
+										<?php foreach ( (array) $koko_snapshot['top_pages'] as $row ) : ?>
+											<tr>
+												<td>
+													<?php if ( ! empty( $row['url'] ) ) : ?>
+														<a href="<?php echo esc_url( nexus_get_seo_cockpit_detail_url( (string) $row['url'] ) ); ?>"><code><?php echo esc_html( (string) ( $row['title'] ?: $row['url'] ) ); ?></code></a>
+													<?php else : ?>
+														<?php echo esc_html( (string) ( $row['title'] ?? '—' ) ); ?>
+													<?php endif; ?>
+												</td>
+												<td><?php echo esc_html( number_format_i18n( (float) ( $row['visitors'] ?? 0 ) ) ); ?></td>
+												<td><?php echo esc_html( number_format_i18n( (float) ( $row['pageviews'] ?? 0 ) ) ); ?></td>
+											</tr>
+										<?php endforeach; ?>
+									</tbody>
+								</table>
+							</div>
 						<?php endif; ?>
 					<?php else : ?>
 						<p class="nexus-seo-cockpit__hint">
@@ -1216,217 +1386,96 @@ function nexus_render_seo_cockpit_dashboard() {
 				</section>
 
 				<section class="nexus-seo-cockpit__panel">
-					<h2>Sitemaps & Technik</h2>
+					<h2>Sitemaps</h2>
 					<?php if ( ! empty( $snapshot['sitemaps'] ) ) : ?>
-						<table class="widefat striped nexus-seo-cockpit__table">
-							<thead>
-								<tr>
-									<th>Sitemap</th>
-									<th>Status</th>
-									<th>Typ</th>
-									<th>Zuletzt geladen</th>
-								</tr>
-							</thead>
-							<tbody>
-								<?php foreach ( (array) $snapshot['sitemaps'] as $sitemap ) : ?>
+						<div class="nexus-seo-cockpit__table-wrap">
+							<table class="widefat striped nexus-seo-cockpit__table">
+								<thead>
 									<tr>
-										<td><code><?php echo esc_html( (string) ( $sitemap['path'] ?? $sitemap['contents'] ?? '' ) ); ?></code></td>
-										<td><?php echo esc_html( (string) ( $sitemap['isPending'] ?? false ? 'Pending' : 'Aktiv' ) ); ?></td>
-										<td><?php echo esc_html( (string) ( $sitemap['type'] ?? '—' ) ); ?></td>
-										<td><?php echo esc_html( (string) ( $sitemap['lastDownloaded'] ?? '—' ) ); ?></td>
+										<th>Sitemap</th>
+										<th>Status</th>
+										<th>Typ</th>
+										<th>Zuletzt geladen</th>
 									</tr>
-								<?php endforeach; ?>
-							</tbody>
-						</table>
+								</thead>
+								<tbody>
+									<?php foreach ( (array) $snapshot['sitemaps'] as $sitemap ) : ?>
+										<tr>
+											<td><code><?php echo esc_html( (string) ( $sitemap['path'] ?? $sitemap['contents'] ?? '' ) ); ?></code></td>
+											<td><?php echo esc_html( (string) ( $sitemap['isPending'] ?? false ? 'Pending' : 'Aktiv' ) ); ?></td>
+											<td><?php echo esc_html( (string) ( $sitemap['type'] ?? '—' ) ); ?></td>
+											<td><?php echo esc_html( (string) ( $sitemap['lastDownloaded'] ?? '—' ) ); ?></td>
+										</tr>
+									<?php endforeach; ?>
+								</tbody>
+							</table>
+						</div>
 					<?php else : ?>
 						<p class="nexus-seo-cockpit__hint">Noch keine Sitemap-Daten in Search Console verfügbar oder abrufbar.</p>
 					<?php endif; ?>
-					<p class="nexus-seo-cockpit__hint">URL-Inspection wird im Drilldown bewusst nur manuell ausgeführt, damit Quotas nicht verbrannt werden.</p>
+					<p class="nexus-seo-cockpit__hint" style="margin-top:12px;">URL-Inspection wird im Drilldown bewusst nur manuell ausgeführt, damit Quotas nicht verbrannt werden.</p>
 				</section>
 			</div>
 
-			<section class="nexus-seo-cockpit__panel">
-				<h2>Problemseiten</h2>
-				<?php if ( empty( $snapshot['problem_pages'] ) ) : ?>
-					<p class="nexus-seo-cockpit__hint">Für dieses Zeitfenster wurden keine priorisierten Problemseiten erkannt.</p>
-				<?php else : ?>
-					<table class="widefat striped nexus-seo-cockpit__table">
-						<thead>
-							<tr>
-								<th>Prio</th>
-								<th>Segment</th>
-								<th>URL</th>
-								<th>Typ</th>
-								<th>Impressionen</th>
-								<th>Position</th>
-								<th>SEO</th>
-								<th>Koko</th>
-								<th>Leads</th>
-								<th>Primärer Hinweis</th>
-							</tr>
-						</thead>
-						<tbody>
-							<?php foreach ( (array) $snapshot['problem_pages'] as $page ) : ?>
-								<?php
-								$context = is_array( $page['context'] ?? null ) ? $page['context'] : [];
-								$primary = is_array( $page['primary'] ?? null ) ? $page['primary'] : [];
-								$lead_page = is_array( $lead_snapshot['page_map'][ (string) $page['url'] ] ?? null ) ? $lead_snapshot['page_map'][ (string) $page['url'] ] : [];
-								?>
-								<tr>
-									<td>
-										<span class="nexus-seo-cockpit__badge is-<?php echo esc_attr( (string) ( $primary['priority_bucket'] ?? 'low' ) ); ?>">
-											<?php
-											echo esc_html(
-												sprintf(
-													'%s · %d',
-													(string) ( $primary['priority_label'] ?? 'P4' ),
-													(int) ( $primary['priority_score'] ?? 0 )
-												)
-											);
-											?>
-										</span>
-									</td>
-									<td><?php echo esc_html( (string) ( $primary['page_role_label'] ?? '—' ) ); ?></td>
-									<td><a href="<?php echo esc_url( (string) $page['detail_url'] ); ?>"><code><?php echo esc_html( (string) $page['url'] ); ?></code></a></td>
-									<td><?php echo esc_html( (string) ( $context['post_type'] ?? '—' ) ); ?></td>
-									<td><?php echo esc_html( number_format_i18n( (float) ( $page['row']['impressions'] ?? 0 ) ) ); ?></td>
-									<td><?php echo esc_html( number_format_i18n( (float) ( $page['row']['position'] ?? 0 ), 1 ) ); ?></td>
-									<td>
-										<?php
-										echo esc_html(
-											sprintf(
-												'Title: %s / Desc: %s / noindex: %s',
-												! empty( $context['seo_title_present'] ) ? 'Ja' : 'Nein',
-												! empty( $context['seo_description_present'] ) ? 'Ja' : 'Nein',
-												! empty( $context['noindex'] ) ? 'Ja' : 'Nein'
-											)
-										);
-										?>
-									</td>
-									<td>
-										<?php
-										$koko_page = is_array( $koko_snapshot['page_map'][ (string) $page['url'] ] ?? null ) ? $koko_snapshot['page_map'][ (string) $page['url'] ] : [];
-										echo esc_html(
-											! empty( $koko_page )
-												? sprintf(
-													'%s / %s',
-													number_format_i18n( (float) ( $koko_page['visitors'] ?? 0 ) ),
-													number_format_i18n( (float) ( $koko_page['pageviews'] ?? 0 ) )
-												)
-												: '—'
-										);
-										?>
-									</td>
-									<td>
-										<?php
-										echo esc_html(
-											! empty( $lead_page )
-												? sprintf(
-													'%d / %d',
-													(int) ( $lead_page['current']['requests'] ?? 0 ),
-													(int) ( $lead_page['lifetime']['requests'] ?? 0 )
-												)
-												: '—'
-										);
-										?>
-									</td>
-									<td><?php echo esc_html( (string) ( $primary['label'] ?? '' ) ); ?></td>
-								</tr>
-							<?php endforeach; ?>
-						</tbody>
-					</table>
-				<?php endif; ?>
-			</section>
+			<details class="nexus-seo-cockpit__disclosure">
+				<summary>Technik, Verbindung & Diagnostik</summary>
+				<div class="nexus-seo-cockpit__disclosure-body">
+					<div class="nexus-seo-cockpit__grid nexus-seo-cockpit__grid--triple">
+						<section class="nexus-seo-cockpit__panel nexus-seo-cockpit__panel--compact">
+							<div class="nexus-seo-cockpit__panel-head">
+								<h2>Verbindung</h2>
+								<?php if ( $can_manage ) : ?>
+									<div class="nexus-seo-cockpit__actions">
+										<a class="button button-secondary" href="<?php echo esc_url( nexus_get_seo_cockpit_settings_url() ); ?>">Einstellungen</a>
+										<?php if ( $is_connected ) : ?>
+											<form method="post" action="<?php echo esc_url( nexus_get_seo_cockpit_admin_action_url( 'nexus_seo_cockpit_disconnect' ) ); ?>">
+												<?php wp_nonce_field( 'nexus_seo_cockpit_disconnect' ); ?>
+												<button type="submit" class="button button-secondary">Trennen</button>
+											</form>
+										<?php endif; ?>
+									</div>
+								<?php endif; ?>
+							</div>
+							<ul class="nexus-seo-cockpit__meta-list nexus-seo-cockpit__meta-list--single">
+								<li><strong>Property:</strong> <?php echo esc_html( $config['property'] ?: 'Noch nicht gesetzt' ); ?></li>
+								<li><strong>Redirect URI:</strong> <code><?php echo esc_html( $config['redirect_uri'] ); ?></code></li>
+								<li><strong>Token aktualisiert:</strong> <?php echo esc_html( ! empty( $tokens['updated_at'] ) ? wp_date( 'd.m.Y H:i', (int) $tokens['updated_at'] ) : 'n/a' ); ?></li>
+								<li><strong>Sync-Quelle:</strong> <?php echo esc_html( (string) ( $runtime['last_sync_source'] ?? 'n/a' ) ); ?></li>
+								<li><strong>Letzter Status:</strong> <?php echo esc_html( (string) ( $runtime['last_sync_status'] ?? 'n/a' ) ); ?></li>
+							</ul>
+							<?php if ( is_wp_error( $site_list ) ) : ?>
+								<p class="nexus-seo-cockpit__hint" style="margin-top:10px;"><?php echo esc_html( $site_list->get_error_message() ); ?></p>
+							<?php elseif ( ! empty( $site_list ) ) : ?>
+								<div class="nexus-seo-cockpit__chips">
+									<?php foreach ( array_slice( $site_list, 0, 6 ) as $site_entry ) : ?>
+										<span class="nexus-seo-cockpit__chip"><?php echo esc_html( (string) ( $site_entry['siteUrl'] ?? '' ) ); ?></span>
+									<?php endforeach; ?>
+								</div>
+							<?php endif; ?>
+						</section>
 
-			<div class="nexus-seo-cockpit__grid nexus-seo-cockpit__grid--reports">
-				<section class="nexus-seo-cockpit__panel">
-					<h2>Top Pages</h2>
-					<table class="widefat striped nexus-seo-cockpit__table">
-						<thead>
-							<tr>
-								<th>URL</th>
-								<th>Klicks</th>
-								<th>Impressionen</th>
-								<th>CTR</th>
-								<th>Position</th>
-								<th>Koko</th>
-								<th>Leads</th>
-								<th>WP-Kontext</th>
-							</tr>
-						</thead>
-						<tbody>
-							<?php foreach ( (array) $snapshot['top_pages'] as $row ) : ?>
-								<?php
-								$url     = nexus_normalize_seo_cockpit_url( nexus_get_seo_cockpit_row_label( $row ) );
-								$context = $snapshot['page_contexts'][ $url ] ?? nexus_get_seo_cockpit_wp_context_for_url( $url );
-								$lead_page = is_array( $lead_snapshot['page_map'][ $url ] ?? null ) ? $lead_snapshot['page_map'][ $url ] : [];
-								?>
-								<tr>
-									<td><a href="<?php echo esc_url( nexus_get_seo_cockpit_detail_url( $url ) ); ?>"><code><?php echo esc_html( $url ); ?></code></a></td>
-									<td><?php echo esc_html( number_format_i18n( (float) ( $row['clicks'] ?? 0 ) ) ); ?></td>
-									<td><?php echo esc_html( number_format_i18n( (float) ( $row['impressions'] ?? 0 ) ) ); ?></td>
-									<td><?php echo esc_html( number_format_i18n( (float) ( ( $row['ctr'] ?? 0 ) * 100 ), 1 ) . '%' ); ?></td>
-									<td><?php echo esc_html( number_format_i18n( (float) ( $row['position'] ?? 0 ), 1 ) ); ?></td>
-									<td>
-										<?php
-										$koko_page = is_array( $koko_snapshot['page_map'][ $url ] ?? null ) ? $koko_snapshot['page_map'][ $url ] : [];
-										echo esc_html(
-											! empty( $koko_page )
-												? sprintf(
-													'%s / %s',
-													number_format_i18n( (float) ( $koko_page['visitors'] ?? 0 ) ),
-													number_format_i18n( (float) ( $koko_page['pageviews'] ?? 0 ) )
-												)
-												: '—'
-										);
-										?>
-									</td>
-									<td>
-										<?php
-										echo esc_html(
-											! empty( $lead_page )
-												? sprintf(
-													'%d / %d',
-													(int) ( $lead_page['current']['requests'] ?? 0 ),
-													(int) ( $lead_page['lifetime']['requests'] ?? 0 )
-												)
-												: '—'
-										);
-										?>
-									</td>
-									<td><?php echo esc_html( (string) ( $context['post_type'] ?? 'nicht zugeordnet' ) ); ?></td>
-								</tr>
-							<?php endforeach; ?>
-						</tbody>
-					</table>
-				</section>
+						<section class="nexus-seo-cockpit__panel nexus-seo-cockpit__panel--compact">
+							<h2>Koko Analytics</h2>
+							<p class="nexus-seo-cockpit__status <?php echo esc_attr( $koko['active'] ? 'is-positive' : 'is-neutral' ); ?>">
+								<?php echo esc_html( $koko['label'] ); ?>
+							</p>
+							<?php if ( ! empty( $koko['note'] ) ) : ?>
+								<p class="nexus-seo-cockpit__hint"><?php echo esc_html( (string) $koko['note'] ); ?></p>
+							<?php endif; ?>
+							<div class="nexus-seo-cockpit__chips">
+								<span class="nexus-seo-cockpit__chip">Totals: <?php echo esc_html( ! empty( $koko['endpoints']['totals'] ) ? 'ja' : 'nein' ); ?></span>
+								<span class="nexus-seo-cockpit__chip">Stats: <?php echo esc_html( ! empty( $koko['endpoints']['stats'] ) ? 'ja' : 'nein' ); ?></span>
+								<span class="nexus-seo-cockpit__chip">Posts: <?php echo esc_html( ! empty( $koko['endpoints']['posts'] ) ? 'ja' : 'nein' ); ?></span>
+							</div>
+						</section>
 
-				<section class="nexus-seo-cockpit__panel">
-					<h2>Top Queries</h2>
-					<table class="widefat striped nexus-seo-cockpit__table">
-						<thead>
-							<tr>
-								<th>Query</th>
-								<th>Klicks</th>
-								<th>Impressionen</th>
-								<th>CTR</th>
-								<th>Position</th>
-							</tr>
-						</thead>
-						<tbody>
-							<?php foreach ( (array) $snapshot['top_queries'] as $row ) : ?>
-								<tr>
-									<td><?php echo esc_html( nexus_get_seo_cockpit_row_label( $row ) ); ?></td>
-									<td><?php echo esc_html( number_format_i18n( (float) ( $row['clicks'] ?? 0 ) ) ); ?></td>
-									<td><?php echo esc_html( number_format_i18n( (float) ( $row['impressions'] ?? 0 ) ) ); ?></td>
-									<td><?php echo esc_html( number_format_i18n( (float) ( ( $row['ctr'] ?? 0 ) * 100 ), 1 ) . '%' ); ?></td>
-									<td><?php echo esc_html( number_format_i18n( (float) ( $row['position'] ?? 0 ), 1 ) ); ?></td>
-								</tr>
-							<?php endforeach; ?>
-						</tbody>
-					</table>
-				</section>
-			</div>
+						<section class="nexus-seo-cockpit__panel nexus-seo-cockpit__panel--compact">
+							<h2>Runtime-Diagnostik</h2>
+							<?php nexus_render_seo_cockpit_diagnostics_list( $diagnostics, 6 ); ?>
+						</section>
+					</div>
+				</div>
+			</details>
 		<?php endif; ?>
 	</div>
 	<?php


### PR DESCRIPTION
… oben

- Schlanke sticky Toolbar (Status-Pill + Range-Switcher + Sync-Button) ersetzt großen Header-Panel
- Vier-zellige Status-Strip (Letzter Sync / Nächster Sync / Cache / Koko) als kompakter Info-Streifen
- Neue Sektionsreihenfolge: Performance → Prio-Queue + Top-Hinweise (Hero-Grid) → Trend → Probleme → Leads → Top Pages/Queries → Onsite/Sitemaps
- Technik & Verbindung + Runtime-Diagnostik in ausklappbares <details> am Seitenende verschoben
- Tabellen-Wrapper für horizontalen Scroll bei breiten Tabellen (Problemseiten, Top Pages)
- CSS auf Custom Properties umgestellt, dreistufiges Responsive-Layout (1280 / 1100 / 860 / 560)
- Bessere Hover-States, Section-Titles mit Trennlinie, refinierte Badge-Farben