### PR TITLE
feat(whitelabel): Premium Dark-Relaunch fuer White-Label-Landingpage

### DIFF
--- a/blocksy-child/assets/css/whitelabel.css
+++ b/blocksy-child/assets/css/whitelabel.css
@@ -1,0 +1,1084 @@
+/* =====================================================================
+   White-Label Retainer — page-whitelabel-retainer.php
+   Premium Dark-Mode-Landingpage für Agenturen.
+   Nutzt --nx-* / --accent-Tokens aus design-system.css.
+   ===================================================================== */
+
+.wl-page {
+	color: var(--nx-text);
+	background: var(--nx-bg-deep);
+}
+
+/* ─── Shared section primitives ─────────────────────────────────────── */
+
+.wl-page .nx-section {
+	position: relative;
+	padding: clamp(4rem, 8vw, 7rem) 1.25rem;
+}
+
+.wl-page .nx-container {
+	max-width: 1200px;
+	margin: 0 auto;
+	position: relative;
+	z-index: 1;
+}
+
+.wl-section-header {
+	max-width: 760px;
+	margin: 0 0 clamp(2rem, 4vw, 3rem);
+}
+
+.wl-section-header--center {
+	margin-left: auto;
+	margin-right: auto;
+	text-align: center;
+}
+
+.wl-section-lede {
+	color: var(--nx-text-secondary);
+	font-size: clamp(1rem, 1.4vw, 1.125rem);
+	line-height: 1.65;
+	margin: 0.75rem 0 0;
+	max-width: 64ch;
+}
+
+.wl-section-header--center .wl-section-lede {
+	margin-left: auto;
+	margin-right: auto;
+}
+
+.wl-eyebrow {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.6rem;
+	font-family: var(--nx-font);
+	font-size: 0.72rem;
+	font-weight: 600;
+	letter-spacing: 0.22em;
+	text-transform: uppercase;
+	color: var(--accent);
+}
+
+.wl-eyebrow::before {
+	content: "";
+	display: inline-block;
+	width: 28px;
+	height: 1px;
+	background: currentColor;
+	opacity: 0.6;
+}
+
+.wl-page .nx-headline-section {
+	font-family: var(--nx-font-heading);
+	font-weight: 500;
+	font-size: clamp(1.85rem, 3.6vw, 2.65rem);
+	line-height: 1.18;
+	letter-spacing: -0.01em;
+	color: var(--nx-text);
+	margin: 0.65rem 0 0;
+}
+
+/* =====================================================================
+   1. HERO
+   ===================================================================== */
+
+.wl-hero {
+	overflow: hidden;
+	padding-top: clamp(5rem, 9vw, 7rem);
+	padding-bottom: clamp(4rem, 7vw, 6rem);
+}
+
+.wl-hero__bg {
+	position: absolute;
+	inset: 0;
+	z-index: 0;
+	pointer-events: none;
+	overflow: hidden;
+}
+
+.wl-hero__bg-warmth {
+	position: absolute;
+	inset: -10% -5%;
+	background:
+		radial-gradient(ellipse 70% 60% at 82% 8%, hsl(23 50% 47% / 0.20) 0%, transparent 55%),
+		radial-gradient(ellipse 55% 80% at 0% 100%, hsl(23 50% 40% / 0.14) 0%, transparent 60%),
+		linear-gradient(180deg, hsl(30 6% 7%) 0%, hsl(30 6% 5%) 100%);
+}
+
+.wl-hero__bg-vignette {
+	position: absolute;
+	inset: 0;
+	background: radial-gradient(ellipse at 50% 35%, transparent 0%, rgba(0, 0, 0, 0.34) 75%, rgba(0, 0, 0, 0.58) 100%);
+}
+
+.wl-hero__bg-grid {
+	position: absolute;
+	inset: 0;
+	background-image:
+		linear-gradient(hsl(30 10% 100% / 0.025) 1px, transparent 1px),
+		linear-gradient(90deg, hsl(30 10% 100% / 0.025) 1px, transparent 1px);
+	background-size: 56px 56px;
+	mask-image: radial-gradient(ellipse at 50% 30%, rgba(0, 0, 0, 0.85), transparent 75%);
+	-webkit-mask-image: radial-gradient(ellipse at 50% 30%, rgba(0, 0, 0, 0.85), transparent 75%);
+}
+
+.wl-hero__top {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 1rem;
+	flex-wrap: wrap;
+	padding-bottom: clamp(1.5rem, 3vw, 2.25rem);
+	border-bottom: 1px solid hsl(30 10% 100% / 0.08);
+}
+
+.wl-hero__mark {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.85rem;
+	color: hsl(30 6% 90% / 0.78);
+	font-family: var(--nx-font);
+	font-size: 0.72rem;
+	font-weight: 600;
+	letter-spacing: 0.22em;
+	text-transform: uppercase;
+}
+
+.wl-hero__mark-rule {
+	display: inline-block;
+	width: clamp(36px, 5vw, 56px);
+	height: 1px;
+	background: hsl(30 10% 100% / 0.35);
+}
+
+.wl-hero__status {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.55rem;
+	font-size: 0.78rem;
+	color: hsl(30 6% 90% / 0.7);
+	font-weight: 500;
+}
+
+.wl-status-dot,
+.wl-dash__dot {
+	display: inline-block;
+	width: 8px;
+	height: 8px;
+	border-radius: 50%;
+	background: hsl(145 55% 50%);
+	box-shadow: 0 0 0 4px hsl(145 55% 50% / 0.16);
+	animation: wl-pulse 2.4s ease-in-out infinite;
+}
+
+@keyframes wl-pulse {
+	0%, 100% { box-shadow: 0 0 0 4px hsl(145 55% 50% / 0.16); }
+	50%      { box-shadow: 0 0 0 8px hsl(145 55% 50% / 0.05); }
+}
+
+.wl-hero__grid {
+	display: grid;
+	grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+	gap: clamp(2.5rem, 5vw, 4rem);
+	align-items: center;
+	margin-top: clamp(2rem, 4vw, 3rem);
+}
+
+@media (max-width: 960px) {
+	.wl-hero__grid { grid-template-columns: 1fr; }
+}
+
+.wl-hero__title {
+	font-family: var(--nx-font-heading);
+	font-weight: 500;
+	font-size: clamp(2.25rem, 4.8vw, 3.75rem);
+	line-height: 1.08;
+	letter-spacing: -0.02em;
+	color: var(--nx-text);
+	margin: 0 0 1.25rem;
+}
+
+.wl-hero__title-line {
+	display: block;
+}
+
+.wl-hero__title-line--em {
+	color: var(--accent);
+	font-style: italic;
+	font-weight: 400;
+}
+
+.wl-hero__lede {
+	color: hsl(30 6% 90% / 0.82);
+	font-size: clamp(1.05rem, 1.4vw, 1.2rem);
+	line-height: 1.6;
+	max-width: 56ch;
+	margin: 0 0 2rem;
+}
+
+.wl-hero__actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.75rem;
+	margin-bottom: 1rem;
+}
+
+.wl-hero__actions .nx-btn {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.55rem;
+}
+
+.wl-hero__fineprint {
+	font-size: 0.85rem;
+	color: hsl(30 6% 90% / 0.55);
+	margin: 0.5rem 0 0;
+}
+
+/* ─── KPI-Dashboard (Hero right) ─────────────────────────────────────── */
+
+.wl-dash {
+	position: relative;
+	padding: clamp(1.25rem, 2.4vw, 1.75rem);
+	background: linear-gradient(180deg, hsl(30 5% 10% / 0.92), hsl(28 8% 7% / 0.96));
+	border: 1px solid hsl(30 10% 100% / 0.08);
+	border-radius: 16px;
+	box-shadow:
+		0 1px 0 hsl(30 10% 100% / 0.04) inset,
+		0 30px 80px -30px rgba(0, 0, 0, 0.55),
+		0 0 0 1px hsl(23 50% 47% / 0.08);
+}
+
+.wl-dash::before {
+	content: "";
+	position: absolute;
+	inset: -1px;
+	border-radius: inherit;
+	pointer-events: none;
+	background: linear-gradient(140deg, hsl(23 50% 54% / 0.18), transparent 40%, transparent 60%, hsl(23 50% 54% / 0.12));
+	-webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+	mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+	-webkit-mask-composite: xor;
+	mask-composite: exclude;
+	padding: 1px;
+}
+
+.wl-dash__head {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 0.5rem;
+	font-size: 0.72rem;
+	text-transform: uppercase;
+	letter-spacing: 0.16em;
+	color: hsl(30 6% 90% / 0.62);
+	padding-bottom: 0.85rem;
+	border-bottom: 1px solid hsl(30 10% 100% / 0.06);
+}
+
+.wl-dash__head-left { display: inline-flex; align-items: center; gap: 0.55rem; }
+
+.wl-dash__primary {
+	padding: 1.15rem 0 0.5rem;
+}
+
+.wl-dash__primary-label {
+	display: block;
+	font-size: 0.74rem;
+	text-transform: uppercase;
+	letter-spacing: 0.16em;
+	color: hsl(30 6% 90% / 0.55);
+	margin-bottom: 0.5rem;
+}
+
+.wl-dash__primary-row {
+	display: flex;
+	align-items: baseline;
+	gap: 0.85rem;
+	font-family: var(--nx-font-heading);
+}
+
+.wl-dash__primary-before {
+	font-size: clamp(1.1rem, 1.8vw, 1.35rem);
+	color: hsl(30 6% 90% / 0.45);
+}
+
+.wl-dash__primary-before s {
+	text-decoration-color: hsl(0 50% 60% / 0.7);
+	text-decoration-thickness: 1.5px;
+}
+
+.wl-dash__primary-arrow {
+	color: var(--accent);
+	display: inline-flex;
+}
+
+.wl-dash__primary-after {
+	font-size: clamp(2.25rem, 4vw, 3rem);
+	font-weight: 600;
+	letter-spacing: -0.02em;
+	color: var(--nx-text);
+	line-height: 1;
+}
+
+.wl-dash__primary-delta {
+	display: inline-flex;
+	align-items: baseline;
+	gap: 0;
+	margin-top: 0.6rem;
+	font-size: 0.85rem;
+	color: hsl(145 50% 60%);
+	font-weight: 600;
+}
+
+.wl-dash__spark {
+	margin: 0.85rem -0.25rem 0.25rem;
+}
+
+.wl-dash__tiles {
+	display: grid;
+	grid-template-columns: repeat(2, 1fr);
+	gap: 0.65rem;
+	margin: 0.75rem 0 0;
+	padding: 0;
+}
+
+.wl-dash__tile {
+	background: hsl(30 5% 9% / 0.65);
+	border: 1px solid hsl(30 10% 100% / 0.05);
+	border-radius: 10px;
+	padding: 0.85rem 0.95rem;
+	min-width: 0;
+}
+
+.wl-dash__tile dt {
+	font-size: 0.68rem;
+	text-transform: uppercase;
+	letter-spacing: 0.14em;
+	color: hsl(30 6% 90% / 0.55);
+	margin-bottom: 0.35rem;
+}
+
+.wl-dash__tile dd {
+	margin: 0;
+	font-family: var(--nx-font-heading);
+	font-size: clamp(1.15rem, 1.7vw, 1.4rem);
+	font-weight: 600;
+	color: var(--nx-text);
+	letter-spacing: -0.01em;
+}
+
+.wl-dash__chips {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.4rem;
+	margin-top: 1rem;
+	padding-top: 0.95rem;
+	border-top: 1px solid hsl(30 10% 100% / 0.06);
+}
+
+/* ─── Chips (shared) ─────────────────────────────────────────────────── */
+
+.wl-chip {
+	display: inline-flex;
+	align-items: center;
+	padding: 0.32rem 0.65rem;
+	font-size: 0.72rem;
+	font-weight: 500;
+	letter-spacing: 0.02em;
+	color: hsl(30 6% 90% / 0.82);
+	background: hsl(30 10% 100% / 0.04);
+	border: 1px solid hsl(30 10% 100% / 0.08);
+	border-radius: 999px;
+	white-space: nowrap;
+}
+
+.wl-chip--mono {
+	font-family: var(--nx-font-mono);
+	font-size: 0.7rem;
+	letter-spacing: 0;
+	background: hsl(23 50% 47% / 0.08);
+	border-color: hsl(23 50% 47% / 0.22);
+	color: hsl(23 50% 70%);
+}
+
+/* =====================================================================
+   2. PROBLEM
+   ===================================================================== */
+
+.wl-problem {
+	background: linear-gradient(180deg, hsl(30 6% 5%) 0%, hsl(30 6% 7%) 100%);
+}
+
+.wl-problem__grid {
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	gap: clamp(1rem, 2vw, 1.5rem);
+}
+
+@media (max-width: 860px) { .wl-problem__grid { grid-template-columns: 1fr; } }
+
+.wl-problem-card {
+	padding: clamp(1.5rem, 2.4vw, 1.85rem);
+	background: var(--nx-card-gradient);
+	border: 1px solid var(--nx-border);
+	border-radius: 14px;
+	transition: transform 0.3s ease, border-color 0.3s ease;
+}
+
+.wl-problem-card:hover {
+	transform: translateY(-2px);
+	border-color: hsl(23 50% 47% / 0.4);
+}
+
+.wl-problem-card__title {
+	font-family: var(--nx-font-heading);
+	font-size: 1.2rem;
+	font-weight: 600;
+	line-height: 1.3;
+	color: var(--nx-text);
+	margin: 0.8rem 0 0.65rem;
+	letter-spacing: -0.01em;
+}
+
+.wl-problem-card__copy {
+	font-size: 0.97rem;
+	line-height: 1.6;
+	color: var(--nx-text-secondary);
+	margin: 0;
+}
+
+/* =====================================================================
+   3. SOLUTION (3-step flow)
+   ===================================================================== */
+
+.wl-solution {
+	background: hsl(30 6% 6%);
+	overflow: hidden;
+	position: relative;
+}
+
+.wl-solution::before {
+	content: "";
+	position: absolute;
+	inset: 0;
+	background: radial-gradient(ellipse 70% 50% at 50% 0%, hsl(23 50% 47% / 0.08) 0%, transparent 70%);
+	pointer-events: none;
+}
+
+.wl-solution__flow {
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	gap: clamp(1rem, 2.5vw, 2rem);
+	list-style: none;
+	padding: 0;
+	margin: 0;
+	counter-reset: wl-step;
+	position: relative;
+}
+
+@media (max-width: 860px) { .wl-solution__flow { grid-template-columns: 1fr; } }
+
+.wl-solution__step {
+	position: relative;
+	padding: clamp(1.5rem, 2.4vw, 1.85rem);
+	background: hsl(30 5% 9% / 0.6);
+	border: 1px solid hsl(30 10% 100% / 0.08);
+	border-radius: 14px;
+}
+
+.wl-solution__step:not(:last-child)::after {
+	content: "→";
+	position: absolute;
+	right: -1.5rem;
+	top: 50%;
+	transform: translateY(-50%);
+	font-size: 1.5rem;
+	color: var(--accent);
+	font-weight: 300;
+	z-index: 2;
+}
+
+@media (max-width: 860px) {
+	.wl-solution__step:not(:last-child)::after {
+		right: 50%;
+		top: auto;
+		bottom: -1.5rem;
+		transform: translateX(50%) rotate(90deg);
+	}
+}
+
+.wl-solution__num {
+	font-family: var(--nx-font-mono);
+	font-size: 0.85rem;
+	color: var(--accent);
+	letter-spacing: 0.1em;
+}
+
+.wl-solution__title {
+	font-family: var(--nx-font-heading);
+	font-size: 1.25rem;
+	font-weight: 600;
+	color: var(--nx-text);
+	margin: 0.5rem 0 0.5rem;
+	letter-spacing: -0.01em;
+}
+
+.wl-solution__copy {
+	font-size: 0.95rem;
+	color: var(--nx-text-secondary);
+	line-height: 1.55;
+	margin: 0;
+}
+
+/* =====================================================================
+   4. STACK
+   ===================================================================== */
+
+.wl-stack {
+	background: linear-gradient(180deg, hsl(30 6% 7%) 0%, hsl(30 6% 5%) 100%);
+}
+
+.wl-stack__grid {
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	gap: clamp(1rem, 1.8vw, 1.35rem);
+}
+
+@media (max-width: 1000px) { .wl-stack__grid { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 680px)  { .wl-stack__grid { grid-template-columns: 1fr; } }
+
+.wl-stack-card {
+	padding: clamp(1.5rem, 2.4vw, 1.85rem);
+	background: var(--nx-card-gradient);
+	border: 1px solid var(--nx-border);
+	border-radius: 14px;
+	display: flex;
+	flex-direction: column;
+	gap: 0.9rem;
+	transition: transform 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.wl-stack-card:hover {
+	transform: translateY(-3px);
+	border-color: hsl(23 50% 47% / 0.4);
+	box-shadow: 0 18px 40px -20px hsl(23 50% 30% / 0.4);
+}
+
+.wl-stack-card__head { display: flex; align-items: center; justify-content: space-between; }
+
+.wl-stack-card__tag {
+	display: inline-flex;
+	align-items: center;
+	padding: 0.28rem 0.6rem;
+	font-family: var(--nx-font-mono);
+	font-size: 0.7rem;
+	letter-spacing: 0.04em;
+	color: var(--accent);
+	background: hsl(23 50% 47% / 0.08);
+	border: 1px solid hsl(23 50% 47% / 0.25);
+	border-radius: 6px;
+	text-transform: uppercase;
+}
+
+.wl-stack-card__title {
+	font-family: var(--nx-font-heading);
+	font-size: 1.2rem;
+	font-weight: 600;
+	color: var(--nx-text);
+	margin: 0;
+	letter-spacing: -0.01em;
+}
+
+.wl-stack-card__copy {
+	font-size: 0.94rem;
+	color: var(--nx-text-secondary);
+	line-height: 1.55;
+	margin: 0;
+}
+
+.wl-stack-card__chips {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.35rem;
+	list-style: none;
+	padding: 0;
+	margin: auto 0 0;
+}
+
+/* =====================================================================
+   5. CONTRACT (3 cards)
+   ===================================================================== */
+
+.wl-contract {
+	background: hsl(30 6% 5%);
+}
+
+.wl-contract__grid {
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	gap: clamp(1rem, 2vw, 1.5rem);
+}
+
+@media (max-width: 860px) { .wl-contract__grid { grid-template-columns: 1fr; } }
+
+.wl-contract-card {
+	position: relative;
+	padding: clamp(1.5rem, 2.4vw, 1.85rem);
+	background: linear-gradient(180deg, hsl(30 5% 10% / 0.92), hsl(28 8% 7% / 0.96));
+	border: 1px solid hsl(30 10% 100% / 0.08);
+	border-radius: 14px;
+	overflow: hidden;
+}
+
+.wl-contract-card::before {
+	content: "";
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	height: 2px;
+	background: linear-gradient(90deg, var(--accent), transparent);
+}
+
+.wl-contract-card__num {
+	font-family: var(--nx-font-mono);
+	font-size: 0.78rem;
+	color: var(--accent);
+	letter-spacing: 0.1em;
+}
+
+.wl-contract-card__title {
+	font-family: var(--nx-font-heading);
+	font-size: 1.35rem;
+	font-weight: 600;
+	color: var(--nx-text);
+	margin: 0.55rem 0 0.5rem;
+	letter-spacing: -0.01em;
+}
+
+.wl-contract-card__copy {
+	font-size: 0.95rem;
+	color: var(--nx-text-secondary);
+	line-height: 1.6;
+	margin: 0 0 1rem;
+}
+
+.wl-contract-card__bullets {
+	list-style: none;
+	padding: 0;
+	margin: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 0.4rem;
+	padding-top: 0.9rem;
+	border-top: 1px solid hsl(30 10% 100% / 0.06);
+}
+
+.wl-contract-card__bullets li {
+	display: flex;
+	align-items: center;
+	gap: 0.55rem;
+	font-size: 0.88rem;
+	color: hsl(30 6% 90% / 0.85);
+}
+
+.wl-contract-card__bullets li::before {
+	content: "";
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	background: var(--accent);
+	flex-shrink: 0;
+}
+
+/* =====================================================================
+   6. PROOF
+   ===================================================================== */
+
+.wl-proof {
+	background: hsl(30 6% 7%);
+	position: relative;
+	overflow: hidden;
+}
+
+.wl-proof::before {
+	content: "";
+	position: absolute;
+	inset: 0;
+	background: radial-gradient(ellipse 60% 70% at 50% 50%, hsl(23 50% 47% / 0.06) 0%, transparent 65%);
+	pointer-events: none;
+}
+
+.wl-proof__grid {
+	display: grid;
+	grid-template-columns: repeat(4, 1fr);
+	gap: 0;
+	border: 1px solid hsl(30 10% 100% / 0.08);
+	border-radius: 14px;
+	overflow: hidden;
+	background: linear-gradient(180deg, hsl(30 5% 9% / 0.6), hsl(28 8% 6% / 0.7));
+}
+
+@media (max-width: 960px) { .wl-proof__grid { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 540px) { .wl-proof__grid { grid-template-columns: 1fr; } }
+
+.wl-proof__item {
+	padding: clamp(1.5rem, 2.4vw, 2rem) clamp(1rem, 2vw, 1.5rem);
+	border-right: 1px solid hsl(30 10% 100% / 0.06);
+	text-align: left;
+}
+
+.wl-proof__item:last-child { border-right: 0; }
+
+@media (max-width: 960px) {
+	.wl-proof__item:nth-child(2n) { border-right: 0; }
+	.wl-proof__item:nth-child(1),
+	.wl-proof__item:nth-child(2) { border-bottom: 1px solid hsl(30 10% 100% / 0.06); }
+}
+
+@media (max-width: 540px) {
+	.wl-proof__item { border-right: 0; border-bottom: 1px solid hsl(30 10% 100% / 0.06); }
+	.wl-proof__item:last-child { border-bottom: 0; }
+}
+
+.wl-proof__value {
+	font-family: var(--nx-font-heading);
+	font-size: clamp(1.6rem, 2.6vw, 2.1rem);
+	font-weight: 600;
+	color: var(--accent);
+	letter-spacing: -0.02em;
+	line-height: 1.1;
+}
+
+.wl-proof__label {
+	font-size: 0.83rem;
+	text-transform: uppercase;
+	letter-spacing: 0.12em;
+	color: hsl(30 6% 90% / 0.62);
+	margin-top: 0.5rem;
+}
+
+.wl-proof__disclaimer {
+	margin: 1.5rem 0 0;
+	font-size: 0.83rem;
+	color: hsl(30 6% 90% / 0.5);
+	text-align: center;
+}
+
+/* =====================================================================
+   7. TECH SPLIT
+   ===================================================================== */
+
+.wl-tech {
+	background: linear-gradient(180deg, hsl(30 6% 5%) 0%, hsl(30 6% 6%) 100%);
+}
+
+.wl-tech__split {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: clamp(1.5rem, 3vw, 2.5rem);
+	align-items: stretch;
+}
+
+@media (max-width: 900px) { .wl-tech__split { grid-template-columns: 1fr; } }
+
+.wl-tech__bullets {
+	list-style: none;
+	padding: 0;
+	margin: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 0.85rem;
+	align-self: center;
+}
+
+.wl-tech__bullets li {
+	position: relative;
+	padding-left: 1.65rem;
+	font-size: 1rem;
+	line-height: 1.55;
+	color: var(--nx-text);
+}
+
+.wl-tech__bullets li::before {
+	content: "";
+	position: absolute;
+	left: 0;
+	top: 0.55rem;
+	width: 10px;
+	height: 10px;
+	border: 1.5px solid var(--accent);
+	border-radius: 2px;
+	transform: rotate(45deg);
+}
+
+.wl-tech__code {
+	margin: 0;
+	padding: 0;
+	background: hsl(28 8% 4%);
+	border: 1px solid hsl(30 10% 100% / 0.08);
+	border-radius: 12px;
+	overflow: hidden;
+	box-shadow: 0 24px 60px -24px rgba(0, 0, 0, 0.55);
+}
+
+.wl-tech__code-head {
+	display: flex;
+	align-items: center;
+	gap: 0.4rem;
+	padding: 0.7rem 1rem;
+	background: hsl(30 6% 7%);
+	border-bottom: 1px solid hsl(30 10% 100% / 0.06);
+}
+
+.wl-tech__code-dot {
+	width: 10px;
+	height: 10px;
+	border-radius: 50%;
+	display: inline-block;
+}
+
+.wl-tech__code-dot--r { background: hsl(0 60% 55%); }
+.wl-tech__code-dot--y { background: hsl(40 70% 55%); }
+.wl-tech__code-dot--g { background: hsl(140 50% 50%); }
+
+.wl-tech__code-file {
+	margin-left: auto;
+	font-family: var(--nx-font-mono);
+	font-size: 0.78rem;
+	color: hsl(30 6% 90% / 0.55);
+}
+
+.wl-tech__code-body {
+	margin: 0;
+	padding: 1.2rem 1.25rem;
+	font-family: var(--nx-font-mono);
+	font-size: 0.84rem;
+	line-height: 1.65;
+	color: hsl(30 6% 90% / 0.88);
+	overflow-x: auto;
+	white-space: pre;
+	tab-size: 4;
+}
+
+.wl-tech__c { color: hsl(30 5% 55%); font-style: italic; }
+.wl-tech__k { color: hsl(280 50% 70%); font-weight: 500; }
+.wl-tech__s { color: hsl(145 45% 60%); }
+.wl-tech__p { color: hsl(200 60% 65%); }
+
+/* =====================================================================
+   8. ENTRY (Testprojekt-Scope)
+   ===================================================================== */
+
+.wl-entry { background: hsl(30 6% 5%); }
+
+.wl-entry__card {
+	position: relative;
+	padding: clamp(1.75rem, 3vw, 2.5rem);
+	background: linear-gradient(140deg, hsl(30 5% 10% / 0.95), hsl(28 8% 6% / 0.95));
+	border: 1px solid hsl(23 50% 47% / 0.25);
+	border-radius: 18px;
+	overflow: hidden;
+	box-shadow: 0 30px 60px -30px hsl(23 50% 25% / 0.5);
+}
+
+.wl-entry__card::before {
+	content: "";
+	position: absolute;
+	top: 0;
+	right: 0;
+	width: 320px;
+	height: 320px;
+	background: radial-gradient(circle, hsl(23 50% 47% / 0.18) 0%, transparent 65%);
+	pointer-events: none;
+}
+
+.wl-entry__head { position: relative; }
+
+.wl-entry__kicker {
+	display: inline-block;
+	font-family: var(--nx-font-mono);
+	font-size: 0.72rem;
+	color: var(--accent);
+	letter-spacing: 0.16em;
+	text-transform: uppercase;
+}
+
+.wl-entry__title {
+	font-family: var(--nx-font-heading);
+	font-size: clamp(1.35rem, 2.4vw, 1.75rem);
+	font-weight: 500;
+	color: var(--nx-text);
+	margin: 0.55rem 0 1rem;
+	letter-spacing: -0.01em;
+	line-height: 1.25;
+	max-width: 32ch;
+}
+
+.wl-entry__copy {
+	position: relative;
+	font-size: 1.02rem;
+	line-height: 1.65;
+	color: hsl(30 6% 90% / 0.85);
+	margin: 0 0 1.5rem;
+	max-width: 64ch;
+}
+
+.wl-entry__bullets {
+	position: relative;
+	list-style: none;
+	padding: 0;
+	margin: 0 0 1.75rem;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 1.25rem;
+}
+
+.wl-entry__bullets li {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.55rem;
+	font-size: 0.92rem;
+	color: hsl(30 6% 90% / 0.88);
+	font-weight: 500;
+}
+
+.wl-entry__bullet-dot {
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	background: var(--accent);
+	box-shadow: 0 0 0 4px hsl(23 50% 47% / 0.15);
+}
+
+.wl-entry__actions { position: relative; }
+
+/* =====================================================================
+   9. FINAL CTA
+   ===================================================================== */
+
+.wl-cta {
+	position: relative;
+	overflow: hidden;
+}
+
+.wl-cta__bg {
+	position: absolute;
+	inset: 0;
+	z-index: 0;
+	pointer-events: none;
+}
+
+.wl-cta__shell {
+	display: grid;
+	grid-template-columns: 1fr auto;
+	gap: clamp(1.5rem, 3vw, 3rem);
+	align-items: center;
+	padding: clamp(2rem, 4vw, 3rem);
+	background: linear-gradient(140deg, hsl(30 5% 10% / 0.7), hsl(28 8% 6% / 0.7));
+	border: 1px solid hsl(30 10% 100% / 0.08);
+	border-radius: 18px;
+	backdrop-filter: blur(8px);
+	-webkit-backdrop-filter: blur(8px);
+}
+
+@media (max-width: 820px) { .wl-cta__shell { grid-template-columns: 1fr; } }
+
+.wl-cta__title {
+	font-family: var(--nx-font-heading);
+	font-size: clamp(1.75rem, 3.4vw, 2.5rem);
+	font-weight: 500;
+	color: var(--nx-text);
+	margin: 0.55rem 0 0.65rem;
+	letter-spacing: -0.01em;
+	line-height: 1.18;
+}
+
+.wl-cta__lede {
+	color: hsl(30 6% 90% / 0.78);
+	font-size: 1rem;
+	line-height: 1.6;
+	margin: 0;
+	max-width: 56ch;
+}
+
+.wl-cta__actions {
+	display: flex;
+	flex-direction: column;
+	gap: 0.6rem;
+	align-items: stretch;
+}
+
+@media (min-width: 821px) { .wl-cta__actions { min-width: 240px; } }
+
+.wl-cta__actions .nx-btn { justify-content: center; }
+
+/* =====================================================================
+   10. STICKY MOBILE CTA
+   ===================================================================== */
+
+.wl-sticky-cta {
+	position: fixed;
+	inset: auto 0 0 0;
+	z-index: 90;
+	display: none;
+	padding: 0.75rem 1rem calc(0.75rem + env(safe-area-inset-bottom));
+	background: hsl(28 8% 7% / 0.96);
+	backdrop-filter: blur(10px);
+	-webkit-backdrop-filter: blur(10px);
+	border-top: 1px solid hsl(23 50% 47% / 0.25);
+	box-shadow: 0 -8px 30px rgba(0, 0, 0, 0.4);
+	transform: translateY(100%);
+	transition: transform 0.35s cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.wl-sticky-cta.is-visible { transform: translateY(0); }
+
+.wl-sticky-cta__inner {
+	display: flex;
+	align-items: center;
+	gap: 0.85rem;
+	max-width: 1200px;
+	margin: 0 auto;
+}
+
+.wl-sticky-cta__label {
+	flex: 1;
+	min-width: 0;
+	font-size: 0.82rem;
+	color: hsl(30 6% 90% / 0.78);
+	line-height: 1.3;
+}
+
+.wl-sticky-cta__label strong {
+	display: block;
+	color: var(--nx-text);
+	font-weight: 600;
+	font-size: 0.95rem;
+	margin-bottom: 0.1rem;
+}
+
+.wl-sticky-cta .nx-btn {
+	padding: 0.65rem 1.15rem;
+	font-size: 0.9rem;
+	white-space: nowrap;
+	flex-shrink: 0;
+}
+
+@media (max-width: 820px) {
+	.wl-sticky-cta { display: block; }
+	body.has-sticky-wl-cta { padding-bottom: 84px; }
+}
+
+/* =====================================================================
+   Reduced Motion
+   ===================================================================== */
+
+@media (prefers-reduced-motion: reduce) {
+	.wl-status-dot,
+	.wl-dash__dot { animation: none; }
+	.wl-sticky-cta { transition: none; }
+	.wl-problem-card,
+	.wl-stack-card { transition: none; }
+}

--- a/blocksy-child/inc/enqueue.php
+++ b/blocksy-child/inc/enqueue.php
@@ -438,17 +438,23 @@ function hu_enqueue_assets() {
 		hu_enqueue_css( 'nexus-meta-ads-css', 'meta-ads.css', [ 'nexus-design-system' ] );
 	}
 
-	// ── P) Template: Ergebnisse Hub + Whitelabel Proof ─────────────
+	// ── P) Template: Ergebnisse Hub ────────────────────────────────
 	if (
 		is_page_template( 'page-case-studies-e-commerce.php' )
-		|| is_page_template( 'page-whitelabel-retainer.php' )
 		|| is_page( 'case-studies-e-commerce' )
 		|| is_page( 'ergebnisse' )
+	) {
+		hu_enqueue_css( 'nexus-results-css', 'results.css', [ 'nexus-design-system' ] );
+	}
+
+	// ── P2) Template: Whitelabel-Retainer ──────────────────────────
+	if (
+		is_page_template( 'page-whitelabel-retainer.php' )
 		|| is_page( 'whitelabel-retainer' )
 		|| is_page( 'whitelabel-retainer-proof' )
 		|| is_page( 'whitelabel' )
 	) {
-		hu_enqueue_css( 'nexus-results-css', 'results.css', [ 'nexus-design-system' ] );
+		hu_enqueue_css( 'nexus-whitelabel-css', 'whitelabel.css', [ 'nexus-design-system' ] );
 	}
 
 	// ── Q) Template: Öffentliche Case Studies ──────────────────────

--- a/blocksy-child/page-whitelabel-retainer.php
+++ b/blocksy-child/page-whitelabel-retainer.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Template Name: Whitelabel & Weiterentwicklung
- * Description: Anonymisierte Whitelabel-Arbeit, laufende Weiterentwicklung und Delivery im Hintergrund.
+ * Description: Premium Dark-Relaunch der White-Label-Partner-Seite für Agenturen.
  *
  * @package Blocksy_Child
  */
@@ -12,141 +12,574 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 get_header();
 
-$whitelabel_fit_url = function_exists( 'nexus_get_whitelabel_calendar_url' ) ? nexus_get_whitelabel_calendar_url() : 'https://cal.com/hasim-uener/whitelabel-fit-gesprach?overlayCalendar=true';
-$proof_anchor_url   = '#proof';
-$mailto_url         = 'mailto:hallo@hasimuener.de';
-$e3_cpl_before      = function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'cpl_before', 'display', '150 €' ) : '150 €';
-$e3_cpl_after       = function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'cpl_after', 'display', '22 €' ) : '22 €';
-$e3_lead_count      = function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'lead_count', 'display', '1.750+' ) : '1.750+';
+$whitelabel_fit_url = function_exists( 'nexus_get_whitelabel_calendar_url' )
+	? nexus_get_whitelabel_calendar_url()
+	: 'https://cal.com/hasim-uener/whitelabel-fit-gesprach?overlayCalendar=true';
+$mailto_url = 'mailto:hallo@hasimuener.de';
 
-$proof_metrics = [
+$cpl_before     = function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'cpl_before', 'display', '150 €' )      : '150 €';
+$cpl_after      = function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'cpl_after',  'display', '22 €' )       : '22 €';
+$cpl_reduction  = function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'cpl_reduction', 'display', '−85 %' )   : '−85 %';
+$lead_count     = function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'lead_count', 'display', '1.750+' )     : '1.750+';
+$sales_conv     = function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'sales_conversion', 'display', '12 %' ) : '12 %';
+$timeframe      = function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'timeframe', 'display', '9 Monate' )    : '9 Monate';
+
+$cpl_before_int    = function_exists( 'hu_e3_metric' ) ? (int) hu_e3_metric( 'cpl_before', 'counter_target', 150 ) : 150;
+$cpl_after_int     = function_exists( 'hu_e3_metric' ) ? (int) hu_e3_metric( 'cpl_after',  'counter_target', 22 )  : 22;
+$lead_count_int    = function_exists( 'hu_e3_metric' ) ? (int) hu_e3_metric( 'lead_count', 'counter_target', 1750 ) : 1750;
+$sales_conv_int    = function_exists( 'hu_e3_metric' ) ? (int) hu_e3_metric( 'sales_conversion', 'counter_target', 12 ) : 12;
+$cpl_reduction_int = function_exists( 'hu_e3_metric' ) ? (int) hu_e3_metric( 'cpl_reduction', 'counter_target', 85 ) : 85;
+
+$problem_cards = [
 	[
-		'label' => 'CPL vorher',
-		'value' => $e3_cpl_before,
+		'eyebrow' => 'Zeit',
+		'title'   => 'Kalender voll, Pipeline auch.',
+		'copy'    => 'Eure Kapazität ist auf Akquise, Strategie und Kunden gebunden. Die technische Umsetzung rutscht in den Abend oder verzögert das Projekt.',
 	],
 	[
-		'label' => 'CPL nachher',
-		'value' => $e3_cpl_after,
+		'eyebrow' => 'Technische Tiefe',
+		'title'   => 'Server-Side, Consent V2, Core Web Vitals.',
+		'copy'    => 'Themen, die euch Kunden bezahlen — die intern aber niemand sauber liefert. Halbgare Setups werden zur Reklamation, nicht zur Referenz.',
 	],
 	[
-		'label' => 'Generierte Leads',
-		'value' => $e3_lead_count,
+		'eyebrow' => 'Umsetzungskapazität',
+		'title'   => 'Senior-Stunden fehlen.',
+		'copy'    => 'Junioren brauchen Aufsicht, Freelancer brauchen Briefing, Agenturen-Backups brauchen Marge. Ihr braucht jemanden, der einfach liefert.',
 	],
 ];
 
-$tech_stack_items = [
-	'GTM Server-Side (eigener Subdomain-Container, GCP/Stape)',
-	'Consent Mode V2, sauberer Cookie-Flow, TCF-kompatibel',
-	'Google Ads Enhanced Conversions, Meta CAPI, TikTok Events API',
-	'CRM-Attribution: Bitrix24, HubSpot, Pipedrive via Zapier/Make',
-	'End-to-End Lead-Attribution von Klick bis Abschluss',
-	'WordPress Performance: Core Web Vitals, Caching, kritischer Renderpfad',
+$solution_steps = [
+	[
+		'step'  => '01',
+		'title' => 'Ihr briefed',
+		'copy'  => 'Kurzes Setup-Gespräch mit eurem Projektleiter. NDA möglich. Keine direkte Kundenansprache.',
+	],
+	[
+		'step'  => '02',
+		'title' => 'Ich liefere',
+		'copy'  => 'Umsetzung im Hintergrund: Code, Tracking, Doku. Kommunikation läuft ausschließlich über euch.',
+	],
+	[
+		'step'  => '03',
+		'title' => 'Ihr präsentiert',
+		'copy'  => 'Übergabe unter eurem Branding. Reports, Code-Doku und Übergabe-Files passend für euren Kunden.',
+	],
+];
+
+$stack_cards = [
+	[
+		'tag'    => 'SEO',
+		'title'  => 'Technical SEO',
+		'copy'   => 'Audits, Indexierung, Logfile-Analysen, Schema, hreflang, internationale Architektur, Cluster-Strukturen.',
+		'chips'  => [ 'Audit', 'Schema', 'hreflang', 'Logfiles' ],
+	],
+	[
+		'tag'    => 'WP',
+		'title'  => 'WordPress + Core Web Vitals',
+		'copy'   => 'Theme- und Plugin-Hardening, bedarfsgesteuertes Asset-Loading, Caching, kritischer Renderpfad, eigene Templates.',
+		'chips'  => [ 'CWV', 'Caching', 'Hardening', 'Templates' ],
+	],
+	[
+		'tag'    => 'Analytics',
+		'title'  => 'GA4 + GTM',
+		'copy'   => 'Sauberes Mess-Setup: Events, eCommerce, Funnel-Reports, klare Datenstrecke vom Klick bis zum Lead.',
+		'chips'  => [ 'GA4', 'GTM', 'Events', 'Reports' ],
+	],
+	[
+		'tag'    => 'Tracking',
+		'title'  => 'Server-Side + CAPI',
+		'copy'   => 'Eigener Subdomain-Container (Stape/GCP), Enhanced Conversions, Meta CAPI, TikTok Events API, Consent Mode V2.',
+		'chips'  => [ 'GTM-SS', 'Consent V2', 'CAPI', 'Enhanced' ],
+	],
+	[
+		'tag'    => 'CRO',
+		'title'  => 'Landingpages',
+		'copy'   => 'Konvertierende Templates statt Page-Builder-Brei. A/B-Hypothesen, klare Funnel-Logik, schnelle Ladezeit.',
+		'chips'  => [ 'LP', 'A/B', 'Funnel', 'Speed' ],
+	],
+	[
+		'tag'    => 'Ops',
+		'title'  => 'Automation & CRM',
+		'copy'   => 'n8n, Make, Zapier. CRM-Attribution: Bitrix24, HubSpot, Pipedrive. End-to-End-Lead-Strecke bis zum Abschluss.',
+		'chips'  => [ 'n8n', 'Make', 'CRM', 'Attribution' ],
+	],
 ];
 
 $contract_cards = [
 	[
-		'title' => 'Unsichtbar',
-		'copy'  => 'NDA Standard, keine Ansprache eurer Kunden, kein Branding in Reports, Kommunikation ausschließlich über euren Projektleiter.',
+		'eyebrow' => '01',
+		'title'   => 'Unsichtbar',
+		'copy'    => 'NDA Standard. Keine Ansprache eurer Kunden, kein Branding in Reports. Kommunikation ausschließlich über euren Projektleiter.',
+		'bullets' => [ 'NDA inkludiert', 'Kein Branding', 'Keine Kunden-DM' ],
 	],
 	[
-		'title' => 'Schnell',
-		'copy'  => 'Onboarding in unter 14 Tagen, Reaktionszeit unter 4 Stunden (werktags), wöchentliches Delivery-Fenster.',
+		'eyebrow' => '02',
+		'title'   => 'Schnell',
+		'copy'    => 'Onboarding in unter 14 Tagen. Reaktionszeit unter 4 Stunden (werktags). Wöchentliches Delivery-Fenster, klare Abnahme.',
+		'bullets' => [ '< 14 Tage Onboarding', '< 4 h Reaktion', 'Wöchentlich Delivery' ],
 	],
 	[
-		'title' => 'Planbar',
-		'copy'  => 'Monats-Retainer ab [X Stunden], feste Tagessätze für Projektarbeit, keine versteckten Zusatzkosten.',
+		'eyebrow' => '03',
+		'title'   => 'Planbar',
+		'copy'    => 'Monats-Retainer mit festem Stundenkontingent oder feste Tagessätze für Projektarbeit. Saubere Doku statt Black Box.',
+		'bullets' => [ 'Feste Tagessätze', 'Klare Doku', 'Keine Surprise-Rechnung' ],
 	],
 ];
+
+$tech_bullets = [
+	'Eigene WordPress-Templates statt generischer Page-Builder',
+	'Bedarfsgesteuertes Asset-Loading pro Template',
+	'Theme- und Plugin-Hardening: Sicherheit, Update-Disziplin',
+	'Performance-Optimierung: Core Web Vitals, kritischer Renderpfad',
+	'Saubere Schema-Architektur, zentral gepflegt',
+	'Versionierter Code, dokumentierte Übergabe',
+];
+
+$entry_bullets = [ 'NDA', 'Fixer Scope', 'Klare Doku', 'Keine Verlängerungsfalle' ];
+
+$hero_chips = [ 'GA4', 'GTM', 'Server-Side', 'Consent V2', 'WordPress', 'n8n' ];
 ?>
 
-<main id="main" class="site-main wl-proof-page" data-track-section="whitelabel_proof">
-	<section class="nx-section wl-hero">
+<main id="main" class="site-main wl-page" data-track-section="whitelabel_proof">
+
+	<!-- ═══════════════════════════════════════════════
+	     SECTION 01 — HERO (dark, KPI-Dashboard rechts)
+	     ═══════════════════════════════════════════════ -->
+	<section class="nx-section wl-hero" data-nx-theme="dark" id="hero">
+		<div class="wl-hero__bg" aria-hidden="true">
+			<div class="wl-hero__bg-warmth"></div>
+			<div class="wl-hero__bg-vignette"></div>
+			<div class="wl-hero__bg-grid"></div>
+		</div>
+
 		<div class="nx-container">
+			<header class="wl-hero__top">
+				<span class="wl-hero__mark">
+					<span class="wl-hero__mark-rule" aria-hidden="true"></span>
+					White-Label · Partner im Hintergrund
+				</span>
+				<span class="wl-hero__status">
+					<span class="wl-status-dot" aria-hidden="true"></span>
+					Aktive Whitelabel-Mandate
+				</span>
+			</header>
+
 			<div class="wl-hero__grid">
 				<div class="wl-hero__copy">
-					<span class="nx-badge nx-badge--gold">Whitelabel für Agenturen</span>
-					<h1 class="wl-hero__title">Whitelabel-Tracking und Conversion für Performance-Agenturen.</h1>
-					<p class="wl-hero__subtitle">Ich docke als externes System an, liefere GTM Server-Side, saubere Attribution und konvertierende Landingpages. Deine Kundenbeziehung bleibt bei dir, das technische Risiko bei mir.</p>
+					<h1 class="wl-hero__title">
+						<span class="wl-hero__title-line">White-Label SEO, WordPress &amp; Tracking</span>
+						<span class="wl-hero__title-line wl-hero__title-line--em">für Agenturen, die sauber liefern wollen.</span>
+					</h1>
+					<p class="wl-hero__lede">
+						Ich unterstütze euch im Hintergrund bei technischer SEO, WordPress-Performance, Tracking-Setups und conversionstarken Landingpages — ohne Kundenzugriff, ohne Branding, ohne Theater.
+					</p>
 
 					<div class="wl-hero__actions">
-						<a href="<?php echo esc_url( $whitelabel_fit_url ); ?>" class="nx-btn nx-btn--primary" data-track-action="cta_whitelabel_hero_fit_call" data-track-category="lead_gen">Whitelabel-Fit-Gespräch buchen</a>
-						<a href="<?php echo esc_url( $proof_anchor_url ); ?>" class="nx-btn nx-btn--ghost" data-track-action="cta_whitelabel_hero_case_study" data-track-category="trust">Case Study ansehen</a>
+						<a href="<?php echo esc_url( $whitelabel_fit_url ); ?>" class="nx-btn nx-btn--primary" data-track-action="cta_whitelabel_hero_fit_call" data-track-category="lead_gen" data-track-section="hero">
+							<span>White-Label-Gespräch buchen</span>
+							<svg width="18" height="18" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+								<path d="M7 4L13 10L7 16" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+							</svg>
+						</a>
+						<a href="#proof" class="nx-btn nx-btn--ghost" data-track-action="cta_whitelabel_hero_proof" data-track-category="navigation" data-track-section="hero">
+							Live-Beleg ansehen
+						</a>
 					</div>
+
+					<p class="wl-hero__fineprint">
+						30&nbsp;Min · NDA möglich · keine Verkaufsshow.
+					</p>
 				</div>
+
+				<aside class="wl-dash" aria-label="Whitelabel-Dashboard, Beispiel-Kennzahlen">
+					<header class="wl-dash__head">
+						<span class="wl-dash__head-left">
+							<span class="wl-dash__dot" aria-hidden="true"></span>
+							Live · Whitelabel-Mandat
+						</span>
+						<span class="wl-dash__head-right">CPL-Verlauf</span>
+					</header>
+
+					<div class="wl-dash__primary">
+						<span class="wl-dash__primary-label">Kosten pro qualifizierter Anfrage</span>
+						<div class="wl-dash__primary-row">
+							<span class="wl-dash__primary-before"><s><?php echo esc_html( $cpl_before ); ?></s></span>
+							<span class="wl-dash__primary-arrow" aria-hidden="true">
+								<svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+									<path d="M4 12h14M14 7l5 5-5 5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+								</svg>
+							</span>
+							<span class="wl-dash__primary-after">
+								<span class="wl-counter" data-counter-target="<?php echo esc_attr( $cpl_after_int ); ?>" data-counter-suffix="&nbsp;€"><?php echo esc_html( $cpl_after ); ?></span>
+							</span>
+						</div>
+						<span class="wl-dash__primary-delta">
+							<span class="wl-counter" data-counter-target="<?php echo esc_attr( $cpl_reduction_int ); ?>" data-counter-prefix="−" data-counter-suffix="&nbsp;%">0</span>
+							<span>&nbsp;in <?php echo esc_html( $timeframe ); ?></span>
+						</span>
+					</div>
+
+					<div class="wl-dash__spark" aria-hidden="true">
+						<svg viewBox="0 0 320 70" preserveAspectRatio="none" width="100%" height="60">
+							<defs>
+								<linearGradient id="wl-spark-fill" x1="0" x2="0" y1="0" y2="1">
+									<stop offset="0%" stop-color="hsl(23 50% 47% / 0.45)"/>
+									<stop offset="100%" stop-color="hsl(23 50% 47% / 0)"/>
+								</linearGradient>
+							</defs>
+							<path d="M0,12 L32,18 L64,16 L96,28 L128,34 L160,40 L192,46 L224,52 L256,56 L288,60 L320,62 L320,70 L0,70 Z" fill="url(#wl-spark-fill)"/>
+							<path d="M0,12 L32,18 L64,16 L96,28 L128,34 L160,40 L192,46 L224,52 L256,56 L288,60 L320,62" fill="none" stroke="hsl(23 50% 54%)" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+						</svg>
+					</div>
+
+					<dl class="wl-dash__tiles">
+						<div class="wl-dash__tile">
+							<dt>Qualifizierte Leads</dt>
+							<dd><span class="wl-counter" data-counter-target="<?php echo esc_attr( $lead_count_int ); ?>" data-counter-suffix="+">0</span></dd>
+						</div>
+						<div class="wl-dash__tile">
+							<dt>CPL-Senkung</dt>
+							<dd><span class="wl-counter" data-counter-target="<?php echo esc_attr( $cpl_reduction_int ); ?>" data-counter-prefix="−" data-counter-suffix=" %">0</span></dd>
+						</div>
+						<div class="wl-dash__tile">
+							<dt>Zeitraum</dt>
+							<dd><span class="wl-counter" data-counter-target="9" data-counter-suffix=" Mon.">0</span></dd>
+						</div>
+						<div class="wl-dash__tile">
+							<dt>Abschlussquote</dt>
+							<dd><span class="wl-counter" data-counter-target="<?php echo esc_attr( $sales_conv_int ); ?>" data-counter-suffix=" %">0</span></dd>
+						</div>
+					</dl>
+
+					<div class="wl-dash__chips" role="list" aria-label="Stack-Komponenten">
+						<?php foreach ( $hero_chips as $chip ) : ?>
+							<span class="wl-chip" role="listitem"><?php echo esc_html( $chip ); ?></span>
+						<?php endforeach; ?>
+					</div>
+				</aside>
 			</div>
 		</div>
 	</section>
 
-	<section class="nx-section wl-section-alt" id="proof">
+	<!-- ═══════════════════════════════════════════════
+	     SECTION 02 — PROBLEM
+	     ═══════════════════════════════════════════════ -->
+	<section class="nx-section wl-problem" id="problem">
 		<div class="nx-container">
-			<div class="nx-section-header">
-				<span class="nx-badge nx-badge--ghost">Proof</span>
-				<h2 class="nx-headline-section">Ergebnis aus einem laufenden Whitelabel-Mandat</h2>
+			<div class="wl-section-header">
+				<span class="wl-eyebrow">Problem</span>
+				<h2 class="nx-headline-section">Ihr verkauft SEO, Tracking oder Websites — und intern fehlt die Tiefe.</h2>
+				<p class="wl-section-lede">Drei Engpässe tauchen bei fast jeder Performance- und Webdesign-Agentur auf. Keiner davon ist eure Schuld — alle drei sind lösbar, ohne dass ihr eigenes Personal hochziehen müsst.</p>
 			</div>
 
-			<div class="results-card-grid" role="list" aria-label="Proof-Kennzahlen">
-				<?php foreach ( $proof_metrics as $metric ) : ?>
-					<article class="nx-card results-card results-card--gold" role="listitem">
-						<p class="results-card__eyebrow"><?php echo esc_html( $metric['label'] ); ?></p>
-						<h3 class="results-card__title"><?php echo esc_html( $metric['value'] ); ?></h3>
+			<div class="wl-problem__grid">
+				<?php foreach ( $problem_cards as $card ) : ?>
+					<article class="wl-problem-card">
+						<span class="wl-eyebrow"><?php echo esc_html( $card['eyebrow'] ); ?></span>
+						<h3 class="wl-problem-card__title"><?php echo esc_html( $card['title'] ); ?></h3>
+						<p class="wl-problem-card__copy"><?php echo esc_html( $card['copy'] ); ?></p>
 					</article>
 				<?php endforeach; ?>
 			</div>
-
-			<p class="nx-subheadline">Nische: erneuerbare Energien. Hebel: GTM Server-Side, Consent Mode V2, CRM-Attribution über Bitrix24 und Zapier. Geliefert im Namen der Agentur, ohne Sichtbarkeit nach außen.</p>
 		</div>
 	</section>
 
-	<section class="nx-section" id="technik-stack">
+	<!-- ═══════════════════════════════════════════════
+	     SECTION 03 — LÖSUNG (Solution Flow)
+	     ═══════════════════════════════════════════════ -->
+	<section class="nx-section wl-solution" data-nx-theme="dark" id="loesung">
 		<div class="nx-container">
-			<div class="nx-section-header">
-				<span class="nx-badge nx-badge--gold">Technik-Stack</span>
-				<h2 class="nx-headline-section">Technik, die eure Kunden brauchen, die aber niemand liefert.</h2>
+			<div class="wl-section-header wl-section-header--center">
+				<span class="wl-eyebrow">Lösung</span>
+				<h2 class="nx-headline-section">Ich docke an. Ihr liefert weiter unter eurem Namen.</h2>
 			</div>
 
-			<div class="nx-card nx-card--flat">
-				<ul class="results-bullet-list wl-hero__list">
-					<?php foreach ( $tech_stack_items as $tech_stack_item ) : ?>
-						<li><?php echo esc_html( $tech_stack_item ); ?></li>
+			<ol class="wl-solution__flow" aria-label="Drei-Schritt-Prozess">
+				<?php foreach ( $solution_steps as $step ) : ?>
+					<li class="wl-solution__step">
+						<span class="wl-solution__num"><?php echo esc_html( $step['step'] ); ?></span>
+						<h3 class="wl-solution__title"><?php echo esc_html( $step['title'] ); ?></h3>
+						<p class="wl-solution__copy"><?php echo esc_html( $step['copy'] ); ?></p>
+					</li>
+				<?php endforeach; ?>
+			</ol>
+		</div>
+	</section>
+
+	<!-- ═══════════════════════════════════════════════
+	     SECTION 04 — STACK / LEISTUNGEN
+	     ═══════════════════════════════════════════════ -->
+	<section class="nx-section wl-stack" id="leistungen">
+		<div class="nx-container">
+			<div class="wl-section-header">
+				<span class="wl-eyebrow">Stack · Leistungen</span>
+				<h2 class="nx-headline-section">Was ich für euch im Hintergrund baue.</h2>
+				<p class="wl-section-lede">Sechs Bereiche, alle senior umgesetzt. Kombinierbar zum Retainer, einzeln als Projekt buchbar.</p>
+			</div>
+
+			<div class="wl-stack__grid">
+				<?php foreach ( $stack_cards as $card ) : ?>
+					<article class="wl-stack-card">
+						<header class="wl-stack-card__head">
+							<span class="wl-stack-card__tag"><?php echo esc_html( $card['tag'] ); ?></span>
+						</header>
+						<h3 class="wl-stack-card__title"><?php echo esc_html( $card['title'] ); ?></h3>
+						<p class="wl-stack-card__copy"><?php echo esc_html( $card['copy'] ); ?></p>
+						<ul class="wl-stack-card__chips" aria-label="Komponenten">
+							<?php foreach ( $card['chips'] as $chip ) : ?>
+								<li><span class="wl-chip wl-chip--mono"><?php echo esc_html( $chip ); ?></span></li>
+							<?php endforeach; ?>
+						</ul>
+					</article>
+				<?php endforeach; ?>
+			</div>
+		</div>
+	</section>
+
+	<!-- ═══════════════════════════════════════════════
+	     SECTION 05 — KONTRAKT / SICHERHEIT
+	     ═══════════════════════════════════════════════ -->
+	<section class="nx-section wl-contract" id="kontrakt">
+		<div class="nx-container">
+			<div class="wl-section-header">
+				<span class="wl-eyebrow">Whitelabel-Kontrakt</span>
+				<h2 class="nx-headline-section">Unsichtbar. Schnell. Planbar.</h2>
+				<p class="wl-section-lede">Drei Regeln, die ich von der ersten Minute an einhalte. Schriftlich, prüfbar, ohne Sternchen.</p>
+			</div>
+
+			<div class="wl-contract__grid">
+				<?php foreach ( $contract_cards as $card ) : ?>
+					<article class="wl-contract-card">
+						<span class="wl-contract-card__num"><?php echo esc_html( $card['eyebrow'] ); ?></span>
+						<h3 class="wl-contract-card__title"><?php echo esc_html( $card['title'] ); ?></h3>
+						<p class="wl-contract-card__copy"><?php echo esc_html( $card['copy'] ); ?></p>
+						<ul class="wl-contract-card__bullets">
+							<?php foreach ( $card['bullets'] as $bullet ) : ?>
+								<li><?php echo esc_html( $bullet ); ?></li>
+							<?php endforeach; ?>
+						</ul>
+					</article>
+				<?php endforeach; ?>
+			</div>
+		</div>
+	</section>
+
+	<!-- ═══════════════════════════════════════════════
+	     SECTION 06 — PROOF (Live-Beleg)
+	     ═══════════════════════════════════════════════ -->
+	<section class="nx-section wl-proof" data-nx-theme="dark" id="proof">
+		<div class="nx-container">
+			<div class="wl-section-header">
+				<span class="wl-eyebrow">Live-Beleg · laufendes Whitelabel-Mandat</span>
+				<h2 class="nx-headline-section">Ergebnis aus einem aktiven Whitelabel-Mandat.</h2>
+				<p class="wl-section-lede">Nische: erneuerbare Energien. Hebel: Server-Side, Consent Mode V2, CRM-Attribution. Geliefert im Namen der Agentur — ohne Sichtbarkeit nach außen.</p>
+			</div>
+
+			<div class="wl-proof__grid" role="list" aria-label="Proof-Kennzahlen">
+				<div class="wl-proof__item" role="listitem">
+					<div class="wl-proof__value"><?php echo esc_html( $cpl_before ); ?>&nbsp;→&nbsp;<?php echo esc_html( $cpl_after ); ?></div>
+					<div class="wl-proof__label">Kosten pro Anfrage</div>
+				</div>
+				<div class="wl-proof__item" role="listitem">
+					<div class="wl-proof__value"><?php echo esc_html( $lead_count ); ?></div>
+					<div class="wl-proof__label">Qualifizierte Anfragen</div>
+				</div>
+				<div class="wl-proof__item" role="listitem">
+					<div class="wl-proof__value"><?php echo esc_html( $cpl_reduction ); ?></div>
+					<div class="wl-proof__label">Niedrigere Kosten pro Anfrage</div>
+				</div>
+				<div class="wl-proof__item" role="listitem">
+					<div class="wl-proof__value"><?php echo esc_html( $sales_conv ); ?></div>
+					<div class="wl-proof__label">Abschlussquote</div>
+				</div>
+			</div>
+
+			<p class="wl-proof__disclaimer">Stand 2024–2025 · keine pauschale Übertragbarkeitsgarantie.</p>
+		</div>
+	</section>
+
+	<!-- ═══════════════════════════════════════════════
+	     SECTION 07 — TECHNISCHER BELEG
+	     ═══════════════════════════════════════════════ -->
+	<section class="nx-section wl-tech" id="technik">
+		<div class="nx-container">
+			<div class="wl-section-header">
+				<span class="wl-eyebrow">Technischer Beleg</span>
+				<h2 class="nx-headline-section">Sauberer Code statt Plugin-Stack.</h2>
+				<p class="wl-section-lede">Eigene Templates, bedarfsgesteuertes Asset-Loading, dokumentierte Übergabe. Keine Page-Builder-Wand, kein generisches Theme-Bloat.</p>
+			</div>
+
+			<div class="wl-tech__split">
+				<ul class="wl-tech__bullets">
+					<?php foreach ( $tech_bullets as $bullet ) : ?>
+						<li><?php echo esc_html( $bullet ); ?></li>
 					<?php endforeach; ?>
 				</ul>
+
+				<figure class="wl-tech__code" aria-hidden="true">
+					<figcaption class="wl-tech__code-head">
+						<span class="wl-tech__code-dot wl-tech__code-dot--r"></span>
+						<span class="wl-tech__code-dot wl-tech__code-dot--y"></span>
+						<span class="wl-tech__code-dot wl-tech__code-dot--g"></span>
+						<span class="wl-tech__code-file">inc/enqueue.php</span>
+					</figcaption>
+<pre class="wl-tech__code-body"><span class="wl-tech__c">// Bedarfsgesteuertes Asset-Loading pro Template</span>
+<span class="wl-tech__k">if</span> ( is_page_template( <span class="wl-tech__s">'page-whitelabel.php'</span> ) ) {
+    hu_enqueue_css( <span class="wl-tech__s">'whitelabel'</span>, <span class="wl-tech__s">'whitelabel.css'</span>, [ <span class="wl-tech__s">'design-system'</span> ] );
+    hu_enqueue_js(  <span class="wl-tech__s">'wl-counters'</span>,  <span class="wl-tech__s">'wl-counters.js'</span> );
+}
+
+<span class="wl-tech__c">// Server-Side Event auf Lead-Submit</span>
+window.dataLayer.push({
+    <span class="wl-tech__p">event</span>: <span class="wl-tech__s">'lead_qualified'</span>,
+    <span class="wl-tech__p">source</span>: <span class="wl-tech__s">'whitelabel_partner'</span>,
+    <span class="wl-tech__p">value</span>: leadValue
+});</pre>
+				</figure>
 			</div>
 		</div>
 	</section>
 
-	<section class="nx-section wl-section-alt" id="kontrakt">
+	<!-- ═══════════════════════════════════════════════
+	     SECTION 08 — EINSTIEG (Testprojekt-Scope)
+	     ═══════════════════════════════════════════════ -->
+	<section class="nx-section wl-entry" id="einstieg">
 		<div class="nx-container">
-			<div class="nx-section-header">
-				<span class="nx-badge nx-badge--ghost">Whitelabel-Kontrakt</span>
-				<h2 class="nx-headline-section">Wie das Whitelabel-Setup läuft.</h2>
+			<div class="wl-section-header">
+				<span class="wl-eyebrow">Einstieg</span>
+				<h2 class="nx-headline-section">Kein sofortiger Retainer. Erst ein kleines Testprojekt.</h2>
 			</div>
 
-			<div class="results-framework__grid">
-				<?php foreach ( $contract_cards as $contract_card ) : ?>
-					<article class="nx-card nx-card--flat results-framework__card">
-						<h3 class="results-framework__title"><?php echo esc_html( $contract_card['title'] ); ?></h3>
-						<p class="results-framework__copy"><?php echo esc_html( $contract_card['copy'] ); ?></p>
-					</article>
-				<?php endforeach; ?>
-			</div>
+			<article class="wl-entry__card">
+				<header class="wl-entry__head">
+					<span class="wl-entry__kicker">Scope · Testprojekt</span>
+					<h3 class="wl-entry__title">Ein klar umrissenes Mini-Projekt, bevor irgendwer „Retainer" sagt.</h3>
+				</header>
+				<p class="wl-entry__copy">
+					Wir starten mit einem fixen, abgegrenzten Scope — typischerweise ein Tracking-Audit, ein Server-Side-Setup oder eine Landingpage. 1–2&nbsp;Wochen Laufzeit, NDA, fixe Lieferung. Erst danach entscheidet ihr, ob daraus ein Retainer wird.
+				</p>
+				<ul class="wl-entry__bullets" aria-label="Rahmen Testprojekt">
+					<?php foreach ( $entry_bullets as $bullet ) : ?>
+						<li><span class="wl-entry__bullet-dot" aria-hidden="true"></span><?php echo esc_html( $bullet ); ?></li>
+					<?php endforeach; ?>
+				</ul>
+				<div class="wl-entry__actions">
+					<a href="<?php echo esc_url( $whitelabel_fit_url ); ?>" class="nx-btn nx-btn--primary" data-track-action="cta_whitelabel_entry_fit_call" data-track-category="lead_gen" data-track-section="entry">
+						Testprojekt besprechen
+					</a>
+				</div>
+			</article>
 		</div>
 	</section>
 
-	<section class="nx-section results-cta">
+	<!-- ═══════════════════════════════════════════════
+	     SECTION 09 — FINAL CTA
+	     ═══════════════════════════════════════════════ -->
+	<section class="nx-section wl-cta" data-nx-theme="dark" id="cta">
+		<div class="wl-cta__bg" aria-hidden="true">
+			<div class="wl-hero__bg-warmth"></div>
+			<div class="wl-hero__bg-vignette"></div>
+		</div>
 		<div class="nx-container">
-			<div class="results-cta__shell">
-				<div>
-					<span class="nx-badge nx-badge--gold">Nächster Schritt</span>
-					<h2 class="results-cta__title">Passt das zu eurem Setup?</h2>
-					<p class="results-cta__copy">Im Fit-Gespräch prüfen wir in 30 Minuten, ob ich technisch, operativ und vertraglich zu eurer Agentur passe. Keine Verkaufsshow, kein Pitch-Deck.</p>
+			<div class="wl-cta__shell">
+				<div class="wl-cta__copy">
+					<span class="wl-eyebrow">Nächster Schritt</span>
+					<h2 class="wl-cta__title">Passt das zu eurem Setup?</h2>
+					<p class="wl-cta__lede">30&nbsp;Min, kein Pitch-Deck, keine Verkaufsshow. Wir prüfen, ob ich technisch und vertraglich zu eurer Agentur passe.</p>
 				</div>
-				<div class="results-cta__actions">
-					<a href="<?php echo esc_url( $whitelabel_fit_url ); ?>" class="nx-btn nx-btn--primary" data-track-action="cta_whitelabel_footer_fit_call" data-track-category="lead_gen">Whitelabel-Fit-Gespräch buchen</a>
-					<a href="<?php echo esc_url( $mailto_url ); ?>" class="nx-btn nx-btn--ghost" data-track-action="cta_whitelabel_footer_mail" data-track-category="contact">hallo@hasimuener.de</a>
+				<div class="wl-cta__actions">
+					<a href="<?php echo esc_url( $whitelabel_fit_url ); ?>" class="nx-btn nx-btn--primary" data-track-action="cta_whitelabel_footer_fit_call" data-track-category="lead_gen" data-track-section="cta">
+						White-Label-Gespräch buchen
+					</a>
+					<a href="<?php echo esc_url( $mailto_url ); ?>" class="nx-btn nx-btn--ghost" data-track-action="cta_whitelabel_footer_mail" data-track-category="contact" data-track-section="cta">
+						hallo@hasimuener.de
+					</a>
 				</div>
 			</div>
 		</div>
 	</section>
+
+	<!-- Sticky Mobile CTA -->
+	<div class="wl-sticky-cta" id="wl-sticky-cta" aria-hidden="true">
+		<div class="wl-sticky-cta__inner">
+			<div class="wl-sticky-cta__label">
+				<strong>White-Label-Partner</strong>
+				<span>30&nbsp;Min Fit-Gespräch · NDA möglich</span>
+			</div>
+			<a href="<?php echo esc_url( $whitelabel_fit_url ); ?>" class="nx-btn nx-btn--primary" data-track-action="cta_sticky_whitelabel_fit_call" data-track-category="lead_gen" data-track-section="sticky_mobile">
+				Gespräch buchen
+			</a>
+		</div>
+	</div>
+
 </main>
+
+<script>
+(function () {
+	// ─── Sticky Mobile CTA visibility ───
+	var sticky = document.getElementById('wl-sticky-cta');
+	var hero   = document.getElementById('hero');
+	var cta    = document.getElementById('cta');
+	if (sticky && hero) {
+		function update() {
+			var heroBottom = hero.getBoundingClientRect().bottom;
+			var ctaTop     = cta ? cta.getBoundingClientRect().top : Infinity;
+			var shouldShow = heroBottom < 0 && ctaTop > window.innerHeight - 80;
+			sticky.classList.toggle('is-visible', shouldShow);
+			sticky.setAttribute('aria-hidden', shouldShow ? 'false' : 'true');
+			document.body.classList.toggle('has-sticky-wl-cta', shouldShow);
+		}
+		window.addEventListener('scroll', update, { passive: true });
+		window.addEventListener('resize', update);
+		update();
+	}
+
+	// ─── Animated Counters ───
+	var counters = document.querySelectorAll('.wl-counter');
+	if (!counters.length) return;
+	var reduceMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+	function format(n, target) {
+		var s = String(Math.round(n));
+		if (target >= 1000) s = s.replace(/\B(?=(\d{3})+(?!\d))/g, '.');
+		return s;
+	}
+
+	function run(el) {
+		var target = parseInt(el.getAttribute('data-counter-target') || '0', 10);
+		var suffix = el.getAttribute('data-counter-suffix') || '';
+		var prefix = el.getAttribute('data-counter-prefix') || '';
+		if (reduceMotion || !('requestAnimationFrame' in window)) {
+			el.innerHTML = prefix + format(target, target) + suffix;
+			return;
+		}
+		var duration = 1400;
+		var start = null;
+		function tick(t) {
+			if (start === null) start = t;
+			var p = Math.min(1, (t - start) / duration);
+			var eased = 1 - Math.pow(1 - p, 3);
+			el.innerHTML = prefix + format(target * eased, target) + suffix;
+			if (p < 1) requestAnimationFrame(tick);
+			else el.innerHTML = prefix + format(target, target) + suffix;
+		}
+		requestAnimationFrame(tick);
+	}
+
+	if (!('IntersectionObserver' in window)) {
+		counters.forEach(run);
+		return;
+	}
+	var io = new IntersectionObserver(function (entries) {
+		entries.forEach(function (entry) {
+			if (entry.isIntersecting) {
+				run(entry.target);
+				io.unobserve(entry.target);
+			}
+		});
+	}, { threshold: 0.2 });
+	counters.forEach(function (el) { io.observe(el); });
+})();
+</script>
 
 <?php get_footer(); ?>


### PR DESCRIPTION
Whitelabel-Retainer-Seite komplett neu aufgesetzt im premium Dark-Look mit KPI-Dashboard-Hero, Problem/Loesung/Stack-Sektionen, Live-Beleg, technischem Code-Beleg und Testprojekt-Scope-Card. Eigenes Stylesheet whitelabel.css ersetzt das generische results.css. Tracking-Attribute auf allen CTAs, animierte Counter mit prefers-reduced-motion-Respekt, Sticky Mobile CTA.

Ziel: Agentur-Inhaber sollen in 10 Sekunden technische Tiefe, Verlaesslichkeit und Umsetzungsqualitaet erkennen.

https://claude.ai/code/session_01AFpvj6igShzpsPURHUv6hm