### PR TITLE
feat(about-editorial): biografisch-editoriale Über-Mich-Variante als …

### DIFF
--- a/blocksy-child/assets/css/about-editorial.css
+++ b/blocksy-child/assets/css/about-editorial.css
@@ -1,0 +1,429 @@
+/* =============================================================
+   About Editorial — Biografisch-editorial, Drop-Cap, Blueprint-Grid
+   Parallel zu about-page.css. Scoped auf .about-editorial.
+   ============================================================= */
+
+.about-editorial {
+	--ae-bg:        #fbfaf8;
+	--ae-bg-2:      #f7f5f0;
+	--ae-ink:       #1a1a1a;
+	--ae-ink-2:     rgba(26, 26, 26, 0.8);
+	--ae-ink-3:     rgba(26, 26, 26, 0.7);
+	--ae-accent:    #8c6239;
+	--ae-accent-2:  #734f2d;
+	--ae-line:      rgba(140, 98, 57, 0.2);
+	--ae-line-soft: rgba(140, 98, 57, 0.1);
+
+	--ae-radius:    10px;
+
+	position: relative;
+	isolation: isolate;
+	background-color: var(--ae-bg);
+	color: var(--ae-ink);
+	font-family: 'Figtree', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+	line-height: 1.55;
+
+	background-image:
+		linear-gradient(to right, rgba(140, 98, 57, 0.03) 1px, transparent 1px),
+		linear-gradient(to bottom, rgba(140, 98, 57, 0.03) 1px, transparent 1px);
+	background-size: 40px 40px;
+}
+
+.about-editorial__inner {
+	max-width: 1100px;
+	margin: 0 auto;
+	padding: clamp(48px, 8vw, 96px) clamp(20px, 5vw, 56px);
+}
+
+/* -----------------------------------------------------------
+   Section kicker (Eyebrow)
+----------------------------------------------------------- */
+.about-editorial__kicker,
+.about-editorial__section-kicker,
+.about-editorial__principle-eyebrow,
+.about-editorial__cta-eyebrow {
+	font-family: 'JetBrains Mono', ui-monospace, monospace;
+	font-size: 12px;
+	font-weight: 500;
+	letter-spacing: 0.18em;
+	text-transform: uppercase;
+	color: var(--ae-accent);
+}
+
+.about-editorial__section-kicker {
+	display: block;
+	margin: 0 0 32px;
+}
+
+.about-editorial__section-kicker--center {
+	text-align: center;
+	margin-bottom: 48px;
+}
+
+/* -----------------------------------------------------------
+   Hero
+----------------------------------------------------------- */
+.about-editorial__hero {
+	margin-bottom: clamp(56px, 8vw, 96px);
+	padding-bottom: clamp(40px, 6vw, 64px);
+	border-bottom: 1px solid var(--ae-line);
+}
+
+.about-editorial__h1 {
+	font-family: 'Satoshi', 'Figtree', -apple-system, sans-serif;
+	font-size: clamp(36px, 5vw, 60px);
+	font-weight: 800;
+	line-height: 1.05;
+	letter-spacing: -0.01em;
+	margin: 14px 0 24px;
+	color: var(--ae-ink);
+	text-wrap: balance;
+	max-width: 22ch;
+}
+
+.about-editorial__lead {
+	font-size: clamp(18px, 2.2vw, 22px);
+	line-height: 1.55;
+	color: var(--ae-ink-2);
+	font-weight: 300;
+	max-width: 60ch;
+	margin: 0;
+}
+
+/* -----------------------------------------------------------
+   Biographic Path + Portrait Card (Split)
+----------------------------------------------------------- */
+.about-editorial__split {
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: clamp(40px, 6vw, 64px);
+	margin-bottom: clamp(80px, 12vw, 128px);
+	align-items: start;
+}
+
+@media (min-width: 900px) {
+	.about-editorial__split {
+		grid-template-columns: minmax(0, 7fr) minmax(0, 5fr);
+	}
+}
+
+.about-editorial__path {
+	list-style: none;
+	padding: 0;
+	margin: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 40px;
+}
+
+.about-editorial__path-item {
+	position: relative;
+	display: grid;
+	grid-template-columns: 40px 1fr;
+	gap: 22px;
+	align-items: start;
+}
+
+.about-editorial__path-item:not(:last-child)::before {
+	content: '';
+	position: absolute;
+	left: 19px;
+	top: 44px;
+	bottom: -40px;
+	width: 2px;
+	background-image: repeating-linear-gradient(
+		to bottom,
+		var(--ae-accent) 0,
+		var(--ae-accent) 4px,
+		transparent 4px,
+		transparent 8px
+	);
+}
+
+.about-editorial__path-num {
+	position: relative;
+	z-index: 1;
+	width: 40px;
+	height: 40px;
+	border-radius: 9999px;
+	border: 1px solid var(--ae-accent);
+	background: var(--ae-bg);
+	color: var(--ae-accent);
+	font-family: 'JetBrains Mono', ui-monospace, monospace;
+	font-size: 13px;
+	font-weight: 700;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.about-editorial__path-title {
+	font-family: 'Satoshi', 'Figtree', sans-serif;
+	font-size: 18px;
+	font-weight: 700;
+	margin: 4px 0 8px;
+	color: var(--ae-ink);
+}
+
+.about-editorial__path-text {
+	color: var(--ae-ink-3);
+	font-size: 15px;
+	line-height: 1.6;
+	margin: 0;
+}
+
+/* Portrait card */
+.about-editorial__portrait-card {
+	background: var(--ae-bg-2);
+	border: 1px solid var(--ae-line);
+	border-radius: var(--ae-radius);
+	padding: 24px;
+}
+
+@media (min-width: 900px) {
+	.about-editorial__portrait-card {
+		position: sticky;
+		top: 32px;
+	}
+}
+
+.about-editorial__portrait {
+	width: 100%;
+	height: auto;
+	display: block;
+	border-radius: 6px;
+	border: 1px solid var(--ae-line-soft);
+	margin-bottom: 22px;
+	filter: grayscale(100%);
+	transition: filter 0.5s ease;
+}
+
+.about-editorial__portrait-card:hover .about-editorial__portrait {
+	filter: grayscale(0%);
+}
+
+.about-editorial__meta {
+	margin: 0;
+	display: flex;
+	flex-direction: column;
+}
+
+.about-editorial__meta-row {
+	display: flex;
+	justify-content: space-between;
+	gap: 16px;
+	padding: 10px 0;
+	font-family: 'JetBrains Mono', ui-monospace, monospace;
+	font-size: 12px;
+	color: var(--ae-accent);
+}
+
+.about-editorial__meta-row + .about-editorial__meta-row {
+	border-top: 1px solid var(--ae-line-soft);
+}
+
+.about-editorial__meta-row dt {
+	text-transform: uppercase;
+	letter-spacing: 0.1em;
+	margin: 0;
+}
+
+.about-editorial__meta-row dd {
+	margin: 0;
+	font-weight: 700;
+	text-align: right;
+}
+
+/* -----------------------------------------------------------
+   Manifest
+----------------------------------------------------------- */
+.about-editorial__manifest {
+	margin-bottom: clamp(80px, 12vw, 128px);
+	padding: clamp(48px, 8vw, 80px) 0;
+	border-top: 1px solid var(--ae-line);
+	border-bottom: 1px solid var(--ae-line);
+}
+
+.about-editorial__manifest-grid {
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: 24px;
+}
+
+@media (min-width: 760px) {
+	.about-editorial__manifest-grid {
+		grid-template-columns: repeat(3, 1fr);
+	}
+}
+
+.about-editorial__principle {
+	background: rgba(247, 245, 240, 0.5);
+	border: 1px solid var(--ae-line-soft);
+	border-radius: var(--ae-radius);
+	padding: 28px;
+	display: flex;
+	flex-direction: column;
+	transition: border-color 0.3s ease;
+}
+
+.about-editorial__principle:hover {
+	border-color: rgba(140, 98, 57, 0.4);
+}
+
+.about-editorial__principle-eyebrow {
+	display: block;
+	margin: 0 0 14px;
+}
+
+.about-editorial__principle-title {
+	font-family: 'Satoshi', 'Figtree', sans-serif;
+	font-size: 20px;
+	font-weight: 700;
+	line-height: 1.25;
+	margin: 0 0 16px;
+	color: var(--ae-ink);
+}
+
+.about-editorial__principle-body {
+	color: var(--ae-ink-2);
+	font-size: 14.5px;
+	line-height: 1.65;
+	margin: 0 0 24px;
+}
+
+.about-editorial__principle-detail {
+	font-family: 'JetBrains Mono', ui-monospace, monospace;
+	font-size: 12px;
+	font-style: italic;
+	color: var(--ae-accent);
+	border-top: 1px solid var(--ae-line-soft);
+	padding-top: 16px;
+	margin: auto 0 0;
+}
+
+/* -----------------------------------------------------------
+   Biography prose (Drop-Cap)
+----------------------------------------------------------- */
+.about-editorial__bio {
+	max-width: 720px;
+	margin: 0 auto clamp(80px, 12vw, 128px);
+}
+
+.about-editorial__bio-prose {
+	font-family: 'Source Serif Pro', 'Georgia', serif;
+	color: rgba(26, 26, 26, 0.9);
+}
+
+.about-editorial__bio-prose p {
+	font-size: clamp(17px, 1.6vw, 20px);
+	line-height: 1.75;
+	margin: 0 0 28px;
+	text-align: justify;
+	hyphens: auto;
+}
+
+.about-editorial__dropcap::first-letter {
+	font-family: 'Satoshi', 'Outfit', 'Figtree', sans-serif;
+	font-size: 4.5rem;
+	font-weight: 700;
+	float: left;
+	line-height: 0.85;
+	margin: 6px 12px 0 0;
+	color: var(--ae-accent);
+}
+
+/* -----------------------------------------------------------
+   Final CTA Card
+----------------------------------------------------------- */
+.about-editorial__cta-card {
+	max-width: 760px;
+	margin: 0 auto;
+	background: var(--ae-bg-2);
+	border: 1px solid var(--ae-line);
+	border-radius: var(--ae-radius);
+	padding: clamp(40px, 6vw, 64px) clamp(24px, 5vw, 56px);
+	text-align: center;
+}
+
+.about-editorial__cta-eyebrow {
+	display: block;
+	margin-bottom: 10px;
+}
+
+.about-editorial__cta-title {
+	font-family: 'Satoshi', 'Figtree', sans-serif;
+	font-size: clamp(26px, 3.5vw, 36px);
+	font-weight: 800;
+	margin: 0 0 16px;
+	color: var(--ae-ink);
+}
+
+.about-editorial__cta-text {
+	color: var(--ae-ink-3);
+	font-size: 15.5px;
+	line-height: 1.65;
+	max-width: 52ch;
+	margin: 0 auto 28px;
+}
+
+.about-editorial__cta-btn {
+	display: inline-block;
+	background: var(--ae-accent);
+	color: #fff;
+	padding: 16px 32px;
+	border-radius: 6px;
+	font-weight: 700;
+	font-size: 14.5px;
+	letter-spacing: 0.02em;
+	text-decoration: none;
+	box-shadow: 0 6px 18px -8px rgba(140, 98, 57, 0.55);
+	transition: background-color 0.25s ease, transform 0.25s ease;
+}
+
+.about-editorial__cta-btn:hover,
+.about-editorial__cta-btn:focus-visible {
+	background: var(--ae-accent-2);
+	transform: translateY(-1px);
+	color: #fff;
+}
+
+.about-editorial__cta-meta {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: center;
+	gap: 8px 22px;
+	margin: 22px 0 0;
+	font-family: 'JetBrains Mono', ui-monospace, monospace;
+	font-size: 11.5px;
+	color: var(--ae-accent);
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+}
+
+.about-editorial__cta-meta span + span {
+	position: relative;
+	padding-left: 22px;
+}
+
+.about-editorial__cta-meta span + span::before {
+	content: '';
+	position: absolute;
+	left: 0;
+	top: 50%;
+	width: 4px;
+	height: 4px;
+	background: var(--ae-accent);
+	border-radius: 9999px;
+	transform: translateY(-50%);
+}
+
+/* -----------------------------------------------------------
+   Reduced motion
+----------------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+	.about-editorial__portrait,
+	.about-editorial__cta-btn,
+	.about-editorial__principle {
+		transition: none;
+	}
+}

--- a/blocksy-child/inc/enqueue.php
+++ b/blocksy-child/inc/enqueue.php
@@ -183,6 +183,11 @@ function hu_enqueue_assets() {
 		hu_enqueue_js( 'nexus-about-js', 'about-page.js', [] );
 	}
 
+	// ── E1) Template: Über Mich (Editorial Variante) ──────────────
+	if ( is_page_template( 'template-about-editorial.php' ) ) {
+		hu_enqueue_css( 'nexus-about-editorial-css', 'about-editorial.css', [ 'nexus-design-system' ] );
+	}
+
 	// ── E2) Kontakt ───────────────────────────────────────────────
 	if ( function_exists( 'nexus_is_contact_page' ) && nexus_is_contact_page() ) {
 		hu_enqueue_css( 'nexus-contact-css', 'contact.css', [ 'nexus-design-system' ] );

--- a/blocksy-child/inc/helpers.php
+++ b/blocksy-child/inc/helpers.php
@@ -1443,6 +1443,7 @@ function nexus_should_hide_footer_primary_cta() {
 
 	$page_templates = [
 		'template-about.php',
+		'template-about-editorial.php',
 		'page-wordpress-agentur.php',
 		'page-wordpress-agentur-hannover.php',
 		'page-case-studies-e-commerce.php',

--- a/blocksy-child/template-about-editorial.php
+++ b/blocksy-child/template-about-editorial.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * Template Name: Über Mich (Editorial)
+ * Description: Biografisch-editoriale Alternative zur Standard-Über-Mich-Seite.
+ *              Fokus: Unternehmer-DNA, Mediensystem-Analyse, Drop-Cap-Erzählung.
+ *
+ * Parallel zu template-about.php. Auswahl pro Page im WP-Admin.
+ *
+ * @package Blocksy_Child
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$request_url  = function_exists( 'nexus_get_primary_request_url' ) ? nexus_get_primary_request_url() : home_url( '/solar-waermepumpen-leadgenerierung/#marktcheck' );
+$request_cta  = function_exists( 'nexus_get_primary_request_cta_label' ) ? nexus_get_primary_request_cta_label() : 'Kostenfreien Marktcheck starten';
+$portrait_url = function_exists( 'hu_get_profile_image_url' ) ? hu_get_profile_image_url() : get_stylesheet_directory_uri() . '/assets/img/hasim-portrait.png';
+$portrait_path = get_stylesheet_directory() . '/assets/img/hasim-portrait.png';
+
+// Biografischer Pfad — von Herkunft zur Methode.
+$about_hero_path = [
+	[
+		't' => 'Die Unternehmer-DNA',
+		's' => 'Aufgewachsen im Bauunternehmen des Vaters. Vertrieb, Margendruck und das wirtschaftliche Risiko von Kindesbeinen an verstanden.',
+	],
+	[
+		't' => 'Die medienwissenschaftliche Struktur',
+		's' => 'Systeme dekonstruieren. Analysieren, wie digitale Zeichen, Signale und Kanäle Märkte und menschliche Entscheidungen steuern.',
+	],
+	[
+		't' => 'Die Fusion im Anfrage-System',
+		's' => 'Vertriebs-Verstand trifft präzise Daten-Integrität. Für Betriebe, die ihre eigene Nachfrage besitzen wollen, statt Leads zu mieten.',
+	],
+];
+
+// Die drei Grundüberzeugungen (Manifest).
+$about_work_principles = [
+	[
+		'eyebrow' => 'Überzeugung I',
+		'title'   => 'Code muss verkaufen, nicht informieren.',
+		'body'    => 'Die meisten Websites sind digitale Hochglanz-Prospekte. Wer selbst aus dem Vertrieb kommt, weiß: Eine B2B-Website hat eine Aufgabe — Abschlüsse vorzubereiten. Ein eigenes Anfrage-System ist kein Informationsfriedhof, sondern ein scharf kalkulierter Filter, der unqualifizierte Anfragen abweist und kaufbereite Entscheider isoliert.',
+		'detail'  => 'Wenn die technische Struktur die Sprache des Vertriebs nicht spricht, ist sie wertlos.',
+	],
+	[
+		'eyebrow' => 'Überzeugung II',
+		'title'   => 'Mieten ist teuer. Eigentum ist planbar.',
+		'body'    => 'Im Bau- und Energiesektor gilt: Wer Maschinen, Hallen und Grundstücke nur mietet, macht sich erpressbar. Beim wichtigsten Gut — den Kundenanfragen — tun viele Betriebe genau das. Wer Leads bei Portalen kauft, füttert fremde Plattformen, teilt sich Kontakte mit Mitbewerbern und steht unter dauerhaftem Margendruck.',
+		'detail'  => 'Eigentum schlägt Miete. Auch im Vertrieb.',
+	],
+	[
+		'eyebrow' => 'Überzeugung III',
+		'title'   => 'Daten-Integrität schlägt Bauchgefühl.',
+		'body'    => 'Wenn Tracking nur Klicks statt unterschriebene Werkverträge misst, verbrennt Werbebudget auf den falschen Kanälen. Erst wenn serverseitiges Tracking und CRM nahtlos verschmelzen, sehen die Werbekanäle, wo der echte Profit liegt — und optimieren auf Umsatz statt auf bunte Grafiken.',
+		'detail'  => 'Saubere Datenarchitektur ist der einzige Hebel für planbare Skalierung.',
+	],
+];
+
+get_header();
+?>
+
+<main id="main" class="site-main">
+	<div class="about-editorial" data-track-section="about_editorial_page">
+		<div class="about-editorial__inner">
+
+			<!-- HERO -->
+			<header class="about-editorial__hero">
+				<span class="about-editorial__kicker">Inquiry Systems Architect</span>
+				<h1 class="about-editorial__h1">Vertriebs-Pragmatismus trifft Mediensystem-Analyse.</h1>
+				<p class="about-editorial__lead">
+					Ich entwerfe keine austauschbaren Webseiten. Ich konstruiere autarke Anfrage-Systeme für den inhabergeführten Solar- und SHK-Mittelstand.
+				</p>
+			</header>
+
+			<!-- BIOGRAFISCHER PFAD + PORTRAIT-CARD -->
+			<section class="about-editorial__split">
+				<div class="about-editorial__path-col">
+					<h2 class="about-editorial__section-kicker">Evolution der Methode</h2>
+					<ol class="about-editorial__path" role="list">
+						<?php foreach ( $about_hero_path as $index => $step ) : ?>
+							<li class="about-editorial__path-item">
+								<span class="about-editorial__path-num" aria-hidden="true">0<?php echo (int) ( $index + 1 ); ?></span>
+								<div class="about-editorial__path-body">
+									<h3 class="about-editorial__path-title"><?php echo esc_html( $step['t'] ); ?></h3>
+									<p class="about-editorial__path-text"><?php echo esc_html( $step['s'] ); ?></p>
+								</div>
+							</li>
+						<?php endforeach; ?>
+					</ol>
+				</div>
+
+				<aside class="about-editorial__portrait-card">
+					<?php if ( file_exists( $portrait_path ) ) : ?>
+						<img
+							src="<?php echo esc_url( $portrait_url ); ?>"
+							alt="Porträt von Haşim Üner"
+							class="about-editorial__portrait"
+							loading="lazy"
+							width="340"
+							height="420"
+						/>
+					<?php endif; ?>
+					<dl class="about-editorial__meta">
+						<div class="about-editorial__meta-row">
+							<dt>Status</dt>
+							<dd>Aktiv · Pattensen</dd>
+						</div>
+						<div class="about-editorial__meta-row">
+							<dt>Fokus</dt>
+							<dd>Solar &amp; SHK-Infrastruktur</dd>
+						</div>
+						<div class="about-editorial__meta-row">
+							<dt>Methode</dt>
+							<dd>Sovereign Demand System</dd>
+						</div>
+					</dl>
+				</aside>
+			</section>
+
+			<!-- MANIFEST -->
+			<section class="about-editorial__manifest" aria-labelledby="about-editorial-manifest-title">
+				<h2 id="about-editorial-manifest-title" class="about-editorial__section-kicker about-editorial__section-kicker--center">
+					Das Unternehmer-Manifest
+				</h2>
+				<div class="about-editorial__manifest-grid">
+					<?php foreach ( $about_work_principles as $principle ) : ?>
+						<article class="about-editorial__principle">
+							<span class="about-editorial__principle-eyebrow"><?php echo esc_html( $principle['eyebrow'] ); ?></span>
+							<h3 class="about-editorial__principle-title"><?php echo esc_html( $principle['title'] ); ?></h3>
+							<p class="about-editorial__principle-body"><?php echo esc_html( $principle['body'] ); ?></p>
+							<p class="about-editorial__principle-detail"><?php echo esc_html( $principle['detail'] ); ?></p>
+						</article>
+					<?php endforeach; ?>
+				</div>
+			</section>
+
+			<!-- BIOGRAFISCHE ERZÄHLUNG -->
+			<section class="about-editorial__bio" id="about-editorial-hintergrund">
+				<h2 class="about-editorial__section-kicker">Der Hintergrund</h2>
+				<div class="about-editorial__bio-prose">
+					<p class="about-editorial__dropcap">Mein Vater war Bauunternehmer. Ich bin mit dem Wissen aufgewachsen, was es bedeutet, Verantwortung für Projekte, Margen und ein fest angestelltes Team zu tragen. Vertrieb und Unternehmertum wurden mir nicht in Seminaren beigebracht — sie sind meine DNA.</p>
+					<p>Mein Studium der Medienwissenschaft an der Universität Paderborn war kein Elfenbeinturm, sondern ein logischer Werkzeugkasten. Ich habe gelernt, komplexe Informationssysteme radikal zu dekonstruieren. Ich schaue nicht darauf, was auf einer Website schön aussieht. Ich analysiere, wie Daten fließen, wo Aufmerksamkeit im Funnel versickert und welche unsichtbaren Signale zwischen einer digitalen Oberfläche und einem B2B-Entscheider übertragen werden müssen, damit echtes Vertrauen entsteht.</p>
+					<p>Die meisten WordPress-Websites scheitern, weil sie von Designern gebaut wurden, die nie ein echtes Verkaufsgespräch geführt haben. Sie informieren den Nutzer zu Tode, statt Entscheidungen zu provozieren. Ich fusioniere den Vertriebs-Pragmatismus des Bauwesens mit der analytischen Präzision der Medienwissenschaft. Seit dem Case bei E3 New Energy wende ich diese Methode exklusiv auf den Solar- und Wärmepumpen-Mittelstand an.</p>
+				</div>
+			</section>
+
+			<!-- CTA -->
+			<footer class="about-editorial__cta-card">
+				<span class="about-editorial__cta-eyebrow">Exklusiver System-Intake</span>
+				<h2 class="about-editorial__cta-title">Bereit für ein autarkes System?</h2>
+				<p class="about-editorial__cta-text">
+					Wir analysieren, wie viel Werbebudget aktuell in Portal-Lücken versickert und wie ein eigenes Anfrage-Kraftwerk für Ihren Betrieb aussehen muss.
+				</p>
+				<a
+					href="<?php echo esc_url( $request_url ); ?>"
+					class="about-editorial__cta-btn"
+					data-track-action="cta_about_editorial_marktcheck"
+					data-track-category="lead_gen"
+					data-track-section="about_editorial_cta"
+				>
+					<?php echo esc_html( $request_cta ); ?>
+				</a>
+				<p class="about-editorial__cta-meta">
+					<span>Exklusive Erst-Analyse</span>
+					<span>Prüfung auf Regions-Verfügbarkeit</span>
+					<span>Händischer Befund in 48 h</span>
+				</p>
+			</footer>
+
+		</div>
+	</div>
+</main>
+
+<?php
+get_footer();


### PR DESCRIPTION
…Parallel-Template

Neue Template-Variante template-about-editorial.php mit eigener about-editorial.css neben dem bestehenden template-about.php. Per Page-Attributes wählbar.

Inhaltlich:
- Biografischer Pfad (Unternehmer-DNA → Medienwissenschaft → Anfrage-System)
- Unternehmer-Manifest in drei Überzeugungen
- Drop-Cap-Narrative zur Herkunft
- Portrait-Card mit Status/Fokus/Methode-Meta

Technisch:
- ABSPATH-Guard, esc_html/esc_url/esc_attr durchgängig
- Helper-basierte URLs (nexus_get_primary_request_url, hu_get_profile_image_url)
- data-track-* Attribute am Final-CTA
- Vanilla CSS, scoped auf .about-editorial (kein Tailwind, kein Inline-Style)
- Conditional Enqueue in inc/enqueue.php
- In nexus_should_hide_footer_primary_cta aufgenommen (kein doppelter Footer-CTA)