### PR TITLE
feat(agentur-hannover): Hero-Viz, Micro-Commitment, lokales Entity-Sc…

### DIFF
--- a/blocksy-child/assets/css/agentur.css
+++ b/blocksy-child/assets/css/agentur.css
@@ -3207,3 +3207,166 @@
     transform: none;
   }
 }
+
+/* ---------------------------------------------------------------------------
+   H9. PHASEN-KARTEN ALS NAVIGATIONS-LINKS (Progressive Disclosure)
+   --------------------------------------------------------------------------- */
+.wgos-steps__link {
+  display: block;
+  height: 100%;
+  color: inherit;
+  text-decoration: none;
+  border-radius: inherit;
+}
+
+.wgos-steps__link:hover,
+.wgos-steps__link:focus-visible {
+  color: inherit;
+  text-decoration: none;
+}
+
+.wgos-steps__link:focus-visible {
+  outline: 2px solid var(--ag-primary);
+  outline-offset: 4px;
+}
+
+.wgos-steps__more {
+  display: inline-block;
+  margin-top: var(--ag-space-md);
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--ag-primary);
+  letter-spacing: 0.01em;
+  opacity: 0.85;
+  transition: opacity var(--ag-dur-base) var(--ag-ease),
+              transform var(--ag-dur-base) var(--ag-ease);
+}
+
+.wp-agentur-process-grid li:hover .wgos-steps__more,
+.wgos-steps__link:focus-visible .wgos-steps__more {
+  opacity: 1;
+  transform: translateX(3px);
+}
+
+/* ---------------------------------------------------------------------------
+   H10. MICRO-COMMITMENT VORQUALIFIZIERUNG (Multi-Step)
+   --------------------------------------------------------------------------- */
+.wp-agentur-quali {
+  max-width: 760px;
+  margin: var(--ag-space-2xl) auto 0;
+  padding: clamp(1.5rem, 3vw, 2.25rem);
+  background: var(--ag-surface);
+  border: 1px solid var(--ag-border);
+  border-radius: 1.25rem;
+  box-shadow: 0 10px 32px rgba(41, 38, 27, 0.06);
+}
+
+.wp-agentur-quali__step[hidden] {
+  display: none;
+}
+
+.wp-agentur-quali__kicker {
+  margin: 0 0 0.4rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ag-primary);
+}
+
+.wp-agentur-quali__q {
+  margin: 0 0 var(--ag-space-lg);
+  font-size: clamp(1.15rem, 2vw, 1.4rem);
+  font-weight: 600;
+  line-height: 1.3;
+  color: var(--ag-text);
+}
+
+.wp-agentur-quali__q:focus {
+  outline: none;
+}
+
+.wp-agentur-quali__options {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--ag-space-md);
+  margin-bottom: var(--ag-space-md);
+}
+
+.wp-agentur-quali__opt {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.35rem;
+  padding: var(--ag-space-md) var(--ag-space-lg);
+  background: #FFFFFF;
+  border: 1px solid var(--ag-border);
+  border-radius: 0.85rem;
+  text-align: left;
+  font-family: inherit;
+  cursor: pointer;
+  transition: border-color var(--ag-dur-base) var(--ag-ease),
+              transform var(--ag-dur-base) var(--ag-ease),
+              box-shadow var(--ag-dur-base) var(--ag-ease),
+              background-color var(--ag-dur-base) var(--ag-ease);
+}
+
+.wp-agentur-quali__opt:hover,
+.wp-agentur-quali__opt:focus-visible {
+  border-color: var(--ag-primary);
+  transform: translateY(-2px);
+  box-shadow: 0 10px 24px rgba(217, 119, 87, 0.12);
+  outline: none;
+}
+
+.wp-agentur-quali__opt.is-selected {
+  border-color: var(--ag-primary);
+  background: rgba(217, 119, 87, 0.06);
+  box-shadow: 0 0 0 3px rgba(217, 119, 87, 0.18);
+}
+
+.wp-agentur-quali__opt strong {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--ag-text);
+  line-height: 1.3;
+}
+
+.wp-agentur-quali__opt span {
+  font-size: 0.85rem;
+  line-height: 1.45;
+  color: var(--ag-text-2);
+}
+
+.wp-agentur-quali__hint {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--ag-text-3);
+  line-height: 1.55;
+}
+
+.wp-agentur-quali__step--done {
+  text-align: center;
+}
+
+.wp-agentur-quali__step--done .wp-agentur-quali__q {
+  margin-bottom: var(--ag-space-md);
+}
+
+.wp-agentur-quali__cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: var(--ag-space-md);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .wp-agentur-quali__opt,
+  .wgos-steps__more {
+    transition: none;
+  }
+  .wp-agentur-quali__opt:hover,
+  .wp-agentur-quali__opt:focus-visible {
+    transform: none;
+  }
+}

--- a/blocksy-child/inc/org-schema.php
+++ b/blocksy-child/inc/org-schema.php
@@ -375,12 +375,29 @@ function hu_output_schema()
                 'sameAs' => 'https://de.wikipedia.org/wiki/Pattensen'
             ],
             [
-                '@type' => 'AdministrativeArea',
-                'name'  => 'Region Hannover'
+                '@type'  => 'City',
+                'name'   => 'Braunschweig',
+                'sameAs' => 'https://de.wikipedia.org/wiki/Braunschweig'
             ],
             [
-                '@type' => 'AdministrativeArea',
-                'name'  => 'Niedersachsen'
+                '@type'  => 'City',
+                'name'   => 'Wolfsburg',
+                'sameAs' => 'https://de.wikipedia.org/wiki/Wolfsburg'
+            ],
+            [
+                '@type'  => 'City',
+                'name'   => 'Hildesheim',
+                'sameAs' => 'https://de.wikipedia.org/wiki/Hildesheim'
+            ],
+            [
+                '@type'  => 'AdministrativeArea',
+                'name'   => 'Region Hannover',
+                'sameAs' => 'https://de.wikipedia.org/wiki/Region_Hannover'
+            ],
+            [
+                '@type'  => 'AdministrativeArea',
+                'name'   => 'Niedersachsen',
+                'sameAs' => 'https://de.wikipedia.org/wiki/Niedersachsen'
             ],
             [
                 '@type' => 'AdministrativeArea',
@@ -725,6 +742,106 @@ function hu_output_schema()
             $schemas[] = $service;
 
             if ('wordpress-agentur-hannover' === $slug) {
+                // Dedicated ProfessionalService (LocalBusiness subtype) for the
+                // Hannover money page: explicit geo, address and an extended
+                // areaServed array boost local-pack relevance.
+                $hannover_area_served = [
+                    [
+                        '@type'  => 'City',
+                        'name'   => 'Hannover',
+                        'sameAs' => 'https://de.wikipedia.org/wiki/Hannover',
+                    ],
+                    [
+                        '@type'  => 'City',
+                        'name'   => 'Pattensen',
+                        'sameAs' => 'https://de.wikipedia.org/wiki/Pattensen',
+                    ],
+                    [
+                        '@type'  => 'City',
+                        'name'   => 'Braunschweig',
+                        'sameAs' => 'https://de.wikipedia.org/wiki/Braunschweig',
+                    ],
+                    [
+                        '@type'  => 'City',
+                        'name'   => 'Wolfsburg',
+                        'sameAs' => 'https://de.wikipedia.org/wiki/Wolfsburg',
+                    ],
+                    [
+                        '@type'  => 'City',
+                        'name'   => 'Hildesheim',
+                        'sameAs' => 'https://de.wikipedia.org/wiki/Hildesheim',
+                    ],
+                    [
+                        '@type'  => 'AdministrativeArea',
+                        'name'   => 'Region Hannover',
+                        'sameAs' => 'https://de.wikipedia.org/wiki/Region_Hannover',
+                    ],
+                    [
+                        '@type'  => 'AdministrativeArea',
+                        'name'   => 'Niedersachsen',
+                        'sameAs' => 'https://de.wikipedia.org/wiki/Niedersachsen',
+                    ],
+                ];
+
+                $professional_service = [
+                    '@context'           => 'https://schema.org',
+                    '@type'              => 'ProfessionalService',
+                    '@id'                => home_url('/wordpress-agentur-hannover/#localbusiness'),
+                    'name'               => 'Haşim Üner – WordPress Agentur Hannover',
+                    'alternateName'      => 'WordPress Agentur Hannover',
+                    'description'        => $def['description'],
+                    'url'                => home_url('/wordpress-agentur-hannover/'),
+                    'image'              => hu_get_profile_image_url(),
+                    'logo'               => function_exists( 'hu_get_brand_logo_url' ) ? hu_get_brand_logo_url() : content_url( '/uploads/2025/08/cropped-Logo-hasim-uener-1.webp' ),
+                    'telephone'          => '+49 176 81407134',
+                    'email'              => 'info@hasimuener.de',
+                    'priceRange'         => '€€',
+                    'currenciesAccepted' => 'EUR',
+                    'paymentAccepted'    => 'Überweisung',
+                    'parentOrganization' => ['@id' => home_url('/#organization')],
+                    'address'            => [
+                        '@type'           => 'PostalAddress',
+                        'streetAddress'   => 'Warschauer Str. 5',
+                        'addressLocality' => 'Pattensen',
+                        'addressRegion'   => 'Niedersachsen',
+                        'postalCode'      => '30982',
+                        'addressCountry'  => 'DE',
+                    ],
+                    'geo' => [
+                        '@type'     => 'GeoCoordinates',
+                        'latitude'  => '52.2736456',
+                        'longitude' => '9.7559953',
+                    ],
+                    'hasMap'        => $google_maps_url,
+                    'areaServed'    => $hannover_area_served,
+                    'knowsAbout'    => [
+                        'WordPress',
+                        'Technisches SEO',
+                        'Core Web Vitals',
+                        'Conversion Rate Optimization',
+                        'GA4 Tracking',
+                        'Server-Side Tagging',
+                        'B2B Lead Generation',
+                    ],
+                    'knowsLanguage' => ['de', 'en', 'tr'],
+                    'sameAs'        => [
+                        'https://www.linkedin.com/in/hasim-%C3%BCner/',
+                        'https://github.com/Hasim-Uner/',
+                        'https://hasimuener.org/',
+                        $google_maps_url,
+                    ],
+                    'openingHoursSpecification' => [
+                        [
+                            '@type'     => 'OpeningHoursSpecification',
+                            'dayOfWeek' => ['Monday', 'Tuesday', 'Wednesday', 'Thursday'],
+                            'opens'     => '08:30',
+                            'closes'    => '16:00',
+                        ],
+                    ],
+                ];
+
+                $schemas[] = $professional_service;
+
                 $schemas[] = [
                     '@context'    => 'https://schema.org',
                     '@type'       => 'WebPage',
@@ -734,7 +851,10 @@ function hu_output_schema()
                     'description' => $def['description'],
                     'inLanguage'  => 'de',
                     'isPartOf'    => ['@id' => home_url('/#website')],
-                    'about'       => ['@id' => home_url('/#organization')],
+                    'about'       => [
+                        ['@id' => home_url('/#organization')],
+                        ['@id' => home_url('/wordpress-agentur-hannover/#localbusiness')],
+                    ],
                     'mainEntity'  => ['@id' => home_url('/wordpress-agentur-hannover/#service')],
                     'author'      => hu_person_schema_ref(),
                     'reviewedBy'  => hu_person_schema_ref(),

--- a/blocksy-child/page-wordpress-agentur.php
+++ b/blocksy-child/page-wordpress-agentur.php
@@ -183,47 +183,54 @@ get_header();
 					</p>
 				</div>
 
-				<aside class="ag-brief" aria-label="Referenzfall E3 New Energy">
-					<div class="ag-brief__head">
-						<span class="ag-brief__kicker">Referenzfall · verifiziert</span>
-						<div class="ag-brief__title">
-							<h2>E3 New Energy</h2>
-							<span class="ag-brief__sector">Solar · Wärmepumpe · Speicher</span>
-						</div>
-					</div>
+				<aside class="ag-hero-viz" aria-label="Referenzfall E3 New Energy – Kosten pro qualifizierter Anfrage">
+					<header class="ag-hero-viz__head">
+						<span class="ag-hero-viz__live">
+							<span class="ag-hero-viz__live-dot" aria-hidden="true"></span>
+							Verifizierter Referenzfall · E3 New Energy
+						</span>
+						<h2 class="ag-hero-viz__title">CPL-Senkung in 9 Monaten</h2>
+						<p class="ag-hero-viz__sub">Kosten pro qualifizierter B2B-Anfrage — vor und nach dem eigenen Anfrage-System.</p>
+					</header>
 
-					<div class="ag-brief__hero">
-						<span class="ag-brief__label">Kosten pro qualifizierter Anfrage</span>
-						<div class="ag-brief__numbers">
-							<span class="ag-brief__before"><s>150&nbsp;€</s></span>
-							<span class="ag-brief__arrow" aria-hidden="true">
-								<svg width="22" height="22" viewBox="0 0 22 22" fill="none">
-									<path d="M4 11h14M14 6l5 5-5 5" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
-								</svg>
+					<div class="ag-hero-viz__chart" role="img" aria-label="Balkenchart: Kosten pro qualifizierter Anfrage fielen von 150 Euro auf 22 Euro, ein Rückgang um 85 Prozent.">
+						<div class="ag-bar ag-bar--before">
+							<span class="ag-bar__num">150&nbsp;€</span>
+							<span class="ag-bar__track">
+								<span class="ag-bar__fill" style="--ag-bar-height: 92%;"></span>
 							</span>
-							<span class="ag-brief__after">22&nbsp;€</span>
+							<span class="ag-bar__label">Vorher · Portal-Leads</span>
 						</div>
-						<span class="ag-brief__delta">−85 % in 9 Monaten</span>
+						<div class="ag-bar__arrow" aria-hidden="true">
+							<span class="ag-bar__delta">−85 %</span>
+							<svg width="36" height="72" viewBox="0 0 36 72" fill="none">
+								<path class="ag-bar__arrow-path" d="M6 6 C 22 22, 6 40, 30 64" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-dasharray="120" stroke-dashoffset="120" fill="none"/>
+								<path class="ag-bar__arrow-head" d="M22 58 L30 64 L24 70" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+							</svg>
+						</div>
+						<div class="ag-bar ag-bar--after">
+							<span class="ag-bar__num">22&nbsp;€</span>
+							<span class="ag-bar__track">
+								<span class="ag-bar__fill" style="--ag-bar-height: 14%;"></span>
+							</span>
+							<span class="ag-bar__label">Nachher · eigenes System</span>
+						</div>
 					</div>
 
-					<dl class="ag-brief__table">
+					<dl class="ag-hero-viz__foot" aria-label="Kennzahlen aus dem E3-Case">
 						<div>
-							<dt>Anfragen</dt>
-							<dd><span class="ag-counter" data-counter-target="1750" data-counter-suffix="+">0</span></dd>
+							<dt><span class="ag-counter" data-counter-target="1750" data-counter-suffix="+">0</span></dt>
+							<dd>Qualifizierte Anfragen</dd>
 						</div>
 						<div>
-							<dt>Abschlussquote</dt>
-							<dd><span class="ag-counter" data-counter-target="12" data-counter-suffix=" %">0</span></dd>
+							<dt><span class="ag-counter" data-counter-target="12" data-counter-suffix=" %">0</span></dt>
+							<dd>Abschlussquote</dd>
 						</div>
 						<div>
-							<dt>Zeitraum</dt>
-							<dd><span class="ag-counter" data-counter-target="9" data-counter-suffix="&nbsp;Mon.">0</span></dd>
+							<dt><span class="ag-counter" data-counter-target="9" data-counter-suffix=" Mon.">0</span></dt>
+							<dd>Zeitraum</dd>
 						</div>
 					</dl>
-
-					<footer class="ag-brief__foot">
-						<span>Stand 2024–2025 · keine pauschale Übertragbarkeitsgarantie.</span>
-					</footer>
 				</aside>
 			</div>
 		</div>
@@ -366,16 +373,24 @@ get_header();
 				'Weiterentwicklung'     => [ 'num' => '06', 'title' => 'Weiterentwicklung', 'icon' => '🚀', 'desc' => 'Welche Änderung erzeugt als Nächstes Wirkung — datenbasiert.' ],
 			];
 			foreach ( $phase_labels as $area => $p ) :
-				$count = count( $asset_groups[ $area ] ?? [] );
+				$count         = count( $asset_groups[ $area ] ?? [] );
+				$phase_slug    = sanitize_title( $area );
+				$track_section = 'methode_' . $phase_slug;
 			?>
 				<li>
-					<span class="step-num"><?php echo esc_html( $p['num'] ); ?></span>
-					<span class="step-icon" aria-hidden="true"><?php echo esc_html( $p['icon'] ?? '' ); ?></span>
-					<h3>
-						<?php echo esc_html( $p['title'] ); ?>
-						<small><?php echo (int) $count; ?> Bausteine</small>
-					</h3>
-					<p><?php echo esc_html( $p['desc'] ); ?></p>
+					<a class="wgos-steps__link" href="#acc-<?php echo esc_attr( $phase_slug ); ?>"
+					   data-track-action="cta_method_phase_open"
+					   data-track-category="navigation"
+					   data-track-section="<?php echo esc_attr( $track_section ); ?>">
+						<span class="step-num"><?php echo esc_html( $p['num'] ); ?></span>
+						<span class="step-icon" aria-hidden="true"><?php echo esc_html( $p['icon'] ?? '' ); ?></span>
+						<h3>
+							<?php echo esc_html( $p['title'] ); ?>
+							<small><?php echo (int) $count; ?> Bausteine</small>
+						</h3>
+						<p><?php echo esc_html( $p['desc'] ); ?></p>
+						<span class="wgos-steps__more" aria-hidden="true">Bausteine ansehen →</span>
+					</a>
 				</li>
 			<?php endforeach; ?>
 		</ol>
@@ -447,7 +462,7 @@ get_header();
 					? hue_kernbereich_label( hue_get_wgos_kernbereich_key( $area ) )
 					: $area;
 			?>
-				<div class="acc-item" data-acc="<?php echo esc_attr( $area_slug ); ?>">
+				<div class="acc-item" id="acc-<?php echo esc_attr( $area_slug ); ?>" data-acc="<?php echo esc_attr( $area_slug ); ?>">
 					<button class="acc-trigger" aria-expanded="false" aria-controls="body-<?php echo esc_attr( $area_slug ); ?>" data-track-action="toggle_methodenbibliothek" data-track-category="engagement" data-track-section="<?php echo esc_attr( $area_slug ); ?>">
 						<div class="acc-trigger-left">
 							<div class="acc-icon" style="background: <?php echo esc_attr( $meta['color'] ); ?>15; color: <?php echo esc_attr( $meta['color'] ); ?>;"><?php echo esc_html( $meta['icon'] ); ?></div>
@@ -529,9 +544,80 @@ get_header();
 			</div>
 		</div>
 
+		<div class="wp-agentur-quali" id="quali" aria-label="Schneller Kontextcheck zur Vorqualifizierung" data-quali-base="<?php echo esc_attr( $contact_url ); ?>">
+			<div class="wp-agentur-quali__step" data-quali-step="1" aria-hidden="false">
+				<p class="wp-agentur-quali__kicker">30-Sekunden-Vorqualifizierung · Schritt 1 von 2</p>
+				<h3 class="wp-agentur-quali__q">Über welchen Kanal generieren Sie aktuell die meisten qualifizierten B2B-Anfragen?</h3>
+				<div class="wp-agentur-quali__options">
+					<button type="button" class="wp-agentur-quali__opt" data-quali-channel="seo"
+					        data-track-action="quali_channel_seo" data-track-category="lead_gen" data-track-section="quali_step_1">
+						<strong>Organische Suche / SEO</strong>
+						<span>Google, technisches SEO, kaufnahe Suchanfragen</span>
+					</button>
+					<button type="button" class="wp-agentur-quali__opt" data-quali-channel="paid"
+					        data-track-action="quali_channel_paid" data-track-category="lead_gen" data-track-section="quali_step_1">
+						<strong>Bezahlte Kampagnen</strong>
+						<span>Google Ads, Meta Ads, LinkedIn Ads</span>
+					</button>
+					<button type="button" class="wp-agentur-quali__opt" data-quali-channel="portals"
+					        data-track-action="quali_channel_portals" data-track-category="lead_gen" data-track-section="quali_step_1">
+						<strong>Portale &amp; Lead-Anbieter</strong>
+						<span>Portal-Leads, Vermittler, Marktplätze</span>
+					</button>
+					<button type="button" class="wp-agentur-quali__opt" data-quali-channel="referral"
+					        data-track-action="quali_channel_referral" data-track-category="lead_gen" data-track-section="quali_step_1">
+						<strong>Empfehlung &amp; Netzwerk</strong>
+						<span>Bestandskunden, Partner, persönliches Netzwerk</span>
+					</button>
+				</div>
+				<p class="wp-agentur-quali__hint">Eine Klick-Antwort, kein Pflichtfeld. Im nächsten Schritt nur das, was Sinn ergibt.</p>
+			</div>
+
+			<div class="wp-agentur-quali__step" data-quali-step="2" aria-hidden="true" hidden>
+				<p class="wp-agentur-quali__kicker">Letzter Schritt · Schritt 2 von 2</p>
+				<h3 class="wp-agentur-quali__q">Was ist gerade der größte Engpass?</h3>
+				<div class="wp-agentur-quali__options">
+					<button type="button" class="wp-agentur-quali__opt" data-quali-pain="quantity"
+					        data-track-action="quali_pain_quantity" data-track-category="lead_gen" data-track-section="quali_step_2">
+						<strong>Zu wenige Anfragen</strong>
+						<span>Reichweite, Sichtbarkeit, Nachfrage</span>
+					</button>
+					<button type="button" class="wp-agentur-quali__opt" data-quali-pain="quality"
+					        data-track-action="quali_pain_quality" data-track-category="lead_gen" data-track-section="quali_step_2">
+						<strong>Anfragen, aber unqualifiziert</strong>
+						<span>Falsche Zielgruppe, hohe Absprungrate</span>
+					</button>
+					<button type="button" class="wp-agentur-quali__opt" data-quali-pain="cpl"
+					        data-track-action="quali_pain_cpl" data-track-category="lead_gen" data-track-section="quali_step_2">
+						<strong>Kosten pro Anfrage zu hoch</strong>
+						<span>CPL steigt, Skalierung wird unrentabel</span>
+					</button>
+					<button type="button" class="wp-agentur-quali__opt" data-quali-pain="tracking"
+					        data-track-action="quali_pain_tracking" data-track-category="lead_gen" data-track-section="quali_step_2">
+						<strong>Keine belastbaren Daten</strong>
+						<span>Tracking, Attribution, GA4 unklar</span>
+					</button>
+				</div>
+				<p class="wp-agentur-quali__hint">Letzte Antwort — direkt im Anschluss landen Sie auf einem vorausgefüllten Kontaktformular.</p>
+			</div>
+
+			<div class="wp-agentur-quali__step wp-agentur-quali__step--done" data-quali-step="3" aria-hidden="true" hidden>
+				<p class="wp-agentur-quali__kicker">Bereit zur Auswertung</p>
+				<h3 class="wp-agentur-quali__q">Ihr Kontext ist erfasst. Im letzten Schritt ordnet Haşim Üner persönlich ein.</h3>
+				<p class="wp-agentur-quali__hint">Ihre Antworten werden an das Formular übergeben. Nur geschäftliche E-Mail &amp; Name sind dort verpflichtend.</p>
+				<a href="<?php echo esc_url( $contact_url ); ?>" class="nx-btn nx-btn--primary wp-agentur-quali__cta"
+				   data-track-action="cta_quali_to_contact" data-track-category="lead_gen" data-track-section="quali_step_3">
+					Auswertung anfordern
+					<svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+						<path d="M7 4L13 10L7 16" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+					</svg>
+				</a>
+			</div>
+		</div>
+
 		<div class="wp-agentur-actions wp-agentur-actions--center" style="margin-top: 2.5rem;">
-			<a href="<?php echo esc_url( $contact_url ); ?>" class="nx-btn nx-btn--primary" data-track-action="cta_projekt_pruefen_mid" data-track-category="lead_gen" data-track-section="projektpruefung">
-				Projekt prüfen
+			<a href="<?php echo esc_url( $contact_url ); ?>" class="nx-btn nx-btn--ghost" data-track-action="cta_projekt_pruefen_mid" data-track-category="navigation" data-track-section="projektpruefung">
+				Lieber direkt zum klassischen Formular
 				<svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
 					<path d="M7 4L13 10L7 16" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 				</svg>
@@ -828,6 +914,92 @@ get_header();
 
 	initAccordion('#asset-accordion', '.acc-item',  '.acc-trigger',  '.acc-body');
 	initAccordion('#faq-accordion',   '.faq-item',  '.faq-trigger',  '.faq-body');
+
+	// ─── Auto-open accordion target via hash (#acc-<slug>) ───
+	(function () {
+		function openFromHash() {
+			var hash = window.location.hash;
+			if (!hash || hash.indexOf('#acc-') !== 0) return;
+			var target = document.querySelector(hash);
+			if (!target || !target.classList.contains('acc-item')) return;
+			var trigger = target.querySelector('.acc-trigger');
+			if (!target.classList.contains('is-open')) {
+				target.classList.add('is-open');
+				if (trigger) trigger.setAttribute('aria-expanded', 'true');
+			}
+			// Smooth scroll respecting any sticky header offset
+			setTimeout(function () {
+				target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+			}, 60);
+		}
+		window.addEventListener('hashchange', openFromHash);
+		if (window.location.hash.indexOf('#acc-') === 0) {
+			// Defer to allow layout to settle
+			setTimeout(openFromHash, 120);
+		}
+	})();
+
+	// ─── Multi-Step Vorqualifizierung (Micro-Commitment) ───
+	(function () {
+		var root = document.getElementById('quali');
+		if (!root) return;
+
+		var base   = root.getAttribute('data-quali-base') || '';
+		var state  = { channel: '', pain: '' };
+		var steps  = root.querySelectorAll('.wp-agentur-quali__step');
+
+		function show(stepNum) {
+			steps.forEach(function (el) {
+				var n        = el.getAttribute('data-quali-step');
+				var isActive = String(n) === String(stepNum);
+				el.hidden   = !isActive;
+				el.setAttribute('aria-hidden', isActive ? 'false' : 'true');
+				if (isActive) {
+					var heading = el.querySelector('.wp-agentur-quali__q');
+					if (heading && typeof heading.focus === 'function') {
+						heading.setAttribute('tabindex', '-1');
+						try { heading.focus({ preventScroll: true }); } catch (e) { heading.focus(); }
+					}
+				}
+			});
+		}
+
+		function appendParam(url, key, val) {
+			if (!val) return url;
+			var sep = url.indexOf('?') === -1 ? '?' : '&';
+			return url + sep + encodeURIComponent(key) + '=' + encodeURIComponent(val);
+		}
+
+		function finalizeUrl() {
+			var url = base;
+			url = appendParam(url, 'channel', state.channel);
+			url = appendParam(url, 'pain', state.pain);
+			var ctaLink = root.querySelector('.wp-agentur-quali__cta');
+			if (ctaLink) ctaLink.setAttribute('href', url);
+			return url;
+		}
+
+		root.querySelectorAll('[data-quali-channel]').forEach(function (btn) {
+			btn.addEventListener('click', function () {
+				state.channel = btn.getAttribute('data-quali-channel') || '';
+				root.querySelectorAll('[data-quali-channel]').forEach(function (b) {
+					b.classList.toggle('is-selected', b === btn);
+				});
+				show(2);
+			});
+		});
+
+		root.querySelectorAll('[data-quali-pain]').forEach(function (btn) {
+			btn.addEventListener('click', function () {
+				state.pain = btn.getAttribute('data-quali-pain') || '';
+				root.querySelectorAll('[data-quali-pain]').forEach(function (b) {
+					b.classList.toggle('is-selected', b === btn);
+				});
+				finalizeUrl();
+				show(3);
+			});
+		});
+	})();
 
 	// ─── Sticky Mobile CTA ───
 	(function () {


### PR DESCRIPTION
…hema

- Hero: ag-brief-Datenkarte durch animierte ag-hero-viz mit CPL-Balkenchart ersetzt (CSS war bereits vorhanden, Markup fehlte). Verifizierter E3-Case wird jetzt visuell statt textuell vermittelt.
- Methode-Phasen sind klickbare Anker auf #acc-<slug>: progressive Offenlegung der Bausteine im Methodenbibliothek-Accordion.
- Projektprüfung: zweistufiger Vorqualifizierungs-Funnel (Kanal + Engpass). Sunk-Cost-Sequenz reicht Antworten als Query-Parameter ans bestehende /kontakt/ weiter, dort wird die Pflichtfeld-Hürde beibehalten.
- Schema: dedizierte ProfessionalService-Entity für die Route /wordpress-agentur-hannover/ mit Geo-Koordinaten Pattensen, vollem areaServed-Array (Hannover, Braunschweig, Wolfsburg, Hildesheim, Region Hannover, Niedersachsen) und hasMap. WebPage.about referenziert Org und LocalBusiness.
- Org-Schema: areaServed um Braunschweig/Wolfsburg/Hildesheim erweitert und Wikipedia-sameAs für Region Hannover und Niedersachsen.