### PR TITLE
Redesign blog archive with bell + card-grid architecture

### DIFF
--- a/blocksy-child/assets/css/blog-archive.css
+++ b/blocksy-child/assets/css/blog-archive.css
@@ -1,364 +1,860 @@
-/* =========================================
-   Minimal editorial blog archive
-   ========================================= */
+/* =============================================================
+   Blog Archive — "Bell" architecture
+   Loaded on is_home() only. Scoped under .blog-bell to avoid
+   colliding with category-hub.css (which keeps .blog-editorial-*).
+   Uses the .hu-hp design tokens defined in homepage-redesign.css.
+============================================================= */
 
-.blog-home.blog-editorial,
-.blog-editorial {
-    min-height: 100vh;
-    background: #0b0b09;
-    color: #f4f1ea;
+.blog-bell {
+	background: var(--hu-bg);
+	color: var(--hu-fg);
+	font-family: var(--font-body);
+	min-height: 100vh;
+	position: relative;
+	overflow-x: clip;
 }
 
-.blog-editorial {
-    padding: calc(var(--nx-header-height, 90px) + clamp(2.5rem, 6vw, 5rem)) 0 clamp(4rem, 8vw, 7rem);
+.blog-bell::before {
+	content: '';
+	position: absolute;
+	inset: 0 0 auto 0;
+	height: 520px;
+	background:
+		radial-gradient(ellipse 60% 100% at 80% 0%, var(--hu-accent-soft), transparent 60%),
+		radial-gradient(ellipse 80% 80% at 10% 10%, hsl(28 12% 12% / 0.55), transparent 65%);
+	pointer-events: none;
+	z-index: 0;
 }
 
-.blog-editorial__inner {
-    width: min(820px, calc(100vw - 2rem));
-    margin-inline: auto;
+.blog-bell__container {
+	max-width: 1280px;
+	margin: 0 auto;
+	padding: 0 clamp(20px, 4vw, 48px);
+	position: relative;
+	z-index: 1;
 }
 
-.blog-editorial-hero {
-    padding-bottom: clamp(2rem, 5vw, 4rem);
-    border-bottom: 1px solid hsl(42 16% 88% / 0.14);
+/* ---------- Hero ---------- */
+
+.blog-bell__hero {
+	padding: clamp(64px, 9vw, 112px) 0 clamp(48px, 7vw, 80px);
+	position: relative;
+	z-index: 1;
 }
 
-.blog-editorial-kicker {
-    display: block;
-    margin-bottom: 1rem;
-    color: #c8a45d;
-    font-size: 0.74rem;
-    font-weight: 800;
-    letter-spacing: 0.08em;
-    line-height: 1.2;
-    text-transform: uppercase;
+.blog-bell__hero::after {
+	content: '';
+	position: absolute;
+	left: clamp(20px, 4vw, 48px);
+	right: clamp(20px, 4vw, 48px);
+	bottom: 0;
+	height: 1px;
+	background: linear-gradient(90deg, transparent, var(--hu-line) 20%, var(--hu-line) 80%, transparent);
 }
 
-.blog-editorial-hero__title,
-.blog-editorial-cta__title {
-    margin: 0;
-    color: #f8f5ee;
-    font-family: var(--font-display);
-    font-weight: 750;
-    letter-spacing: 0;
-    overflow-wrap: break-word;
-    hyphens: auto;
+.blog-bell__eyebrow {
+	display: inline-flex;
+	align-items: center;
+	gap: 10px;
+	font-family: var(--font-mono);
+	font-size: 11px;
+	font-weight: 600;
+	letter-spacing: 0.2em;
+	text-transform: uppercase;
+	color: var(--hu-accent);
+	background: var(--hu-accent-soft);
+	padding: 7px 14px;
+	border-radius: 8px;
+	border: 1px solid rgba(224, 138, 60, 0.18);
+	margin-bottom: 22px;
 }
 
-.blog-editorial-hero__title {
-    max-width: 11ch;
-    font-size: clamp(2.55rem, 7vw, 5.2rem);
-    line-height: 0.98;
+.blog-bell__eyebrow-dot {
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	background: var(--hu-good);
+	box-shadow: 0 0 0 0 rgba(107, 161, 122, 0.6);
+	animation: blogBellPulse 2.5s ease infinite;
 }
 
-.blog-editorial-hero__lead {
-    max-width: 66ch;
-    margin: clamp(1.1rem, 2.8vw, 1.7rem) 0 0;
-    color: hsl(42 16% 88% / 0.72);
-    font-size: clamp(1rem, 1.5vw, 1.12rem);
-    line-height: 1.72;
+@keyframes blogBellPulse {
+	0%, 100% { box-shadow: 0 0 0 0 rgba(107, 161, 122, 0.65); }
+	50%      { box-shadow: 0 0 0 6px rgba(107, 161, 122, 0); }
 }
 
-.blog-editorial-filter {
-    display: flex;
-    gap: clamp(1.15rem, 4vw, 2.6rem);
-    overflow-x: auto;
-    margin-bottom: clamp(1rem, 3vw, 2rem);
-    padding: clamp(1.15rem, 2.6vw, 1.65rem) 0 0;
-    border-bottom: 1px solid hsl(42 16% 88% / 0.12);
-    scrollbar-width: thin;
+.blog-bell__title {
+	font-family: var(--font-display);
+	font-weight: 800;
+	font-size: clamp(40px, 5.8vw, 72px);
+	line-height: 1.0;
+	letter-spacing: -0.04em;
+	margin: 0 0 22px;
+	max-width: 18ch;
+	text-wrap: balance;
+	background: linear-gradient(135deg, var(--hu-fg) 0%, var(--hu-fg-2) 100%);
+	-webkit-background-clip: text;
+	background-clip: text;
+	-webkit-text-fill-color: transparent;
+	color: transparent;
 }
 
-.blog-editorial-filter__link {
-    position: relative;
-    flex: 0 0 auto;
-    padding: 0 0 1rem;
-    color: hsl(42 16% 88% / 0.52);
-    font-size: 0.9rem;
-    font-weight: 750;
-    line-height: 1.2;
-    text-decoration: none;
-    transition: color 160ms var(--ease-default);
+.blog-bell__lead {
+	font-size: clamp(17px, 1.6vw, 20px);
+	line-height: 1.65;
+	color: var(--hu-fg-2);
+	max-width: 64ch;
+	margin: 0;
+	text-wrap: pretty;
 }
 
-.blog-editorial-filter__link:hover,
-.blog-editorial-filter__link:focus-visible,
-.blog-editorial-filter__link.is-active {
-    color: #f8f5ee;
+/* ---------- Sticky Filter ---------- */
+
+.blog-bell__filter {
+	position: sticky;
+	top: var(--nx-header-height, 76px);
+	z-index: 50;
+	background: hsl(216 16% 6% / 0.86);
+	backdrop-filter: blur(16px) saturate(180%);
+	-webkit-backdrop-filter: blur(16px) saturate(180%);
+	border-bottom: 1px solid var(--hu-line);
 }
 
-.blog-editorial-filter__link.is-active::after {
-    content: '';
-    position: absolute;
-    right: 0;
-    bottom: -1px;
-    left: 0;
-    height: 2px;
-    background: #c8a45d;
+.blog-bell__filter-inner {
+	max-width: 1280px;
+	margin: 0 auto;
+	padding: 16px clamp(20px, 4vw, 48px);
+	display: flex;
+	gap: 10px;
+	align-items: center;
+	overflow-x: auto;
+	scrollbar-width: none;
+	-ms-overflow-style: none;
+	position: relative;
+	mask-image: linear-gradient(90deg, #000 calc(100% - 60px), transparent);
+	-webkit-mask-image: linear-gradient(90deg, #000 calc(100% - 60px), transparent);
 }
 
-.blog-editorial-clusters,
-.blog-editorial-list {
-    display: grid;
+.blog-bell__filter-inner::-webkit-scrollbar {
+	display: none;
 }
 
-.blog-editorial-clusters {
-    gap: clamp(2.4rem, 6vw, 4.5rem);
+.blog-bell__filter-label {
+	font-size: 13px;
+	font-weight: 600;
+	color: var(--hu-fg-3);
+	white-space: nowrap;
+	margin-right: 6px;
 }
 
-.blog-topic-cluster {
-    display: grid;
-    gap: clamp(1.1rem, 3vw, 1.9rem);
-    padding: clamp(1.3rem, 3vw, 2rem) 0 0;
-    border-top: 1px solid hsl(42 16% 88% / 0.14);
+.blog-bell__chip {
+	display: inline-flex;
+	align-items: center;
+	min-height: 40px;
+	padding: 9px 18px;
+	background: var(--hu-bg-2);
+	border: 1px solid var(--hu-line);
+	border-radius: 9999px;
+	color: var(--hu-fg-2);
+	font-family: var(--font-body);
+	font-size: 14px;
+	font-weight: 500;
+	text-decoration: none;
+	white-space: nowrap;
+	transition: background 0.25s var(--ease-default, ease),
+	            border-color 0.25s var(--ease-default, ease),
+	            color 0.25s var(--ease-default, ease),
+	            transform 0.25s var(--ease-default, ease);
 }
 
-.blog-topic-cluster__head {
-    display: grid;
-    gap: 0.65rem;
+.blog-bell__chip:hover,
+.blog-bell__chip:focus-visible {
+	border-color: var(--hu-accent);
+	color: var(--hu-fg);
+	background: var(--hu-accent-soft);
+	transform: translateY(-1px);
 }
 
-.blog-topic-cluster__title {
-    max-width: 18ch;
-    margin: 0;
-    color: #f8f5ee;
-    font-family: var(--font-display);
-    font-size: clamp(1.55rem, 3.2vw, 2.35rem);
-    font-weight: 750;
-    letter-spacing: 0;
-    line-height: 1.08;
-    overflow-wrap: break-word;
-    hyphens: auto;
+.blog-bell__chip.is-active {
+	background: var(--hu-accent);
+	color: #1A0F05;
+	border-color: var(--hu-accent);
+	box-shadow: 0 2px 10px rgba(224, 138, 60, 0.28), inset 0 1px 0 rgba(255, 255, 255, 0.18);
 }
 
-.blog-topic-cluster__desc {
-    max-width: 66ch;
-    margin: 0;
-    color: hsl(42 16% 88% / 0.68);
-    line-height: 1.64;
+.blog-bell__chip.is-active:hover {
+	background: var(--hu-accent);
+	color: #1A0F05;
 }
 
-.blog-editorial-item {
-    padding: clamp(1.65rem, 4vw, 2.75rem) 0;
-    border-bottom: 1px solid hsl(42 16% 88% / 0.1);
+/* ---------- Main + Grid ---------- */
+
+.blog-bell__main {
+	padding: clamp(40px, 6vw, 80px) 0 clamp(64px, 8vw, 120px);
+	position: relative;
+	z-index: 1;
 }
 
-.blog-editorial-item__meta {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.45rem 0.85rem;
-    margin-bottom: 0.85rem;
-    color: hsl(42 16% 88% / 0.48);
-    font-size: 0.73rem;
-    font-weight: 800;
-    letter-spacing: 0.08em;
-    line-height: 1.4;
-    text-transform: uppercase;
+.blog-bell__grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(min(100%, 340px), 1fr));
+	gap: clamp(24px, 3vw, 36px);
 }
 
-.blog-editorial-topic {
-    color: #c8a45d;
-    text-decoration: none;
+.blog-bell__card {
+	background: var(--hu-bg-2);
+	border: 1px solid var(--hu-line);
+	border-radius: 20px;
+	overflow: hidden;
+	position: relative;
+	transition: transform 0.35s var(--ease-default, ease),
+	            border-color 0.35s var(--ease-default, ease),
+	            box-shadow 0.35s var(--ease-default, ease);
 }
 
-.blog-editorial-topic:hover,
-.blog-editorial-topic:focus-visible {
-    color: #f8f5ee;
+.blog-bell__card::before {
+	content: '';
+	position: absolute;
+	inset: 0;
+	border-radius: inherit;
+	background: radial-gradient(circle at top right, rgba(224, 138, 60, 0.06), transparent 60%);
+	opacity: 0;
+	transition: opacity 0.35s var(--ease-default, ease);
+	pointer-events: none;
 }
 
-.blog-editorial-item__title {
-    max-width: 28ch;
-    margin: 0;
-    color: #f8f5ee;
-    font-family: var(--font-display);
-    font-size: clamp(1.45rem, 3.5vw, 2.28rem);
-    font-weight: 750;
-    letter-spacing: 0;
-    line-height: 1.12;
-    overflow-wrap: break-word;
-    hyphens: auto;
+.blog-bell__card:hover {
+	transform: translateY(-6px);
+	border-color: var(--hu-accent);
+	box-shadow: 0 18px 40px hsl(30 25% 2% / 0.5),
+	            0 8px 22px rgba(224, 138, 60, 0.14);
 }
 
-.blog-editorial-item__title a {
-    color: inherit;
-    text-decoration: none;
+.blog-bell__card:hover::before {
+	opacity: 1;
 }
 
-.blog-editorial-item__title a:hover,
-.blog-editorial-item__title a:focus-visible {
-    color: #d9bd82;
+.blog-bell__card.is-featured {
+	grid-column: 1 / -1;
+	background: linear-gradient(135deg, var(--hu-bg-2) 0%, hsl(216 16% 9%) 100%);
 }
 
-.blog-editorial-item__excerpt {
-    max-width: 64ch;
-    margin: 0.95rem 0 0;
-    color: hsl(42 16% 88% / 0.7);
-    font-size: 1rem;
-    line-height: 1.68;
+.blog-bell__card-link {
+	display: flex;
+	flex-direction: column;
+	gap: 14px;
+	padding: clamp(26px, 3.2vw, 36px);
+	text-decoration: none;
+	color: inherit;
+	height: 100%;
+	position: relative;
+	z-index: 1;
 }
 
-.blog-editorial-empty {
-    margin: 0;
-    padding: 2rem 0;
-    color: hsl(42 16% 88% / 0.68);
+.blog-bell__card-link:focus-visible {
+	outline: 2px solid var(--hu-accent);
+	outline-offset: -2px;
+	border-radius: inherit;
 }
 
-.blog-editorial-inline-cta {
-    display: grid;
-    gap: 0.72rem;
-    margin: clamp(1.2rem, 3vw, 1.8rem) 0;
-    padding: clamp(1.3rem, 3.4vw, 2rem);
-    border: 1px solid hsl(39 50% 58% / 0.38);
-    border-radius: 8px;
-    background:
-        linear-gradient(135deg, hsl(38 42% 18% / 0.72), hsl(170 22% 13% / 0.62)),
-        #15130f;
-    box-shadow: 0 20px 50px -42px hsl(39 60% 55% / 0.75);
+.blog-bell__card-meta {
+	display: flex;
+	gap: 12px;
+	align-items: center;
+	flex-wrap: wrap;
+	font-size: 13px;
+	color: var(--hu-fg-3);
 }
 
-.blog-editorial-inline-cta__title {
-    max-width: 19ch;
-    margin: 0;
-    color: #f8f5ee;
-    font-family: var(--font-display);
-    font-size: clamp(1.28rem, 2.8vw, 1.9rem);
-    font-weight: 750;
-    letter-spacing: 0;
-    line-height: 1.12;
+.blog-bell__card-cat {
+	font-family: var(--font-mono);
+	font-size: 10.5px;
+	font-weight: 700;
+	letter-spacing: 0.12em;
+	text-transform: uppercase;
+	color: var(--hu-accent);
+	background: var(--hu-accent-soft);
+	padding: 5px 11px;
+	border-radius: 6px;
 }
 
-.blog-editorial-inline-cta__text {
-    max-width: 58ch;
-    margin: 0;
-    color: hsl(42 16% 88% / 0.74);
-    line-height: 1.62;
+.blog-bell__card-date {
+	font-size: 13px;
+	color: var(--hu-fg-3);
 }
 
-.blog-editorial-inline-cta__link {
-    width: fit-content;
-    min-height: 44px;
-    display: inline-flex;
-    align-items: center;
-    margin-top: 0.15rem;
-    padding: 0.72rem 1rem;
-    border: 1px solid hsl(39 50% 58% / 0.65);
-    border-radius: 6px;
-    color: #0b0b09;
-    background: #d9bd82;
-    font-size: 0.92rem;
-    font-weight: 850;
-    line-height: 1.1;
-    text-decoration: none;
+.blog-bell__card-title {
+	font-family: var(--font-display);
+	font-weight: 700;
+	font-size: clamp(20px, 2vw, 25px);
+	line-height: 1.25;
+	letter-spacing: -0.025em;
+	margin: 0;
+	color: var(--hu-fg);
+	text-wrap: balance;
+	transition: color 0.2s var(--ease-default, ease);
 }
 
-.blog-editorial-inline-cta__link:hover,
-.blog-editorial-inline-cta__link:focus-visible {
-    color: #0b0b09;
-    background: #f1d99d;
+.blog-bell__card.is-featured .blog-bell__card-title {
+	font-size: clamp(28px, 3.5vw, 40px);
+	line-height: 1.15;
+	max-width: 22ch;
 }
 
-.blog-editorial-pagination {
-    padding-top: clamp(1.5rem, 4vw, 2.5rem);
+.blog-bell__card:hover .blog-bell__card-title {
+	color: var(--hu-accent);
 }
 
-.blog-editorial-pagination .nav-links {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.45rem;
+.blog-bell__card-excerpt {
+	font-size: 15px;
+	line-height: 1.6;
+	color: var(--hu-fg-2);
+	margin: 0;
+	flex: 1 1 auto;
+	text-wrap: pretty;
 }
 
-.blog-editorial-pagination .page-numbers {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-width: 2.45rem;
-    min-height: 2.45rem;
-    padding: 0 0.75rem;
-    border: 1px solid hsl(42 16% 88% / 0.14);
-    color: hsl(42 16% 88% / 0.62);
-    font-size: 0.9rem;
-    font-weight: 750;
-    text-decoration: none;
+.blog-bell__card.is-featured .blog-bell__card-excerpt {
+	font-size: 16.5px;
+	max-width: 60ch;
 }
 
-.blog-editorial-pagination .page-numbers.current,
-.blog-editorial-pagination .page-numbers:hover,
-.blog-editorial-pagination .page-numbers:focus-visible {
-    border-color: #c8a45d;
-    color: #f8f5ee;
+.blog-bell__card-footer {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding-top: 14px;
+	margin-top: 6px;
+	border-top: 1px solid rgba(255, 255, 255, 0.06);
+	font-size: 13px;
+	color: var(--hu-fg-3);
 }
 
-.blog-editorial-cta {
-    display: grid;
-    gap: 0.85rem;
-    margin-top: clamp(2.5rem, 7vw, 5rem);
-    padding: clamp(1.6rem, 4vw, 2.4rem) 0;
-    border-top: 1px solid hsl(42 16% 88% / 0.16);
-    border-bottom: 1px solid hsl(42 16% 88% / 0.16);
+.blog-bell__card-readtime {
+	display: inline-flex;
+	align-items: center;
+	gap: 7px;
 }
 
-.blog-editorial-cta__title {
-    max-width: 17ch;
-    font-size: clamp(1.45rem, 3.4vw, 2.25rem);
-    line-height: 1.12;
+.blog-bell__card-readtime::before {
+	content: '';
+	width: 5px;
+	height: 5px;
+	border-radius: 50%;
+	background: var(--hu-accent);
 }
 
-.blog-editorial-cta__text {
-    max-width: 62ch;
-    margin: 0;
-    color: hsl(42 16% 88% / 0.7);
-    line-height: 1.66;
+.blog-bell__card-arrow {
+	width: 20px;
+	height: 20px;
+	stroke: var(--hu-accent);
+	transition: transform 0.3s var(--ease-default, ease);
 }
 
-.blog-editorial-cta__link {
-    width: fit-content;
-    margin-top: 0.35rem;
-    padding-bottom: 0.18rem;
-    border-bottom: 1px solid currentColor;
-    color: #f8f5ee;
-    font-weight: 800;
-    text-decoration: none;
+.blog-bell__card:hover .blog-bell__card-arrow {
+	transform: translateX(6px);
 }
 
-.blog-editorial-cta__link:hover,
-.blog-editorial-cta__link:focus-visible {
-    color: #c8a45d;
+/* ---------- Pagination ---------- */
+
+.blog-bell__pagination {
+	margin-top: clamp(40px, 5vw, 64px);
 }
 
-@media (max-width: 760px) {
-    .blog-editorial {
-        padding-top: calc(var(--nx-header-height, 82px) + 2.25rem);
-    }
-
-    .blog-editorial__inner {
-        width: min(100% - 1.25rem, 820px);
-    }
-
-    .blog-editorial-hero__title {
-        max-width: 10.5ch;
-    }
-
-    .blog-editorial-filter {
-        margin-right: -0.625rem;
-        margin-left: -0.625rem;
-        padding-right: 0.625rem;
-        padding-left: 0.625rem;
-    }
-
-    .blog-editorial-item__title {
-        max-width: none;
-    }
-
-    .blog-topic-cluster__title,
-    .blog-editorial-inline-cta__title {
-        max-width: none;
-    }
+.blog-bell__pagination .nav-links {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+	justify-content: center;
 }
+
+.blog-bell__pagination .page-numbers {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-width: 44px;
+	min-height: 44px;
+	padding: 0 14px;
+	border: 1px solid var(--hu-line);
+	border-radius: 9999px;
+	color: var(--hu-fg-2);
+	font-size: 14px;
+	font-weight: 500;
+	text-decoration: none;
+	background: var(--hu-bg-2);
+	transition: border-color 0.2s, color 0.2s, background 0.2s;
+}
+
+.blog-bell__pagination .page-numbers.current {
+	background: var(--hu-accent);
+	border-color: var(--hu-accent);
+	color: #1A0F05;
+}
+
+.blog-bell__pagination .page-numbers:not(.current):hover,
+.blog-bell__pagination .page-numbers:focus-visible {
+	border-color: var(--hu-accent);
+	color: var(--hu-fg);
+	background: var(--hu-accent-soft);
+}
+
+.blog-bell__pagination .page-numbers.dots {
+	border-color: transparent;
+	background: transparent;
+}
+
+/* ---------- Bottom CTA ---------- */
+
+.blog-bell__bottom-cta {
+	margin-top: clamp(72px, 9vw, 120px);
+	padding: clamp(36px, 5vw, 56px);
+	border-radius: 24px;
+	border: 1px solid var(--hu-line);
+	background:
+		radial-gradient(ellipse 70% 100% at 100% 0%, rgba(224, 138, 60, 0.10), transparent 60%),
+		linear-gradient(135deg, var(--hu-bg-2) 0%, hsl(216 16% 9%) 100%);
+	display: grid;
+	gap: 14px;
+	box-shadow: 0 16px 40px hsl(30 25% 2% / 0.4);
+}
+
+.blog-bell__bottom-cta .blog-bell__eyebrow {
+	margin-bottom: 0;
+}
+
+.blog-bell__bottom-cta-title {
+	font-family: var(--font-display);
+	font-weight: 800;
+	font-size: clamp(26px, 3.5vw, 38px);
+	line-height: 1.15;
+	letter-spacing: -0.03em;
+	margin: 0;
+	max-width: 22ch;
+	color: var(--hu-fg);
+	text-wrap: balance;
+}
+
+.blog-bell__bottom-cta-text {
+	font-size: 16px;
+	line-height: 1.65;
+	color: var(--hu-fg-2);
+	max-width: 60ch;
+	margin: 0;
+}
+
+.blog-bell__bottom-cta-link {
+	display: inline-flex;
+	align-items: center;
+	gap: 10px;
+	margin-top: 8px;
+	padding: 14px 28px;
+	background: linear-gradient(135deg, var(--hu-accent) 0%, #D97757 100%);
+	color: #1A0F05;
+	font-size: 15px;
+	font-weight: 600;
+	border-radius: 9999px;
+	text-decoration: none;
+	width: fit-content;
+	box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2),
+	            0 4px 12px rgba(224, 138, 60, 0.32);
+	transition: transform 0.25s var(--ease-default, ease),
+	            box-shadow 0.25s var(--ease-default, ease);
+}
+
+.blog-bell__bottom-cta-link:hover,
+.blog-bell__bottom-cta-link:focus-visible {
+	transform: translateY(-2px);
+	box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25),
+	            0 8px 22px rgba(224, 138, 60, 0.45);
+}
+
+.blog-bell__bottom-cta-link svg {
+	width: 16px;
+	height: 16px;
+	transition: transform 0.25s var(--ease-default, ease);
+}
+
+.blog-bell__bottom-cta-link:hover svg {
+	transform: translateX(4px);
+}
+
+.blog-bell__empty {
+	padding: clamp(40px, 6vw, 64px) 0;
+	color: var(--hu-fg-3);
+	font-size: 16px;
+	text-align: center;
+}
+
+/* ---------- Floating Bell ---------- */
+
+.blog-bell__bell {
+	position: fixed;
+	bottom: 28px;
+	right: 28px;
+	z-index: 80;
+	display: inline-flex;
+	align-items: center;
+	gap: 10px;
+	padding: 14px 20px 14px 18px;
+	background: linear-gradient(135deg, var(--hu-accent) 0%, #D97757 100%);
+	color: #1A0F05;
+	border: 0;
+	border-radius: 9999px;
+	font-family: var(--font-body);
+	font-size: 14px;
+	font-weight: 600;
+	cursor: pointer;
+	box-shadow: 0 8px 28px rgba(224, 138, 60, 0.4),
+	            inset 0 1px 0 rgba(255, 255, 255, 0.2);
+	transition: transform 0.3s var(--ease-default, ease),
+	            box-shadow 0.3s var(--ease-default, ease);
+	animation: blogBellRingPulse 4s ease infinite;
+}
+
+@keyframes blogBellRingPulse {
+	0%, 100% { box-shadow: 0 8px 28px rgba(224, 138, 60, 0.4), 0 0 0 0 rgba(224, 138, 60, 0.5), inset 0 1px 0 rgba(255, 255, 255, 0.2); }
+	50%      { box-shadow: 0 10px 34px rgba(224, 138, 60, 0.5), 0 0 0 12px rgba(224, 138, 60, 0), inset 0 1px 0 rgba(255, 255, 255, 0.2); }
+}
+
+.blog-bell__bell:hover,
+.blog-bell__bell:focus-visible {
+	transform: translateY(-4px) scale(1.03);
+	outline: none;
+}
+
+.blog-bell__bell svg {
+	width: 22px;
+	height: 22px;
+	stroke: #1A0F05;
+	stroke-width: 2.5;
+	fill: none;
+	transition: transform 0.3s var(--ease-default, ease);
+}
+
+.blog-bell__bell:hover svg {
+	animation: blogBellShake 0.6s ease;
+}
+
+@keyframes blogBellShake {
+	0%, 100% { transform: rotate(0deg); }
+	25%      { transform: rotate(-12deg); }
+	50%      { transform: rotate(10deg); }
+	75%      { transform: rotate(-6deg); }
+}
+
+.blog-bell__bell-label {
+	white-space: nowrap;
+}
+
+/* ---------- Modal ---------- */
+
+.blog-bell__modal {
+	position: fixed;
+	inset: 0;
+	z-index: 200;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 20px;
+	opacity: 0;
+	pointer-events: none;
+	transition: opacity 0.35s var(--ease-default, ease);
+}
+
+.blog-bell__modal[hidden] {
+	display: none;
+}
+
+.blog-bell__modal.is-open {
+	opacity: 1;
+	pointer-events: auto;
+}
+
+.blog-bell__modal-backdrop {
+	position: absolute;
+	inset: 0;
+	background: rgba(11, 15, 18, 0.86);
+	backdrop-filter: blur(10px);
+	-webkit-backdrop-filter: blur(10px);
+}
+
+.blog-bell__modal-panel {
+	position: relative;
+	z-index: 1;
+	width: 100%;
+	max-width: 540px;
+	background: linear-gradient(135deg, var(--hu-bg-2) 0%, hsl(216 16% 9%) 100%);
+	border: 1px solid var(--hu-line);
+	border-radius: 24px;
+	padding: clamp(28px, 4vw, 44px);
+	box-shadow: 0 30px 70px rgba(0, 0, 0, 0.6),
+	            0 0 0 1px rgba(224, 138, 60, 0.08);
+	transform: scale(0.94) translateY(16px);
+	transition: transform 0.4s var(--ease-default, ease);
+}
+
+.blog-bell__modal.is-open .blog-bell__modal-panel {
+	transform: scale(1) translateY(0);
+}
+
+.blog-bell__modal-close {
+	position: absolute;
+	top: 16px;
+	right: 16px;
+	width: 40px;
+	height: 40px;
+	border-radius: 50%;
+	background: var(--hu-bg);
+	border: 1px solid var(--hu-line);
+	color: var(--hu-fg-2);
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	transition: color 0.2s, border-color 0.2s, transform 0.25s var(--ease-default, ease), background 0.2s;
+}
+
+.blog-bell__modal-close svg {
+	width: 18px;
+	height: 18px;
+}
+
+.blog-bell__modal-close:hover,
+.blog-bell__modal-close:focus-visible {
+	color: var(--hu-accent);
+	border-color: var(--hu-accent);
+	background: var(--hu-accent-soft);
+	transform: rotate(90deg);
+	outline: none;
+}
+
+.blog-bell__modal .blog-bell__eyebrow {
+	margin-bottom: 16px;
+}
+
+.blog-bell__modal-title {
+	font-family: var(--font-display);
+	font-weight: 800;
+	font-size: clamp(26px, 3.5vw, 36px);
+	line-height: 1.15;
+	letter-spacing: -0.03em;
+	margin: 0 0 12px;
+	color: var(--hu-fg);
+	text-wrap: balance;
+}
+
+.blog-bell__modal-body {
+	font-size: 15.5px;
+	line-height: 1.6;
+	color: var(--hu-fg-2);
+	margin: 0 0 24px;
+	text-wrap: pretty;
+}
+
+/* ---------- Form ---------- */
+
+.blog-bell__form {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
+.blog-bell__honeypot {
+	position: absolute;
+	left: -9999px;
+	width: 1px;
+	height: 1px;
+	overflow: hidden;
+}
+
+.blog-bell__input {
+	width: 100%;
+	padding: 15px 20px;
+	background: var(--hu-bg);
+	border: 1.5px solid var(--hu-line);
+	border-radius: 14px;
+	color: var(--hu-fg);
+	font-family: var(--font-body);
+	font-size: 15.5px;
+	transition: border-color 0.2s, box-shadow 0.2s, transform 0.2s;
+}
+
+.blog-bell__input::placeholder {
+	color: var(--hu-fg-3);
+}
+
+.blog-bell__input:hover {
+	border-color: rgba(224, 138, 60, 0.35);
+}
+
+.blog-bell__input:focus {
+	outline: none;
+	border-color: var(--hu-accent);
+	box-shadow: 0 0 0 4px rgba(224, 138, 60, 0.15);
+	transform: translateY(-1px);
+}
+
+.blog-bell__submit {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: 10px;
+	width: 100%;
+	padding: 16px 28px;
+	border: 0;
+	border-radius: 9999px;
+	background: linear-gradient(135deg, var(--hu-accent) 0%, #D97757 100%);
+	color: #1A0F05;
+	font-family: var(--font-body);
+	font-size: 15px;
+	font-weight: 600;
+	cursor: pointer;
+	box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2),
+	            0 4px 12px rgba(224, 138, 60, 0.35);
+	transition: transform 0.25s var(--ease-default, ease),
+	            box-shadow 0.25s var(--ease-default, ease),
+	            opacity 0.2s;
+}
+
+.blog-bell__submit svg {
+	width: 16px;
+	height: 16px;
+}
+
+.blog-bell__submit:hover:not(:disabled),
+.blog-bell__submit:focus-visible {
+	transform: translateY(-2px);
+	box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25),
+	            0 8px 22px rgba(224, 138, 60, 0.5);
+	outline: none;
+}
+
+.blog-bell__submit:disabled {
+	opacity: 0.7;
+	cursor: progress;
+}
+
+.blog-bell__trust {
+	list-style: none;
+	margin: 12px 0 0;
+	padding: 12px 0 0;
+	border-top: 1px solid rgba(255, 255, 255, 0.06);
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px 14px;
+	font-size: 12px;
+	color: var(--hu-fg-3);
+}
+
+.blog-bell__trust li {
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
+}
+
+.blog-bell__trust li::before {
+	content: '✓';
+	color: var(--hu-accent);
+	font-weight: 700;
+}
+
+.blog-bell__hint {
+	font-size: 12px;
+	color: var(--hu-fg-3);
+	margin: 8px 0 0;
+}
+
+.blog-bell__hint a {
+	color: var(--hu-fg-2);
+	text-decoration: underline;
+	text-underline-offset: 2px;
+}
+
+.blog-bell__hint a:hover {
+	color: var(--hu-accent);
+}
+
+.blog-bell__feedback {
+	font-size: 14px;
+	min-height: 1.4em;
+	margin-top: 6px;
+}
+
+.blog-bell__feedback.is-success {
+	color: var(--hu-good);
+}
+
+.blog-bell__feedback.is-error {
+	color: var(--hu-bad);
+}
+
+/* ---------- Reveal ---------- */
+
+.blog-bell [data-reveal] {
+	opacity: 0;
+	transform: translateY(20px);
+	transition: opacity 0.6s var(--ease-default, ease),
+	            transform 0.6s var(--ease-default, ease);
+}
+
+.blog-bell [data-reveal].is-visible {
+	opacity: 1;
+	transform: translateY(0);
+}
+
+/* ---------- Body lock when modal is open ---------- */
+
+body.blog-bell-modal-open {
+	overflow: hidden;
+}
+
+/* ---------- Responsive ---------- */
+
+@media (max-width: 720px) {
+	.blog-bell__bell {
+		bottom: 18px;
+		right: 18px;
+		padding: 12px 16px 12px 14px;
+	}
+
+	.blog-bell__bell-label {
+		display: none;
+	}
+
+	.blog-bell__filter-label {
+		display: none;
+	}
+
+	.blog-bell__hero {
+		padding-top: clamp(40px, 8vw, 64px);
+	}
+}
+
+/* ---------- Reduced motion ---------- */
 
 @media (prefers-reduced-motion: reduce) {
-    .blog-editorial-filter__link,
-    .blog-editorial-item__title a,
-    .blog-editorial-cta__link {
-        transition: none;
-    }
+	.blog-bell [data-reveal] {
+		opacity: 1;
+		transform: none;
+		transition: none;
+	}
+
+	.blog-bell__bell {
+		animation: none;
+	}
+
+	.blog-bell__eyebrow-dot {
+		animation: none;
+	}
+
+	.blog-bell__card,
+	.blog-bell__card-arrow,
+	.blog-bell__bottom-cta-link,
+	.blog-bell__modal-close,
+	.blog-bell__modal-panel,
+	.blog-bell__input,
+	.blog-bell__submit,
+	.blog-bell__chip {
+		transition: none;
+	}
 }

--- a/blocksy-child/assets/js/blog-archive.js
+++ b/blocksy-child/assets/js/blog-archive.js
@@ -1,0 +1,138 @@
+(function () {
+	'use strict';
+
+	var BODY_OPEN_CLASS = 'blog-bell-modal-open';
+	var FOCUSABLE = 'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+	function initRevealObserver() {
+		var nodes = document.querySelectorAll('.blog-bell [data-reveal]');
+		if (!nodes.length) {
+			return;
+		}
+
+		if (!('IntersectionObserver' in window)) {
+			nodes.forEach(function (node) { node.classList.add('is-visible'); });
+			return;
+		}
+
+		var observer = new IntersectionObserver(function (entries) {
+			entries.forEach(function (entry, index) {
+				if (!entry.isIntersecting) { return; }
+				var delay = Math.min(index * 60, 240);
+				window.setTimeout(function () {
+					entry.target.classList.add('is-visible');
+				}, delay);
+				observer.unobserve(entry.target);
+			});
+		}, { threshold: 0.08, rootMargin: '0px 0px -40px 0px' });
+
+		nodes.forEach(function (node) { observer.observe(node); });
+	}
+
+	function initBellModal() {
+		var trigger = document.getElementById('blog-bell-trigger');
+		var modal = document.getElementById('blog-bell-modal');
+		if (!trigger || !modal) { return; }
+
+		var panel = modal.querySelector('.blog-bell__modal-panel');
+		var dismissers = modal.querySelectorAll('[data-blog-bell-dismiss]');
+		var lastFocus = null;
+
+		function open() {
+			lastFocus = document.activeElement;
+			modal.hidden = false;
+			// next frame so the transition kicks in
+			window.requestAnimationFrame(function () {
+				modal.classList.add('is-open');
+			});
+			document.body.classList.add(BODY_OPEN_CLASS);
+			trigger.setAttribute('aria-expanded', 'true');
+
+			var firstField = modal.querySelector('input[type="email"]');
+			if (firstField) {
+				window.setTimeout(function () { firstField.focus(); }, 120);
+			} else if (panel) {
+				panel.focus();
+			}
+		}
+
+		function close() {
+			modal.classList.remove('is-open');
+			document.body.classList.remove(BODY_OPEN_CLASS);
+			trigger.setAttribute('aria-expanded', 'false');
+
+			// hide after the transition has finished
+			window.setTimeout(function () {
+				if (!modal.classList.contains('is-open')) {
+					modal.hidden = true;
+				}
+			}, 360);
+
+			if (lastFocus && typeof lastFocus.focus === 'function') {
+				lastFocus.focus();
+			}
+		}
+
+		trigger.addEventListener('click', function (event) {
+			event.preventDefault();
+			open();
+		});
+
+		dismissers.forEach(function (node) {
+			node.addEventListener('click', function (event) {
+				event.preventDefault();
+				close();
+			});
+		});
+
+		document.addEventListener('keydown', function (event) {
+			if (!modal.classList.contains('is-open')) { return; }
+
+			if (event.key === 'Escape') {
+				event.preventDefault();
+				close();
+				return;
+			}
+
+			if (event.key !== 'Tab') { return; }
+
+			var focusables = Array.prototype.slice.call(modal.querySelectorAll(FOCUSABLE))
+				.filter(function (node) { return node.offsetParent !== null; });
+			if (!focusables.length) { return; }
+
+			var first = focusables[0];
+			var last = focusables[focusables.length - 1];
+
+			if (event.shiftKey && document.activeElement === first) {
+				event.preventDefault();
+				last.focus();
+			} else if (!event.shiftKey && document.activeElement === last) {
+				event.preventDefault();
+				first.focus();
+			}
+		});
+
+		// Auto-close after a successful subscription (the shared blog-notify.js
+		// writes the message into [data-blog-notify-feedback].is-success).
+		var feedback = modal.querySelector('[data-blog-notify-feedback]');
+		if (feedback && 'MutationObserver' in window) {
+			var fbObserver = new MutationObserver(function () {
+				if (feedback.classList.contains('is-success')) {
+					window.setTimeout(close, 2600);
+				}
+			});
+			fbObserver.observe(feedback, { attributes: true, attributeFilter: ['class'] });
+		}
+	}
+
+	function init() {
+		initRevealObserver();
+		initBellModal();
+	}
+
+	if (document.readyState === 'loading') {
+		document.addEventListener('DOMContentLoaded', init);
+	} else {
+		init();
+	}
+})();

--- a/blocksy-child/home.php
+++ b/blocksy-child/home.php
@@ -1,6 +1,15 @@
 <?php
 /**
- * Minimal editorial blog archive template.
+ * Blog Archive — "Bell" architecture.
+ *
+ * Replaces the editorial cluster layout with a card-grid + sticky filter +
+ * floating newsletter bell modal. All content comes from the WP_Query loop —
+ * no hard-coded post titles, dates, or numbers.
+ *
+ * Re-uses:
+ *  - template-parts/site-header.php (global)
+ *  - template-parts/site-footer.php (global)
+ *  - inc/blog-notify.php REST endpoint (DOI subscription, NexusBlogNotifyConfig)
  *
  * @package Blocksy_Child
  */
@@ -12,262 +21,265 @@ if ( ! defined( 'ABSPATH' ) ) {
 $audit_url     = function_exists( 'nexus_get_audit_url' ) ? nexus_get_audit_url() : home_url( '/solar-waermepumpen-leadgenerierung/#marktcheck' );
 $posts_page_id = (int) get_option( 'page_for_posts' );
 $blog_url      = $posts_page_id ? get_permalink( $posts_page_id ) : home_url( '/blog/' );
-$categories    = get_categories(
+
+$blog_categories = get_categories(
 	[
-		'hide_empty' => false,
-		'orderby'    => 'name',
-		'order'      => 'ASC',
+		'hide_empty' => true,
+		'orderby'    => 'count',
+		'order'      => 'DESC',
+		'number'     => 8,
 	]
 );
 
-$blog_topic_clusters = [
-	'portal-kritik' => [
-		'title'          => 'Portal-Kritik & Markteinordnung',
-		'desc'           => 'Einordnungen zu Lead-Portalen, geteilten Anfragen, CPL-Logik und der Frage, wann ein eigener Anfrageweg wirtschaftlicher wird.',
-		'category_slugs' => [ 'markteinordnung', 'owned-leads', 'solar-waermepumpen-anfrage-systeme' ],
-		'keywords'       => [ 'portal', 'portale', 'portal-leads', 'leads kaufen', 'photovoltaik leads', 'aroundhome', 'wattfox', 'daa', 'leadfluss' ],
-	],
-	'cro'           => [
-		'title'          => 'CRO & Anfragepfad',
-		'desc'           => 'Beiträge zu Angebotslogik, Entscheidungsführung, Formular-Reibung und dem Weg von Traffic zu qualifizierter Anfrage.',
-		'category_slugs' => [ 'cro', 'strategie' ],
-		'keywords'       => [ 'cro', 'conversion', 'formular', 'funnel', 'lead-funnel', 'anfragepfad', 'qualifiziert', 'qualifizierte' ],
-	],
-	'tracking'      => [
-		'title'          => 'Tracking & Datenqualität',
-		'desc'           => 'GA4, Server-Side Tracking, Consent, Attribution und CRM-Rückführung als Grundlage für bessere Budgetentscheidungen.',
-		'category_slugs' => [ 'tracking', 'sichtbarkeit-daten-conversion' ],
-		'keywords'       => [ 'tracking', 'ga4', 'analytics', 'server-side', 'capi', 'consent', 'attribution', 'daten' ],
-	],
-	'performance'   => [
-		'title'          => 'Performance & WordPress-Fundament',
-		'desc'           => 'Technisches SEO, Core Web Vitals, WordPress-Struktur und Ladezeit als Fundament für Sichtbarkeit und Anfragequalität.',
-		'category_slugs' => [ 'wordpress-performance', 'seo', 'wordpress-growth-agentur' ],
-		'keywords'       => [ 'performance', 'core web vitals', 'cwv', 'wordpress', 'seo', 'ladezeit', 'pagespeed', 'sichtbarkeit' ],
-	],
-];
+$current_category_id = is_category() ? (int) get_queried_object_id() : 0;
 
-$blog_posts = [];
-global $wp_query;
-if ( isset( $wp_query->posts ) && is_array( $wp_query->posts ) ) {
-	$blog_posts = array_values(
-		array_filter(
-			$wp_query->posts,
-			static function ( $post ) {
-				return $post instanceof WP_Post && 'post' === $post->post_type;
-			}
-		)
-	);
-}
-
-$blog_posts_by_cluster = array_fill_keys( array_keys( $blog_topic_clusters ), [] );
-$resolve_blog_cluster  = static function ( WP_Post $post ) use ( $blog_topic_clusters ) {
-	$post_categories = get_the_category( $post->ID );
-	$category_slugs  = [];
-	$category_names  = [];
-
-	if ( ! empty( $post_categories ) && ! is_wp_error( $post_categories ) ) {
-		foreach ( $post_categories as $category ) {
-			$category_slugs[] = (string) $category->slug;
-			$category_names[] = (string) $category->name;
-		}
-	}
-
-	foreach ( $blog_topic_clusters as $cluster_key => $cluster ) {
-		if ( array_intersect( $category_slugs, $cluster['category_slugs'] ) ) {
-			return $cluster_key;
-		}
-	}
-
-	$haystack = strtolower(
-		remove_accents(
-			wp_strip_all_tags(
-				get_the_title( $post )
-				. ' '
-				. get_the_excerpt( $post )
-				. ' '
-				. implode( ' ', $category_slugs )
-				. ' '
-				. implode( ' ', $category_names )
-			)
-		)
-	);
-
-	foreach ( $blog_topic_clusters as $cluster_key => $cluster ) {
-		foreach ( $cluster['keywords'] as $keyword ) {
-			if ( false !== strpos( $haystack, strtolower( remove_accents( $keyword ) ) ) ) {
-				return $cluster_key;
-			}
-		}
-	}
-
-	return 'performance';
-};
-
-foreach ( $blog_posts as $blog_post ) {
-	$cluster_key = $resolve_blog_cluster( $blog_post );
-	if ( ! isset( $blog_posts_by_cluster[ $cluster_key ] ) ) {
-		$cluster_key = 'performance';
-	}
-	$blog_posts_by_cluster[ $cluster_key ][] = $blog_post;
-}
+$blog_form_nonce  = wp_create_nonce( 'nexus_blog_notify_subscribe' );
+$blog_notify_copy = function_exists( 'nexus_get_blog_notify_copy' ) ? nexus_get_blog_notify_copy() : [];
+$privacy_url      = function_exists( 'nexus_get_page_url' )
+	? nexus_get_page_url( [ 'datenschutz' ], home_url( '/datenschutz/' ) )
+	: home_url( '/datenschutz/' );
 
 get_header();
 ?>
 
-<section class="blog-home blog-editorial blog-editorial--index" aria-labelledby="blog-archive-heading">
-	<div class="blog-editorial__inner">
-		<header class="blog-editorial-hero" aria-labelledby="blog-archive-heading" data-track-section="blog_archive_hero">
-			<span class="blog-editorial-kicker">Blog & Markteinordnung</span>
-			<h1 id="blog-archive-heading" class="blog-editorial-hero__title">
+<main id="main" class="site-main blog-bell hu-hp" data-track-section="blog_archive">
+	<section class="blog-bell__hero" aria-labelledby="blog-archive-heading">
+		<div class="blog-bell__container">
+			<span class="blog-bell__eyebrow">
+				<span class="blog-bell__eyebrow-dot" aria-hidden="true"></span>
+				Blog
+			</span>
+			<h1 id="blog-archive-heading" class="blog-bell__title">
 				Analysen für eigene Anfrage-Systeme.
 			</h1>
-			<p class="blog-editorial-hero__lead">
-				Keine Magazinoptik. Keine Stockfoto-Sammlung. Hier stehen die Themen, die bei Solar-, SHK- und B2B-Websites über Sichtbarkeit, Lead-Qualität und Abschlusskosten entscheiden.
+			<p class="blog-bell__lead">
+				Portal-Abhängigkeit, Leadkosten, Tracking und Vorqualifizierung — für Solar-, Wärmepumpen- und Speicher-Anbieter im DACH-Raum, die eigene Nachfrage-Infrastruktur aufbauen wollen.
 			</p>
-		</header>
+		</div>
+	</section>
 
-		<nav class="blog-editorial-filter" aria-label="<?php esc_attr_e( 'Artikel nach Kategorie filtern', 'blocksy-child' ); ?>" data-track-section="blog_archive_filter">
-			<a
-				class="blog-editorial-filter__link is-active"
-				href="<?php echo esc_url( $blog_url ); ?>"
-				aria-current="page"
-				data-track-action="blog_filter_all"
-				data-track-category="navigation"
-				data-track-section="blog_archive_filter"
-			>
-				Alle
-			</a>
-			<?php foreach ( $categories as $category ) : ?>
-				<?php $category_url = get_category_link( $category->term_id ); ?>
-				<?php if ( is_wp_error( $category_url ) ) : ?>
-					<?php continue; ?>
-				<?php endif; ?>
+	<?php if ( ! empty( $blog_categories ) ) : ?>
+		<nav class="blog-bell__filter" aria-label="<?php esc_attr_e( 'Artikel nach Kategorie filtern', 'blocksy-child' ); ?>" data-track-section="blog_archive_filter">
+			<div class="blog-bell__filter-inner">
+				<span class="blog-bell__filter-label">Themen</span>
 				<a
-					class="blog-editorial-filter__link"
-					href="<?php echo esc_url( $category_url ); ?>"
-					data-track-action="<?php echo esc_attr( 'blog_filter_' . $category->slug ); ?>"
+					class="blog-bell__chip <?php echo $current_category_id ? '' : 'is-active'; ?>"
+					href="<?php echo esc_url( $blog_url ); ?>"
+					<?php echo $current_category_id ? '' : 'aria-current="page"'; ?>
+					data-track-action="blog_filter_all"
 					data-track-category="navigation"
-					data-track-section="blog_archive_filter"
 				>
-					<?php echo esc_html( $category->name ); ?>
+					Alle
 				</a>
-			<?php endforeach; ?>
-		</nav>
-
-		<section class="blog-editorial-clusters" aria-label="<?php esc_attr_e( 'Beiträge nach strategischen Themenclustern', 'blocksy-child' ); ?>" data-track-section="blog_archive_clusters">
-			<?php if ( ! empty( $blog_posts ) ) : ?>
-				<?php $rendered_posts = 0; ?>
-				<?php foreach ( $blog_topic_clusters as $cluster_key => $cluster ) : ?>
-					<?php if ( empty( $blog_posts_by_cluster[ $cluster_key ] ) ) : ?>
-						<?php continue; ?>
-					<?php endif; ?>
-					<section class="blog-topic-cluster" aria-labelledby="blog-cluster-<?php echo esc_attr( $cluster_key ); ?>" data-track-section="<?php echo esc_attr( 'blog_cluster_' . $cluster_key ); ?>">
-						<header class="blog-topic-cluster__head">
-							<h2 id="blog-cluster-<?php echo esc_attr( $cluster_key ); ?>" class="blog-topic-cluster__title">
-								<?php echo esc_html( $cluster['title'] ); ?>
-							</h2>
-							<p class="blog-topic-cluster__desc"><?php echo esc_html( $cluster['desc'] ); ?></p>
-						</header>
-
-						<div class="blog-editorial-list">
-							<?php foreach ( $blog_posts_by_cluster[ $cluster_key ] as $cluster_post ) : ?>
-								<?php
-								++$rendered_posts;
-
-								$cluster_post_id  = (int) $cluster_post->ID;
-								$post_categories  = get_the_category( $cluster_post_id );
-								$primary_category = ! empty( $post_categories ) && ! is_wp_error( $post_categories ) ? $post_categories[0] : null;
-								$reading_time     = function_exists( 'nexus_get_reading_time' ) ? (int) nexus_get_reading_time( $cluster_post_id ) : 0;
-								?>
-								<article class="blog-editorial-item">
-									<div class="blog-editorial-item__meta">
-										<?php if ( $primary_category instanceof WP_Term ) : ?>
-											<a class="blog-editorial-topic" href="<?php echo esc_url( get_category_link( $primary_category->term_id ) ); ?>">
-												<?php echo esc_html( $primary_category->name ); ?>
-											</a>
-										<?php endif; ?>
-										<time datetime="<?php echo esc_attr( get_the_date( 'c', $cluster_post_id ) ); ?>">
-											<?php echo esc_html( get_the_date( 'd. M Y', $cluster_post_id ) ); ?>
-										</time>
-										<?php if ( $reading_time > 0 ) : ?>
-											<span><?php echo esc_html( sprintf( '%d Min. Lesezeit', $reading_time ) ); ?></span>
-										<?php endif; ?>
-									</div>
-
-									<h3 class="blog-editorial-item__title">
-										<a href="<?php echo esc_url( get_permalink( $cluster_post_id ) ); ?>">
-											<?php echo esc_html( get_the_title( $cluster_post_id ) ); ?>
-										</a>
-									</h3>
-
-									<p class="blog-editorial-item__excerpt">
-										<?php echo esc_html( wp_trim_words( get_the_excerpt( $cluster_post_id ), 28, '...' ) ); ?>
-									</p>
-								</article>
-
-								<?php if ( 3 === $rendered_posts ) : ?>
-									<aside class="blog-editorial-inline-cta" aria-labelledby="blog-inline-cta-heading" data-track-section="blog_archive_inline_cta">
-										<span class="blog-editorial-kicker">60-Sekunden-Marktcheck</span>
-										<h3 id="blog-inline-cta-heading" class="blog-editorial-inline-cta__title">
-											Genug gelesen. Prüfen, ob der Markt überhaupt trägt.
-										</h3>
-										<p class="blog-editorial-inline-cta__text">
-											Projektwert, Zielgebiet, Vertriebsreife und Website-Fundament werden händisch eingeordnet. Ergebnis: klare nächste Priorität statt weiterer Artikel-Warteschleife.
-										</p>
-										<a
-											class="blog-editorial-inline-cta__link"
-											href="<?php echo esc_url( $audit_url ); ?>"
-											data-track-action="cta_blog_archive_inline_marktcheck"
-											data-track-category="lead_gen"
-											data-track-section="blog_archive_inline_cta"
-										>
-											Marktcheck starten
-										</a>
-									</aside>
-								<?php endif; ?>
-							<?php endforeach; ?>
-						</div>
-					</section>
+				<?php foreach ( $blog_categories as $category ) : ?>
+					<?php
+					$category_url = get_category_link( $category->term_id );
+					if ( is_wp_error( $category_url ) ) {
+						continue;
+					}
+					$is_active = $current_category_id === (int) $category->term_id;
+					?>
+					<a
+						class="blog-bell__chip <?php echo $is_active ? 'is-active' : ''; ?>"
+						href="<?php echo esc_url( $category_url ); ?>"
+						<?php echo $is_active ? 'aria-current="page"' : ''; ?>
+						data-track-action="<?php echo esc_attr( 'blog_filter_' . $category->slug ); ?>"
+						data-track-category="navigation"
+					>
+						<?php echo esc_html( $category->name ); ?>
+					</a>
 				<?php endforeach; ?>
+			</div>
+		</nav>
+	<?php endif; ?>
 
-				<div class="blog-editorial-pagination">
+	<section class="blog-bell__main" data-track-section="blog_archive_grid">
+		<div class="blog-bell__container">
+			<?php if ( have_posts() ) : ?>
+				<div class="blog-bell__grid">
+					<?php
+					$post_index = 0;
+					while ( have_posts() ) :
+						the_post();
+						$post_index++;
+
+						$post_id          = get_the_ID();
+						$post_categories  = get_the_category( $post_id );
+						$primary_category = ! empty( $post_categories ) && ! is_wp_error( $post_categories ) ? $post_categories[0] : null;
+						$reading_time     = function_exists( 'nexus_get_reading_time' ) ? (int) nexus_get_reading_time( $post_id ) : 0;
+						$excerpt          = wp_strip_all_tags( get_the_excerpt() );
+						$excerpt          = $excerpt ? wp_trim_words( $excerpt, 28, '…' ) : '';
+						$is_featured      = ( 1 === $post_index ) && ! is_paged() && ! $current_category_id;
+						$card_classes     = 'blog-bell__card' . ( $is_featured ? ' is-featured' : '' );
+						?>
+						<article
+							class="<?php echo esc_attr( $card_classes ); ?>"
+							data-reveal
+							<?php if ( $primary_category instanceof WP_Term ) : ?>
+								data-category="<?php echo esc_attr( $primary_category->slug ); ?>"
+							<?php endif; ?>
+						>
+							<a class="blog-bell__card-link" href="<?php the_permalink(); ?>" aria-labelledby="blog-bell-card-title-<?php echo esc_attr( (string) $post_id ); ?>">
+								<header class="blog-bell__card-meta">
+									<?php if ( $primary_category instanceof WP_Term ) : ?>
+										<span class="blog-bell__card-cat"><?php echo esc_html( $primary_category->name ); ?></span>
+									<?php endif; ?>
+									<time class="blog-bell__card-date" datetime="<?php echo esc_attr( get_the_date( 'c' ) ); ?>">
+										<?php echo esc_html( get_the_date( 'd. M Y' ) ); ?>
+									</time>
+								</header>
+
+								<h2 id="blog-bell-card-title-<?php echo esc_attr( (string) $post_id ); ?>" class="blog-bell__card-title">
+									<?php the_title(); ?>
+								</h2>
+
+								<?php if ( '' !== $excerpt ) : ?>
+									<p class="blog-bell__card-excerpt"><?php echo esc_html( $excerpt ); ?></p>
+								<?php endif; ?>
+
+								<footer class="blog-bell__card-footer">
+									<?php if ( $reading_time > 0 ) : ?>
+										<span class="blog-bell__card-readtime"><?php echo esc_html( sprintf( '%d Min.', $reading_time ) ); ?></span>
+									<?php else : ?>
+										<span class="blog-bell__card-readtime">Lesen</span>
+									<?php endif; ?>
+									<svg class="blog-bell__card-arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+										<path d="M5 12h14M13 6l6 6-6 6"></path>
+									</svg>
+								</footer>
+							</a>
+						</article>
+					<?php endwhile; ?>
+				</div>
+
+				<nav class="blog-bell__pagination" aria-label="<?php esc_attr_e( 'Seiten', 'blocksy-child' ); ?>">
 					<?php
 					the_posts_pagination(
 						[
 							'mid_size'  => 1,
-							'prev_text' => __( 'Zurück', 'blocksy-child' ),
-							'next_text' => __( 'Weiter', 'blocksy-child' ),
+							'prev_text' => esc_html__( 'Zurück', 'blocksy-child' ),
+							'next_text' => esc_html__( 'Weiter', 'blocksy-child' ),
 						]
 					);
 					?>
-				</div>
+				</nav>
 			<?php else : ?>
-				<p class="blog-editorial-empty">
+				<p class="blog-bell__empty">
 					<?php esc_html_e( 'Aktuell sind keine Beiträge veröffentlicht.', 'blocksy-child' ); ?>
 				</p>
 			<?php endif; ?>
-		</section>
 
-		<section class="blog-editorial-cta" aria-labelledby="blog-archive-cta-heading" data-track-section="blog_archive_final_cta">
-			<span class="blog-editorial-kicker">Nächster Schritt</span>
-			<h2 id="blog-archive-cta-heading" class="blog-editorial-cta__title">
-				Nicht mehr Inhalte lesen, bevor das System geprüft ist.
-			</h2>
-			<p class="blog-editorial-cta__text">
-				Der regionale Marktcheck prüft Projektwert, Zielgebiet, Vertriebsreife und Website-Fundament. Wer nicht passt, bekommt keine Verkaufsstrecke, sondern eine klare Absage.
-			</p>
-			<a
-				class="blog-editorial-cta__link"
-				href="<?php echo esc_url( $audit_url ); ?>"
-				data-track-action="cta_blog_archive_marktcheck"
-				data-track-category="lead_gen"
-				data-track-section="blog_archive_final_cta"
+			<aside class="blog-bell__bottom-cta" aria-labelledby="blog-bell-bottom-cta-heading" data-track-section="blog_archive_final_cta">
+				<span class="blog-bell__eyebrow">Nächster Schritt</span>
+				<h2 id="blog-bell-bottom-cta-heading" class="blog-bell__bottom-cta-title">
+					Nicht mehr Inhalte lesen, bevor das System geprüft ist.
+				</h2>
+				<p class="blog-bell__bottom-cta-text">
+					Der regionale Marktcheck prüft Projektwert, Zielgebiet, Vertriebsreife und Website-Fundament. Wer nicht passt, bekommt keine Verkaufsstrecke, sondern eine klare Absage.
+				</p>
+				<a
+					class="blog-bell__bottom-cta-link"
+					href="<?php echo esc_url( $audit_url ); ?>"
+					data-track-action="cta_blog_archive_marktcheck"
+					data-track-category="lead_gen"
+				>
+					Marktcheck 48 h starten
+					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+						<path d="M5 12h14M13 6l6 6-6 6"></path>
+					</svg>
+				</a>
+			</aside>
+		</div>
+	</section>
+</main>
+
+<button
+	class="blog-bell__bell"
+	type="button"
+	id="blog-bell-trigger"
+	aria-label="<?php esc_attr_e( 'Neue Artikel per E-Mail abonnieren', 'blocksy-child' ); ?>"
+	aria-haspopup="dialog"
+	aria-expanded="false"
+	aria-controls="blog-bell-modal"
+>
+	<svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+		<path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"></path>
+		<path d="M13.73 21a2 2 0 0 1-3.46 0"></path>
+	</svg>
+	<span class="blog-bell__bell-label">E-Mail-Updates</span>
+</button>
+
+<div
+	class="blog-bell__modal"
+	id="blog-bell-modal"
+	role="dialog"
+	aria-modal="true"
+	aria-labelledby="blog-bell-modal-title"
+	hidden
+>
+	<div class="blog-bell__modal-backdrop" data-blog-bell-dismiss></div>
+
+	<div class="blog-bell__modal-panel" role="document">
+		<button
+			class="blog-bell__modal-close"
+			type="button"
+			data-blog-bell-dismiss
+			aria-label="<?php esc_attr_e( 'Schließen', 'blocksy-child' ); ?>"
+		>
+			<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+				<path d="M18 6L6 18M6 6l12 12"></path>
+			</svg>
+		</button>
+
+		<span class="blog-bell__eyebrow">Blog-Benachrichtigungen</span>
+		<h2 id="blog-bell-modal-title" class="blog-bell__modal-title">
+			<?php echo esc_html( $blog_notify_copy['headline'] ?? 'Neue Artikel per E-Mail' ); ?>
+		</h2>
+		<p class="blog-bell__modal-body">
+			<?php echo esc_html( $blog_notify_copy['body'] ?? 'Ich schicke nur dann eine kurze Mail, wenn ein neuer Beitrag online ist. Kein Newsletter-Rauschen. Keine Sales-Mails.' ); ?>
+		</p>
+
+		<form class="blog-bell__form" data-blog-notify-form novalidate>
+			<div class="blog-bell__honeypot" aria-hidden="true">
+				<label for="blog-bell-website">Website</label>
+				<input id="blog-bell-website" type="text" name="website" tabindex="-1" autocomplete="off">
+			</div>
+
+			<input type="hidden" name="nonce" value="<?php echo esc_attr( $blog_form_nonce ); ?>">
+			<input type="hidden" name="contextPostId" value="0">
+
+			<label class="screen-reader-text" for="blog-bell-email"><?php esc_html_e( 'E-Mail-Adresse', 'blocksy-child' ); ?></label>
+			<input
+				id="blog-bell-email"
+				class="blog-bell__input"
+				type="email"
+				name="email"
+				placeholder="<?php echo esc_attr( $blog_notify_copy['placeholder'] ?? 'Ihre E-Mail-Adresse' ); ?>"
+				autocomplete="email"
+				required
 			>
-				Regionalen Marktcheck starten
-			</a>
-		</section>
+
+			<button type="submit" class="blog-bell__submit">
+				<?php echo esc_html( $blog_notify_copy['button'] ?? 'Artikel-Benachrichtigungen aktivieren' ); ?>
+				<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+					<path d="M5 12h14M13 6l6 6-6 6"></path>
+				</svg>
+			</button>
+
+			<ul class="blog-bell__trust">
+				<li>Nur neue Artikel</li>
+				<li>Keine Werbemails</li>
+				<li>Jederzeit abmelden</li>
+			</ul>
+
+			<p class="blog-bell__hint">
+				<?php esc_html_e( 'Double-Opt-In über E-Mail.', 'blocksy-child' ); ?>
+				<a href="<?php echo esc_url( $privacy_url ); ?>"><?php esc_html_e( 'Datenschutz', 'blocksy-child' ); ?></a>
+			</p>
+
+			<div class="blog-bell__feedback" data-blog-notify-feedback aria-live="polite"></div>
+		</form>
 	</div>
-</section>
+</div>
 
 <?php get_footer(); ?>

--- a/blocksy-child/inc/enqueue.php
+++ b/blocksy-child/inc/enqueue.php
@@ -138,6 +138,7 @@ function hu_enqueue_assets() {
 	// ── B) Blog-Archive Styles ────────────────────────────────────
 	if ( is_home() ) {
 		hu_enqueue_css( 'nexus-blog-archive-css', 'blog-archive.css', [ 'nexus-design-system' ] );
+		hu_enqueue_js( 'nexus-blog-archive-js', 'blog-archive.js', [ 'nexus-core-js' ] );
 	}
 
 	// ── C) Kategorie-Seiten (Pillar Hub) ──────────────────────────


### PR DESCRIPTION
Replaces the cluster-list layout in home.php with the design handed off in blog-final.html, adapted for production WordPress:

- Hero with animated eyebrow badge, gradient display title, balanced lead.
- Sticky filter pills (real category anchor links, SEO-safe, active state).
- Responsive card grid driven by the WP loop — first card on page 1 is rendered as a featured spanning card. No invented post data.
- Bottom-of-archive Marktcheck CTA aligned with the global audit URL.
- Floating "E-Mail-Updates" bell opens an accessible modal (focus trap, ESC, click-outside, aria-modal). Form reuses the existing data-blog-notify-form contract so inc/blog-notify.php + REST DOI flow power it without changes.
- New blog-archive.js owns the bell + reveal-on-scroll; conditionally enqueued via is_home(). CSS scoped under .blog-bell to keep category-hub.css / .blog-editorial-* intact.