### PR TITLE
Editorial single-post template: shell + reusable block classes + rating

### DIFF
--- a/blocksy-child/assets/css/single-editorial.css
+++ b/blocksy-child/assets/css/single-editorial.css
@@ -1,0 +1,1370 @@
+/* ============================================================
+   NEXUS Single Post — Editorial Layer
+   Adds the "Beitragseite Weltklasse" editorial shell on top of
+   the existing single.css base. Scope: .nexus-single-container
+   wrapped in .hu-hp so the homepage-redesign tokens (--hu-*)
+   apply without touching the global Nexus palette.
+
+   Author: Haşim Üner
+   ============================================================ */
+
+/* -------------------------------------------------------------
+   1. Local token bridge — map .hu-hp tokens onto the Nexus
+      container so existing single.css remains the visual base
+      while the editorial layer can rely on a stable accent.
+------------------------------------------------------------- */
+.nexus-single-container.hu-hp {
+    --hu-radius: 18px;
+    --hu-radius-sm: 12px;
+    --hu-shadow-card: 0 18px 48px hsl(30 25% 2% / 0.32);
+}
+
+/* -------------------------------------------------------------
+   2. Reading Progress Bar — fixed at the very top
+------------------------------------------------------------- */
+.nexus-reading-progress {
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 3px;
+    width: 0;
+    z-index: 1100;
+    background: linear-gradient(90deg, var(--hu-accent, #E08A3C) 0%, #F5A668 100%);
+    box-shadow: 0 0 12px hsl(var(--accent-hsl) / 0.55);
+    transition: width 100ms linear;
+    pointer-events: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .nexus-reading-progress {
+        transition: none;
+    }
+}
+
+/* -------------------------------------------------------------
+   3. Vertical Share Rail — sticky on the left while reading
+------------------------------------------------------------- */
+.nexus-share-rail {
+    position: fixed;
+    left: 24px;
+    top: 50%;
+    transform: translateY(-50%);
+    z-index: 60;
+    display: none;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    padding: 14px 10px;
+    border-radius: 9999px;
+    background: hsl(30 6% 6% / 0.72);
+    border: 1px solid var(--nx-border, #232A30);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.4s ease;
+}
+
+.nexus-share-rail.is-visible {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+@media (min-width: 1280px) {
+    .nexus-share-rail { display: flex; }
+}
+
+.nexus-share-rail__label {
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+    font-size: 9px;
+    font-weight: 600;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--hu-fg-4, #5C5A52);
+    writing-mode: vertical-rl;
+    transform: rotate(180deg);
+    padding-bottom: 6px;
+    margin-bottom: 4px;
+}
+
+.nexus-share-rail__btn {
+    width: 38px;
+    height: 38px;
+    border-radius: 50%;
+    border: 1px solid transparent;
+    background: transparent;
+    color: var(--hu-fg-2, #C8C0B0);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: background 0.2s, color 0.2s, transform 0.2s;
+    padding: 0;
+}
+
+.nexus-share-rail__btn:hover,
+.nexus-share-rail__btn:focus-visible {
+    background: hsl(var(--accent-hsl) / 0.14);
+    color: var(--hu-accent, #E08A3C);
+    transform: translateY(-1px);
+    outline: none;
+}
+
+.nexus-share-rail__btn svg {
+    width: 16px;
+    height: 16px;
+}
+
+/* -------------------------------------------------------------
+   4. Back-to-top button
+------------------------------------------------------------- */
+.nexus-back-to-top {
+    position: fixed;
+    bottom: 112px;
+    right: 24px;
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    background: hsl(30 6% 8% / 0.92);
+    border: 1px solid var(--nx-border, #232A30);
+    color: var(--hu-fg-2, #C8C0B0);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    z-index: 80;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s, background 0.2s, color 0.2s, transform 0.2s;
+}
+
+.nexus-back-to-top.is-visible {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.nexus-back-to-top:hover,
+.nexus-back-to-top:focus-visible {
+    background: hsl(var(--accent-hsl) / 0.16);
+    color: var(--hu-accent, #E08A3C);
+    transform: translateY(-2px);
+    outline: none;
+}
+
+.nexus-back-to-top svg {
+    width: 18px;
+    height: 18px;
+}
+
+@media (max-width: 768px) {
+    .nexus-back-to-top { bottom: 96px; right: 16px; }
+}
+
+/* -------------------------------------------------------------
+   5. Hero "ghost" decorative stat — opt-in via data attribute
+      on the hero. Renders the big number top-right behind text.
+------------------------------------------------------------- */
+.nexus-article-hero[data-hero-stat] {
+    position: relative;
+    overflow: hidden;
+}
+
+.nexus-article-hero[data-hero-stat]::before {
+    content: attr(data-hero-stat-label);
+    position: absolute;
+    top: 32px;
+    right: 32px;
+    font-family: var(--font-mono, monospace);
+    font-size: 10px;
+    font-weight: 500;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--hu-fg-3, #8A8478);
+    pointer-events: none;
+    z-index: 0;
+}
+
+.nexus-article-hero[data-hero-stat]::after {
+    content: attr(data-hero-stat);
+    position: absolute;
+    top: 48px;
+    right: 32px;
+    font-family: var(--font-display, 'Satoshi', sans-serif);
+    font-size: clamp(4rem, 8vw, 8rem);
+    font-weight: 800;
+    line-height: 0.9;
+    letter-spacing: -0.05em;
+    color: var(--hu-accent, #E08A3C);
+    opacity: 0.10;
+    pointer-events: none;
+    z-index: 0;
+}
+
+@media (max-width: 1100px) {
+    .nexus-article-hero[data-hero-stat]::before,
+    .nexus-article-hero[data-hero-stat]::after {
+        display: none;
+    }
+}
+
+/* -------------------------------------------------------------
+   6. Reveal-on-scroll
+------------------------------------------------------------- */
+.nexus-reveal {
+    opacity: 0;
+    transform: translateY(20px);
+    transition: opacity 0.7s cubic-bezier(0.16, 1, 0.3, 1),
+                transform 0.7s cubic-bezier(0.16, 1, 0.3, 1);
+    will-change: opacity, transform;
+}
+
+.nexus-reveal.is-in {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .nexus-reveal { opacity: 1; transform: none; transition: none; }
+}
+
+/* =============================================================
+   EDITOR BLOCK CLASSES — usable inside the_content()
+   ============================================================= */
+
+/* -------------------------------------------------------------
+   7. Lead paragraph + drop cap (.lead-para, .dropcap)
+      Set the first paragraph of an article visually apart.
+      Add both classes for max effect, or .dropcap alone.
+------------------------------------------------------------- */
+.nexus-article-content > p.lead-para {
+    font-size: clamp(1.18rem, 1.6vw, 1.35rem);
+    line-height: 1.55;
+    color: var(--nx-text);
+    font-weight: 500;
+    margin-bottom: 1.6rem;
+    text-wrap: pretty;
+}
+
+.nexus-article-content > p.dropcap::first-letter,
+.nexus-article-content > .dropcap::first-letter {
+    font-family: var(--font-display, 'Satoshi', sans-serif);
+    float: left;
+    font-size: 4.4rem;
+    line-height: 0.85;
+    font-weight: 800;
+    margin: 6px 14px 0 0;
+    color: var(--hu-accent, #E08A3C);
+    letter-spacing: -0.04em;
+}
+
+/* -------------------------------------------------------------
+   8. Section divider with big numbered prefix
+      Usage in editor (Custom HTML block):
+      <div class="section-divider">
+        <div class="section-divider-num">01</div>
+        <div class="section-divider-content">
+          <h2 id="...">Section title</h2>
+          <p class="section-divider-dek">Optional one-line dek.</p>
+        </div>
+      </div>
+------------------------------------------------------------- */
+.nexus-article-content .section-divider {
+    margin: 4.5rem 0 1.5rem;
+    padding-top: 2rem;
+    border-top: 1px solid var(--nx-border, #232A30);
+    display: grid;
+    grid-template-columns: 80px minmax(0, 1fr);
+    gap: 24px;
+    align-items: baseline;
+}
+
+.nexus-article-content .section-divider-num {
+    font-family: var(--font-display, 'Satoshi', sans-serif);
+    font-size: clamp(2.25rem, 4vw, 3.5rem);
+    font-weight: 800;
+    line-height: 1;
+    letter-spacing: -0.04em;
+    color: var(--hu-accent, #E08A3C);
+    opacity: 0.5;
+}
+
+.nexus-article-content .section-divider-content h2 {
+    margin: 0 !important;
+    padding: 0 !important;
+    border: none !important;
+}
+
+.nexus-article-content .section-divider-dek {
+    font-size: 1rem;
+    line-height: 1.5;
+    color: var(--hu-fg-3, #8A8478);
+    margin: 12px 0 0 !important;
+    max-width: 56ch;
+}
+
+@media (max-width: 768px) {
+    .nexus-article-content .section-divider {
+        grid-template-columns: 1fr;
+        gap: 8px;
+        margin: 3rem 0 1rem;
+    }
+    .nexus-article-content .section-divider-num { font-size: 2.25rem; }
+}
+
+/* -------------------------------------------------------------
+   9. Pull-quote — bigger, with decorative quote mark + attribution
+      Usage: <blockquote class="pull-quote">...
+        <span class="pull-quote-attr">Kapitel · Markt</span>
+      </blockquote>
+------------------------------------------------------------- */
+.nexus-article-content blockquote.pull-quote {
+    margin: 3rem 0;
+    padding: 2.25rem 2.5rem;
+    border-left: 3px solid var(--hu-accent, #E08A3C);
+    border-right: none;
+    border-top: none;
+    border-bottom: none;
+    border-radius: 0;
+    background: linear-gradient(90deg, hsl(var(--accent-hsl) / 0.08) 0%, transparent 100%);
+    font-family: var(--font-display, 'Satoshi', sans-serif);
+    font-size: clamp(1.3rem, 2.1vw, 1.65rem);
+    line-height: 1.4;
+    font-weight: 600;
+    color: var(--nx-text);
+    font-style: italic;
+    letter-spacing: -0.01em;
+    position: relative;
+    text-wrap: pretty;
+}
+
+.nexus-article-content blockquote.pull-quote::before {
+    content: "\201C";
+    position: absolute;
+    top: -8px;
+    left: 14px;
+    font-family: var(--font-display, 'Satoshi', sans-serif);
+    font-size: 6rem;
+    line-height: 1;
+    color: var(--hu-accent, #E08A3C);
+    opacity: 0.18;
+    pointer-events: none;
+}
+
+.nexus-article-content .pull-quote-attr {
+    display: block;
+    margin-top: 1rem;
+    font-family: var(--font-mono, monospace);
+    font-size: 11px;
+    font-weight: 500;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    color: var(--hu-fg-3, #8A8478);
+    font-style: normal;
+}
+
+.nexus-article-content .pull-quote-attr::before {
+    content: "— ";
+}
+
+@media (max-width: 768px) {
+    .nexus-article-content blockquote.pull-quote {
+        padding: 1.5rem 1.5rem;
+        font-size: 1.15rem;
+    }
+    .nexus-article-content blockquote.pull-quote::before {
+        font-size: 4rem;
+        left: 8px;
+        top: -6px;
+    }
+}
+
+/* -------------------------------------------------------------
+   10. Formula block — code-style framing for formulas / lists
+       Usage: <div class="formula-block">
+         <span class="comment"># comment</span>
+         <span class="accent">Formula</span> = ...
+       </div>
+       Inline color helpers: .accent (copper), .good, .bad,
+       .warn, .comment.
+------------------------------------------------------------- */
+.nexus-article-content .formula-block {
+    margin: 2rem 0;
+    padding: 1.5rem 1.75rem;
+    border: 1px solid var(--nx-border, #232A30);
+    border-radius: 12px;
+    background: hsl(30 6% 6%);
+    font-family: var(--font-mono, monospace);
+    font-size: 0.95rem;
+    line-height: 1.7;
+    color: var(--hu-fg, #F2EBDD);
+    white-space: pre-wrap;
+    overflow-x: auto;
+    text-shadow: none;
+}
+
+.nexus-article-content .formula-block .accent  { color: var(--hu-accent, #E08A3C); }
+.nexus-article-content .formula-block .good    { color: var(--hu-good, #6BA17A); }
+.nexus-article-content .formula-block .bad     { color: var(--hu-bad,  #C7705F); }
+.nexus-article-content .formula-block .warn    { color: var(--hu-warn, #D9B25A); }
+.nexus-article-content .formula-block .comment { color: var(--hu-fg-4, #5C5A52); }
+
+/* -------------------------------------------------------------
+   11. Stat row — 3-column big-number cards
+       Usage: <div class="stat-row">
+         <div class="stat-card">
+           <div class="stat-value">€ 1.500</div>
+           <div class="stat-label">...</div>
+         </div> ...
+       </div>
+------------------------------------------------------------- */
+.nexus-article-content .stat-row {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 16px;
+    margin: 2rem 0;
+}
+
+.nexus-article-content .stat-row .stat-card {
+    padding: 1.5rem;
+    border: 1px solid var(--nx-border, #232A30);
+    border-radius: 14px;
+    background: hsl(30 5% 8%);
+}
+
+.nexus-article-content .stat-row .stat-value {
+    font-family: var(--font-display, 'Satoshi', sans-serif);
+    font-size: clamp(1.8rem, 3vw, 2.5rem);
+    font-weight: 800;
+    letter-spacing: -0.03em;
+    line-height: 1;
+    color: var(--hu-accent, #E08A3C);
+    margin-bottom: 0.5rem;
+}
+
+.nexus-article-content .stat-row .stat-label {
+    font-size: 0.85rem;
+    color: var(--hu-fg-3, #8A8478);
+    line-height: 1.4;
+}
+
+.nexus-article-content .stat-row .stat-label strong {
+    color: var(--nx-text);
+}
+
+@media (max-width: 768px) {
+    .nexus-article-content .stat-row { grid-template-columns: 1fr; }
+}
+
+/* -------------------------------------------------------------
+   12. Callout box — Stopp / Hinweis with inline CTA
+       Usage: <div class="callout">
+         <div class="callout-label">Stopp · Bevor Sie weiterlesen</div>
+         <div class="callout-title">...</div>
+         <p class="callout-text">...</p>
+         <a href="..." class="callout-cta">Aktion</a>
+       </div>
+------------------------------------------------------------- */
+.nexus-article-content .callout {
+    margin: 3rem 0;
+    padding: 2rem;
+    border: 1px solid hsl(var(--accent-hsl) / 0.4);
+    border-radius: 16px;
+    background:
+        radial-gradient(ellipse 70% 100% at 0% 0%, hsl(var(--accent-hsl) / 0.12) 0%, transparent 60%),
+        hsl(30 5% 8%);
+    position: relative;
+}
+
+.nexus-article-content .callout-label {
+    font-family: var(--font-mono, monospace);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--hu-accent, #E08A3C);
+    margin-bottom: 0.75rem;
+}
+
+.nexus-article-content .callout-title {
+    font-family: var(--font-display, 'Satoshi', sans-serif);
+    font-size: clamp(1.25rem, 2.2vw, 1.5rem);
+    font-weight: 700;
+    color: var(--nx-text);
+    margin: 0 0 0.75rem;
+    line-height: 1.25;
+    letter-spacing: -0.01em;
+}
+
+.nexus-article-content .callout-text {
+    font-size: 1rem;
+    line-height: 1.6;
+    color: var(--hu-fg-2, #C8C0B0);
+    margin: 0 0 1.25rem !important;
+}
+
+.nexus-article-content .callout-cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 22px;
+    background: var(--hu-accent, #E08A3C);
+    color: #1A0F05 !important;
+    font-weight: 700;
+    font-size: 0.9rem;
+    text-decoration: none !important;
+    border-radius: 9999px;
+    transition: transform 0.2s, background 0.2s;
+}
+
+.nexus-article-content .callout-cta:hover,
+.nexus-article-content .callout-cta:focus-visible {
+    background: #F09A4C;
+    transform: translateY(-1px);
+}
+
+.nexus-article-content .callout-cta svg {
+    width: 14px;
+    height: 14px;
+}
+
+/* -------------------------------------------------------------
+   13. Comparison table — 3-column (Dimension | A | B)
+       Usage:
+       <div class="comparison">
+         <div class="comparison-row header"><div>...</div><div>...</div><div>...</div></div>
+         <div class="comparison-row"><div>...</div><div>...</div><div>...</div></div>
+       </div>
+------------------------------------------------------------- */
+.nexus-article-content .comparison {
+    margin: 3rem 0;
+    border-radius: 18px;
+    overflow: hidden;
+    border: 1px solid var(--nx-border, #232A30);
+}
+
+.nexus-article-content .comparison-row {
+    display: grid;
+    grid-template-columns: 1.4fr 1fr 1fr;
+    border-bottom: 1px solid var(--nx-border, #232A30);
+}
+
+.nexus-article-content .comparison-row:last-child { border-bottom: none; }
+
+.nexus-article-content .comparison-row.header {
+    background: hsl(30 5% 8%);
+}
+
+.nexus-article-content .comparison-row.header > div {
+    padding: 1.1rem 1.4rem;
+    font-family: var(--font-mono, monospace);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+}
+
+.nexus-article-content .comparison-row.header > div:nth-child(1) { color: var(--hu-fg-3, #8A8478); }
+.nexus-article-content .comparison-row.header > div:nth-child(2) {
+    color: var(--hu-bad, #C7705F);
+    border-left: 1px solid var(--nx-border, #232A30);
+}
+.nexus-article-content .comparison-row.header > div:nth-child(3) {
+    color: var(--hu-good, #6BA17A);
+    border-left: 1px solid var(--nx-border, #232A30);
+}
+
+.nexus-article-content .comparison-row > div {
+    padding: 1rem 1.4rem;
+    font-size: 0.95rem;
+    line-height: 1.5;
+    color: var(--hu-fg-2, #C8C0B0);
+}
+
+.nexus-article-content .comparison-row > div:nth-child(1) {
+    color: var(--nx-text);
+    font-weight: 500;
+    background: hsl(30 5% 7%);
+}
+
+.nexus-article-content .comparison-row > div:nth-child(2),
+.nexus-article-content .comparison-row > div:nth-child(3) {
+    border-left: 1px solid var(--nx-border, #232A30);
+}
+
+@media (max-width: 768px) {
+    .nexus-article-content .comparison-row { grid-template-columns: 1fr; }
+    .nexus-article-content .comparison-row > div { border-left: none !important; padding: 0.75rem 1.1rem; }
+    .nexus-article-content .comparison-row.header > div { padding: 0.75rem 1.1rem; }
+}
+
+/* -------------------------------------------------------------
+   14. Case study card
+       Usage: <div class="casestudy">
+         <div class="casestudy-header">
+           <div>
+             <div class="casestudy-label">Fallstudie</div>
+             <div class="casestudy-name">E3 New Energy</div>
+           </div>
+           <div class="casestudy-meta">9 Monate · ...</div>
+         </div>
+         <div class="casestudy-stats">
+           <div class="casestudy-stat">
+             <div class="casestudy-stat-num">71 %</div>
+             <div class="casestudy-stat-from">CPO-Reduktion</div>
+             <div class="casestudy-stat-label">€ 5.000 → € 1.450</div>
+           </div> ...
+         </div>
+         <blockquote class="casestudy-quote">...</blockquote>
+       </div>
+------------------------------------------------------------- */
+.nexus-article-content .casestudy {
+    margin: 3rem 0;
+    padding: 2.5rem;
+    border-radius: 24px;
+    background:
+        radial-gradient(ellipse 60% 80% at 100% 0%, hsl(var(--accent-hsl) / 0.1) 0%, transparent 60%),
+        hsl(30 5% 8%);
+    border: 1px solid var(--nx-border, #232A30);
+    position: relative;
+    overflow: hidden;
+}
+
+.nexus-article-content .casestudy-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 32px;
+    margin-bottom: 2rem;
+}
+
+.nexus-article-content .casestudy-label {
+    font-family: var(--font-mono, monospace);
+    font-size: 11px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--hu-accent, #E08A3C);
+    margin-bottom: 0.5rem;
+}
+
+.nexus-article-content .casestudy-name {
+    font-family: var(--font-display, 'Satoshi', sans-serif);
+    font-size: clamp(1.5rem, 2.6vw, 2rem);
+    font-weight: 800;
+    letter-spacing: -0.025em;
+    color: var(--nx-text);
+    line-height: 1.05;
+}
+
+.nexus-article-content .casestudy-meta {
+    font-family: var(--font-mono, monospace);
+    font-size: 0.75rem;
+    color: var(--hu-fg-3, #8A8478);
+    letter-spacing: 0.05em;
+    text-align: right;
+    line-height: 1.5;
+}
+
+.nexus-article-content .casestudy-stats {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 24px;
+    margin-bottom: 2rem;
+    padding-top: 2rem;
+    border-top: 1px solid var(--nx-border, #232A30);
+}
+
+.nexus-article-content .casestudy-stat {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.nexus-article-content .casestudy-stat-num {
+    font-family: var(--font-display, 'Satoshi', sans-serif);
+    font-size: clamp(1.8rem, 3.2vw, 2.5rem);
+    font-weight: 800;
+    letter-spacing: -0.04em;
+    line-height: 1;
+    color: var(--hu-accent, #E08A3C);
+}
+
+.nexus-article-content .casestudy-stat-from {
+    font-family: var(--font-mono, monospace);
+    font-size: 11px;
+    color: var(--hu-fg-3, #8A8478);
+    letter-spacing: 0.05em;
+}
+
+.nexus-article-content .casestudy-stat-label {
+    font-size: 0.8rem;
+    color: var(--hu-fg-3, #8A8478);
+    line-height: 1.4;
+}
+
+.nexus-article-content blockquote.casestudy-quote {
+    font-family: var(--font-display, 'Satoshi', sans-serif);
+    font-size: clamp(1.1rem, 1.9vw, 1.35rem);
+    line-height: 1.45;
+    font-weight: 500;
+    color: var(--nx-text);
+    font-style: italic;
+    letter-spacing: -0.01em;
+    padding-left: 1.5rem;
+    border-left: 2px solid var(--hu-accent, #E08A3C);
+    border-right: none;
+    border-top: none;
+    border-bottom: none;
+    background: transparent;
+    border-radius: 0;
+    margin: 0;
+}
+
+@media (max-width: 768px) {
+    .nexus-article-content .casestudy { padding: 1.5rem; }
+    .nexus-article-content .casestudy-header { flex-direction: column; gap: 12px; }
+    .nexus-article-content .casestudy-meta { text-align: left; }
+    .nexus-article-content .casestudy-stats { grid-template-columns: 1fr; gap: 20px; }
+}
+
+/* -------------------------------------------------------------
+   15. Highlight marker — yellow/copper "marker" on key phrase
+       Usage: <span class="highlight">key sentence</span>
+------------------------------------------------------------- */
+.nexus-article-content .highlight {
+    background: linear-gradient(180deg, transparent 60%, hsl(var(--accent-hsl) / 0.28) 60%);
+    padding: 0 3px;
+    color: var(--nx-text);
+}
+
+/* -------------------------------------------------------------
+   16. FAQ Accordion
+       Usage: <section class="nexus-faq">
+         <ul class="faq-list">
+           <li class="faq-item">
+             <button class="faq-question" type="button">
+               Question? <span class="faq-toggle"></span>
+             </button>
+             <div class="faq-answer"><div class="faq-answer-inner">Answer.</div></div>
+           </li> ...
+         </ul>
+       </section>
+
+       Behaviour added by single-editorial.js: clicking toggles
+       `.is-open` on the .faq-item. CSS opens the answer + rotates
+       the +/- icon.
+------------------------------------------------------------- */
+.nexus-article-content .nexus-faq {
+    margin: 4rem 0 2rem;
+}
+
+.nexus-article-content .faq-list {
+    list-style: none !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    border-top: 1px solid var(--nx-border, #232A30);
+    display: flex;
+    flex-direction: column;
+}
+
+.nexus-article-content .faq-list > li {
+    margin: 0 !important;
+}
+
+.nexus-article-content .faq-item {
+    border-bottom: 1px solid var(--nx-border, #232A30);
+    list-style: none;
+}
+
+.nexus-article-content .faq-question {
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 24px;
+    padding: 1.4rem 0;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    font-family: var(--font-display, 'Satoshi', sans-serif);
+    font-size: clamp(1.05rem, 1.8vw, 1.2rem);
+    font-weight: 600;
+    line-height: 1.3;
+    color: var(--nx-text);
+    text-align: left;
+    letter-spacing: -0.01em;
+    transition: color 0.2s;
+}
+
+.nexus-article-content .faq-question:hover,
+.nexus-article-content .faq-question:focus-visible {
+    color: var(--hu-accent, #E08A3C);
+    outline: none;
+}
+
+.nexus-article-content .faq-toggle {
+    width: 34px;
+    height: 34px;
+    border-radius: 50%;
+    border: 1px solid var(--nx-border, #232A30);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    position: relative;
+    transition: border-color 0.3s, background 0.3s, color 0.3s;
+    color: var(--hu-fg-3, #8A8478);
+}
+
+.nexus-article-content .faq-question:hover .faq-toggle {
+    border-color: var(--hu-accent, #E08A3C);
+    background: hsl(var(--accent-hsl) / 0.12);
+}
+
+.nexus-article-content .faq-toggle::before,
+.nexus-article-content .faq-toggle::after {
+    content: "";
+    position: absolute;
+    background: currentColor;
+    border-radius: 1px;
+}
+
+.nexus-article-content .faq-toggle::before {
+    width: 12px;
+    height: 1.5px;
+}
+
+.nexus-article-content .faq-toggle::after {
+    width: 1.5px;
+    height: 12px;
+    transition: transform 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.nexus-article-content .faq-item.is-open .faq-toggle::after {
+    transform: rotate(90deg);
+}
+
+.nexus-article-content .faq-item.is-open .faq-toggle {
+    border-color: var(--hu-accent, #E08A3C);
+    color: var(--hu-accent, #E08A3C);
+}
+
+.nexus-article-content .faq-answer {
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.nexus-article-content .faq-item.is-open .faq-answer {
+    max-height: 1200px;
+}
+
+.nexus-article-content .faq-answer-inner {
+    padding: 0 0 1.6rem;
+    font-size: 1rem;
+    line-height: 1.65;
+    color: var(--hu-fg-2, #C8C0B0);
+    max-width: 64ch;
+}
+
+.nexus-article-content .faq-answer-inner p:first-child { margin-top: 0; }
+.nexus-article-content .faq-answer-inner p:last-child  { margin-bottom: 0; }
+
+/* -------------------------------------------------------------
+   17. Cover schematic (optional editor block)
+       Renders a "Modell A vs Modell B" flow diagram. Drop into
+       the_content() right after the lead paragraph or before
+       the first H2 to give the article an interactive opener.
+
+       Usage:
+       <div class="cover-schematic">
+         <div class="cover-grid">
+           <div class="cover-pane bad">
+             <div class="cover-pane-label">Modell A</div>
+             <div class="cover-pane-title">...</div>
+             <div class="cover-nodes">
+               <div class="cover-node"><span class="dot"></span>Node<span class="cover-node-meta">meta</span></div>
+             </div>
+             <div class="cover-cpo">
+               <div class="cover-cpo-label">Cost per Order</div>
+               <div class="cover-cpo-value">€ 2.500</div>
+             </div>
+           </div>
+           <div class="cover-divider">
+             <div class="cover-divider-line"></div>
+             <div class="cover-divider-vs">VS</div>
+             <div class="cover-divider-line"></div>
+           </div>
+           <div class="cover-pane good"> ... </div>
+         </div>
+       </div>
+------------------------------------------------------------- */
+.nexus-article-content .cover-schematic {
+    width: 100%;
+    aspect-ratio: 16 / 8;
+    margin: 1.5rem 0 2.5rem;
+    border-radius: 18px;
+    background:
+        radial-gradient(ellipse 60% 100% at 25% 50%, hsl(15 35% 50% / 0.06) 0%, transparent 60%),
+        radial-gradient(ellipse 60% 100% at 75% 50%, hsl(140 25% 45% / 0.06) 0%, transparent 60%),
+        linear-gradient(180deg, #11161A 0%, #0d1114 100%);
+    border: 1px solid var(--nx-border, #232A30);
+    position: relative;
+    overflow: hidden;
+    padding: 2.5rem;
+}
+
+.nexus-article-content .cover-schematic::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background-image: radial-gradient(circle at 1px 1px, hsl(0 0% 100% / 0.04) 1px, transparent 0);
+    background-size: 32px 32px;
+    pointer-events: none;
+}
+
+.nexus-article-content .cover-grid {
+    position: relative;
+    z-index: 1;
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    gap: 32px;
+    height: 100%;
+    align-items: stretch;
+}
+
+.nexus-article-content .cover-pane {
+    display: flex;
+    flex-direction: column;
+}
+
+.nexus-article-content .cover-pane-label {
+    font-family: var(--font-mono, monospace);
+    font-size: 10px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    margin-bottom: 12px;
+}
+
+.nexus-article-content .cover-pane.bad  .cover-pane-label { color: var(--hu-bad,  #C7705F); }
+.nexus-article-content .cover-pane.good .cover-pane-label { color: var(--hu-good, #6BA17A); }
+
+.nexus-article-content .cover-pane-title {
+    font-family: var(--font-display, 'Satoshi', sans-serif);
+    font-size: 1.05rem;
+    font-weight: 700;
+    color: var(--nx-text);
+    margin-bottom: 1rem;
+    letter-spacing: -0.01em;
+    line-height: 1.25;
+}
+
+.nexus-article-content .cover-nodes {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.nexus-article-content .cover-node {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 12px;
+    background: hsl(30 6% 5% / 0.65);
+    border: 1px solid var(--nx-border, #232A30);
+    border-radius: 8px;
+    font-family: var(--font-mono, monospace);
+    font-size: 11px;
+    color: var(--hu-fg-2, #C8C0B0);
+    letter-spacing: 0.04em;
+}
+
+.nexus-article-content .cover-node .dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.nexus-article-content .cover-pane.bad  .cover-node .dot { background: var(--hu-bad, #C7705F); }
+.nexus-article-content .cover-pane.good .cover-node .dot { background: var(--hu-good, #6BA17A); box-shadow: 0 0 6px hsl(140 25% 45% / 0.5); }
+
+.nexus-article-content .cover-node-meta {
+    margin-left: auto;
+    color: var(--hu-fg-4, #5C5A52);
+    font-size: 10px;
+}
+
+.nexus-article-content .cover-divider {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 16px;
+}
+
+.nexus-article-content .cover-divider-line {
+    width: 1px;
+    flex: 1;
+    background: linear-gradient(180deg, transparent, var(--nx-border, #232A30) 30%, var(--nx-border, #232A30) 70%, transparent);
+}
+
+.nexus-article-content .cover-divider-vs {
+    font-family: var(--font-display, 'Satoshi', sans-serif);
+    font-size: 1.5rem;
+    font-weight: 800;
+    letter-spacing: -0.02em;
+    color: var(--hu-fg-3, #8A8478);
+    background: hsl(30 5% 8%);
+    padding: 6px 14px;
+    border-radius: 9999px;
+    border: 1px solid var(--nx-border, #232A30);
+}
+
+.nexus-article-content .cover-cpo {
+    margin-top: auto;
+    padding-top: 1rem;
+    border-top: 1px dashed var(--nx-border, #232A30);
+}
+
+.nexus-article-content .cover-cpo-label {
+    font-family: var(--font-mono, monospace);
+    font-size: 9px;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--hu-fg-4, #5C5A52);
+    margin-bottom: 4px;
+}
+
+.nexus-article-content .cover-cpo-value {
+    font-family: var(--font-display, 'Satoshi', sans-serif);
+    font-size: 1.65rem;
+    font-weight: 800;
+    letter-spacing: -0.02em;
+    line-height: 1;
+}
+
+.nexus-article-content .cover-pane.bad  .cover-cpo-value { color: var(--hu-bad,  #C7705F); }
+.nexus-article-content .cover-pane.good .cover-cpo-value { color: var(--hu-good, #6BA17A); }
+
+@media (max-width: 768px) {
+    .nexus-article-content .cover-schematic { padding: 1.25rem; aspect-ratio: 4/5; }
+    .nexus-article-content .cover-grid { grid-template-columns: 1fr; gap: 16px; }
+    .nexus-article-content .cover-divider { flex-direction: row; }
+    .nexus-article-content .cover-divider-line { width: 100%; height: 1px; flex: 0 0 1px; min-height: 1px; }
+}
+
+/* =============================================================
+   END EDITOR BLOCK CLASSES — start template-driven sections
+   ============================================================= */
+
+/* -------------------------------------------------------------
+   18. Rating widget — Hilfreich / Nicht hilfreich
+------------------------------------------------------------- */
+.nexus-rating {
+    margin: 4rem 0 2rem;
+    padding: 2.75rem 2rem;
+    background:
+        radial-gradient(ellipse 80% 60% at 50% 0%, hsl(var(--accent-hsl) / 0.06) 0%, transparent 60%),
+        var(--nx-card-gradient, hsl(30 5% 8%));
+    border: 1px solid var(--nx-border, #232A30);
+    border-radius: 20px;
+    text-align: center;
+    max-width: 820px;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.nexus-rating__label {
+    font-family: var(--font-mono, monospace);
+    font-size: 11px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--hu-accent, #E08A3C);
+    margin-bottom: 0.75rem;
+}
+
+.nexus-rating__title {
+    font-family: var(--font-display, 'Satoshi', sans-serif);
+    font-size: clamp(1.4rem, 2.4vw, 1.75rem);
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    color: var(--nx-text);
+    margin: 0 0 0.5rem;
+    line-height: 1.2;
+}
+
+.nexus-rating__sub {
+    font-size: 0.95rem;
+    color: var(--hu-fg-3, #8A8478);
+    margin: 0 0 1.75rem;
+}
+
+.nexus-rating__buttons {
+    display: flex;
+    gap: 16px;
+    justify-content: center;
+    flex-wrap: wrap;
+}
+
+.nexus-rating__btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px 24px;
+    border-radius: 9999px;
+    border: 1px solid var(--nx-border, #232A30);
+    background: hsl(30 6% 5%);
+    color: var(--hu-fg-2, #C8C0B0);
+    font-size: 0.95rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: border-color 0.2s, background 0.2s, color 0.2s, transform 0.2s;
+    font-family: var(--font-body, 'Figtree', sans-serif);
+}
+
+.nexus-rating__btn:hover,
+.nexus-rating__btn:focus-visible {
+    border-color: var(--hu-accent, #E08A3C);
+    background: hsl(var(--accent-hsl) / 0.1);
+    color: var(--nx-text);
+    transform: translateY(-1px);
+    outline: none;
+}
+
+.nexus-rating__btn.is-selected {
+    border-color: var(--hu-accent, #E08A3C);
+    background: var(--hu-accent, #E08A3C);
+    color: #1A0F05;
+}
+
+.nexus-rating__btn svg {
+    width: 18px;
+    height: 18px;
+}
+
+.nexus-rating__feedback {
+    display: none;
+    margin: 1.75rem auto 0;
+    text-align: left;
+    max-width: 480px;
+}
+
+.nexus-rating__feedback.is-shown { display: block; }
+
+.nexus-rating__feedback textarea {
+    width: 100%;
+    padding: 14px 16px;
+    border: 1px solid var(--nx-border, #232A30);
+    border-radius: 12px;
+    background: hsl(30 6% 5%);
+    color: var(--nx-text);
+    font-size: 0.95rem;
+    font-family: var(--font-body, 'Figtree', sans-serif);
+    resize: vertical;
+    min-height: 96px;
+    margin-bottom: 12px;
+    line-height: 1.5;
+}
+
+.nexus-rating__feedback textarea:focus {
+    outline: none;
+    border-color: var(--hu-accent, #E08A3C);
+    box-shadow: 0 0 0 3px hsl(var(--accent-hsl) / 0.2);
+}
+
+.nexus-rating__feedback-actions {
+    display: flex;
+    gap: 12px;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+}
+
+.nexus-rating__skip {
+    padding: 10px 20px;
+    border-radius: 9999px;
+    border: 1px solid var(--nx-border, #232A30);
+    background: transparent;
+    color: var(--hu-fg-2, #C8C0B0);
+    font-size: 0.85rem;
+    font-weight: 500;
+    cursor: pointer;
+    font-family: var(--font-body, 'Figtree', sans-serif);
+    transition: border-color 0.2s, color 0.2s;
+}
+
+.nexus-rating__skip:hover {
+    border-color: var(--hu-fg-3, #8A8478);
+    color: var(--nx-text);
+}
+
+.nexus-rating__submit {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 22px;
+    border-radius: 9999px;
+    border: none;
+    background: linear-gradient(135deg, var(--hu-accent, #E08A3C) 0%, #F5A668 100%);
+    color: #1A0F05;
+    font-size: 0.9rem;
+    font-weight: 700;
+    cursor: pointer;
+    font-family: var(--font-body, 'Figtree', sans-serif);
+    transition: transform 0.2s, box-shadow 0.2s;
+    box-shadow: 0 6px 16px hsl(var(--accent-hsl) / 0.28);
+}
+
+.nexus-rating__submit:hover,
+.nexus-rating__submit:focus-visible {
+    transform: translateY(-1px);
+    box-shadow: 0 10px 24px hsl(var(--accent-hsl) / 0.4);
+    outline: none;
+}
+
+.nexus-rating__submit svg { width: 14px; height: 14px; }
+
+.nexus-rating__thanks {
+    display: none;
+    margin-top: 1.25rem;
+    font-size: 0.95rem;
+    color: var(--hu-good, #6BA17A);
+    font-weight: 500;
+}
+
+.nexus-rating__thanks.is-shown { display: block; }
+
+.nexus-rating__error {
+    display: none;
+    margin-top: 1rem;
+    font-size: 0.9rem;
+    color: var(--hu-bad, #C7705F);
+}
+
+.nexus-rating__error.is-shown { display: block; }
+
+/* -------------------------------------------------------------
+   19. Author bio card
+------------------------------------------------------------- */
+.nexus-author-bio {
+    margin: 3rem auto 4rem;
+    padding: 2.5rem;
+    border-radius: 20px;
+    background: var(--nx-card-gradient, hsl(30 5% 8%));
+    border: 1px solid var(--nx-border, #232A30);
+    display: grid;
+    grid-template-columns: 96px minmax(0, 1fr);
+    gap: 32px;
+    align-items: start;
+    max-width: 820px;
+}
+
+.nexus-author-bio__avatar {
+    width: 96px;
+    height: 96px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, var(--hu-accent, #E08A3C) 0%, var(--hu-accent-2, #C0701F) 100%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #1A0F05;
+    font-family: var(--font-display, 'Satoshi', sans-serif);
+    font-size: 36px;
+    font-weight: 800;
+    letter-spacing: -0.02em;
+    flex-shrink: 0;
+    overflow: hidden;
+}
+
+.nexus-author-bio__avatar img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 50%;
+}
+
+.nexus-author-bio__label {
+    font-family: var(--font-mono, monospace);
+    font-size: 10px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--hu-fg-3, #8A8478);
+    margin-bottom: 8px;
+    display: block;
+}
+
+.nexus-author-bio__name {
+    font-family: var(--font-display, 'Satoshi', sans-serif);
+    font-size: 1.5rem;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    color: var(--nx-text);
+    margin: 0 0 4px;
+    line-height: 1.2;
+}
+
+.nexus-author-bio__role {
+    font-size: 0.9rem;
+    color: var(--hu-fg-3, #8A8478);
+    margin: 0 0 1rem;
+}
+
+.nexus-author-bio__text {
+    font-size: 0.95rem;
+    line-height: 1.6;
+    color: var(--hu-fg-2, #C8C0B0);
+    margin: 0 0 1.25rem;
+    max-width: 56ch;
+}
+
+.nexus-author-bio__links {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.nexus-author-bio__link {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 16px;
+    border: 1px solid var(--nx-border, #232A30);
+    border-radius: 9999px;
+    font-size: 0.82rem;
+    font-weight: 500;
+    color: var(--hu-fg-2, #C8C0B0);
+    text-decoration: none;
+    transition: border-color 0.2s, color 0.2s, background 0.2s;
+}
+
+.nexus-author-bio__link:hover,
+.nexus-author-bio__link:focus-visible {
+    border-color: var(--hu-accent, #E08A3C);
+    color: var(--hu-accent, #E08A3C);
+    background: hsl(var(--accent-hsl) / 0.1);
+    outline: none;
+}
+
+.nexus-author-bio__link svg { width: 14px; height: 14px; }
+
+@media (max-width: 768px) {
+    .nexus-author-bio {
+        grid-template-columns: 1fr;
+        gap: 20px;
+        padding: 1.75rem;
+    }
+    .nexus-author-bio__avatar { width: 72px; height: 72px; font-size: 28px; }
+}
+
+/* -------------------------------------------------------------
+   20. Polish: nicer headings + scroll margin inside the article
+       so #fragment links land below the fixed progress bar.
+------------------------------------------------------------- */
+.nexus-article-content h2,
+.nexus-article-content h3 {
+    scroll-margin-top: 96px;
+}
+
+/* Improve list bullets in editor lists when not in a special block */
+.nexus-article-content > ul:not(.faq-list) > li::marker {
+    color: var(--hu-accent, #E08A3C);
+}

--- a/blocksy-child/assets/js/single-editorial.js
+++ b/blocksy-child/assets/js/single-editorial.js
@@ -1,0 +1,318 @@
+/* ============================================================
+   NEXUS Single Post — Editorial Behaviours
+   Reading progress, sticky share rail, back-to-top, FAQ accordion,
+   scroll reveal observer and rating widget (REST → post meta).
+
+   Config injected via wp_localize_script:
+     window.NexusSingleEditorial = {
+       restEndpoint: '/wp-json/nexus/v1/post-rating',
+       nonce:        '...',
+       postId:       42,
+       successMsg:   'Danke...',
+       errorMsg:     'Das hat nicht geklappt...',
+       shareUrl:     'https://...',
+       shareTitle:   'Title'
+     };
+   ============================================================ */
+(function () {
+    'use strict';
+
+    if (typeof document === 'undefined') return;
+
+    var config = window.NexusSingleEditorial || {};
+
+    document.addEventListener('DOMContentLoaded', function () {
+        initProgressBar();
+        initShareRail();
+        initBackToTop();
+        initFAQ();
+        initReveal();
+        initRating();
+        initShareButtons();
+    });
+
+    /* ----------------------------------------------------------
+       Reading progress bar
+       ---------------------------------------------------------- */
+    function initProgressBar() {
+        var bar = document.querySelector('.nexus-reading-progress');
+        var article = document.querySelector('.nexus-article-content');
+        if (!bar || !article) return;
+
+        var ticking = false;
+        function update() {
+            var rect = article.getBoundingClientRect();
+            var top = rect.top + window.scrollY;
+            var height = rect.height || 1;
+            var scrolled = window.scrollY - top + window.innerHeight;
+            var progress = Math.max(0, Math.min(100, (scrolled / height) * 100));
+            bar.style.width = progress + '%';
+            ticking = false;
+        }
+        function onScroll() {
+            if (!ticking) {
+                window.requestAnimationFrame(update);
+                ticking = true;
+            }
+        }
+        window.addEventListener('scroll', onScroll, { passive: true });
+        window.addEventListener('resize', onScroll);
+        update();
+    }
+
+    /* ----------------------------------------------------------
+       Sticky share rail visibility
+       ---------------------------------------------------------- */
+    function initShareRail() {
+        var rail = document.querySelector('.nexus-share-rail');
+        if (!rail) return;
+
+        var hero = document.querySelector('.nexus-article-hero');
+        var endMarker = document.querySelector('.nexus-author-bio') ||
+                        document.querySelector('.nexus-related-content') ||
+                        document.querySelector('.nexus-rating');
+
+        function update() {
+            var y = window.scrollY;
+            var heroBottom = hero ? hero.offsetTop + hero.offsetHeight : 600;
+            var footerTop = endMarker ? endMarker.offsetTop : Number.MAX_SAFE_INTEGER;
+            if (y > heroBottom - 200 && y < footerTop - 200) {
+                rail.classList.add('is-visible');
+            } else {
+                rail.classList.remove('is-visible');
+            }
+        }
+        window.addEventListener('scroll', update, { passive: true });
+        window.addEventListener('resize', update);
+        update();
+    }
+
+    /* ----------------------------------------------------------
+       Back to top button
+       ---------------------------------------------------------- */
+    function initBackToTop() {
+        var btn = document.querySelector('.nexus-back-to-top');
+        if (!btn) return;
+
+        function update() {
+            if (window.scrollY > 600) {
+                btn.classList.add('is-visible');
+            } else {
+                btn.classList.remove('is-visible');
+            }
+        }
+        window.addEventListener('scroll', update, { passive: true });
+        update();
+
+        btn.addEventListener('click', function () {
+            window.scrollTo({ top: 0, behavior: 'smooth' });
+        });
+    }
+
+    /* ----------------------------------------------------------
+       FAQ accordion (delegated, works for content typed by editor)
+       ---------------------------------------------------------- */
+    function initFAQ() {
+        document.addEventListener('click', function (event) {
+            var question = event.target.closest('.faq-question');
+            if (!question) return;
+            var item = question.closest('.faq-item');
+            if (!item) return;
+            event.preventDefault();
+            var isOpen = item.classList.toggle('is-open');
+            question.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+        });
+
+        // Initialise ARIA + IDs so screen readers can use the accordion.
+        document.querySelectorAll('.faq-item').forEach(function (item, index) {
+            var question = item.querySelector('.faq-question');
+            var answer = item.querySelector('.faq-answer');
+            if (!question || !answer) return;
+            if (!answer.id) answer.id = 'nexus-faq-answer-' + index;
+            question.setAttribute('aria-expanded', 'false');
+            question.setAttribute('aria-controls', answer.id);
+            question.setAttribute('type', 'button');
+        });
+    }
+
+    /* ----------------------------------------------------------
+       Scroll reveal observer (.nexus-reveal -> .is-in)
+       ---------------------------------------------------------- */
+    function initReveal() {
+        var els = document.querySelectorAll('.nexus-reveal');
+        if (!els.length || !('IntersectionObserver' in window)) {
+            els.forEach(function (el) { el.classList.add('is-in'); });
+            return;
+        }
+        var observer = new IntersectionObserver(function (entries) {
+            entries.forEach(function (entry) {
+                if (entry.isIntersecting) {
+                    entry.target.classList.add('is-in');
+                    observer.unobserve(entry.target);
+                }
+            });
+        }, { threshold: 0.12, rootMargin: '0px 0px -80px 0px' });
+        els.forEach(function (el) { observer.observe(el); });
+    }
+
+    /* ----------------------------------------------------------
+       Rating widget
+       ---------------------------------------------------------- */
+    function initRating() {
+        var root = document.querySelector('.nexus-rating');
+        if (!root) return;
+
+        var buttons = root.querySelectorAll('.nexus-rating__btn');
+        var feedback = root.querySelector('.nexus-rating__feedback');
+        var thanks = root.querySelector('.nexus-rating__thanks');
+        var errorEl = root.querySelector('.nexus-rating__error');
+        var textarea = root.querySelector('textarea');
+        var submitBtn = root.querySelector('.nexus-rating__submit');
+        var skipBtn = root.querySelector('.nexus-rating__skip');
+
+        var state = { rating: null, submitted: false };
+
+        buttons.forEach(function (btn) {
+            btn.addEventListener('click', function () {
+                if (state.submitted) return;
+                buttons.forEach(function (b) { b.classList.remove('is-selected'); });
+                btn.classList.add('is-selected');
+                state.rating = btn.getAttribute('data-rating');
+
+                if (feedback) feedback.classList.add('is-shown');
+                if (errorEl) errorEl.classList.remove('is-shown');
+
+                // Push the rating itself immediately (text is optional).
+                sendRating(state.rating, '');
+                pushDataLayer({
+                    event: 'post_rating',
+                    rating: state.rating,
+                    post_id: config.postId || null
+                });
+            });
+        });
+
+        if (submitBtn) {
+            submitBtn.addEventListener('click', function () {
+                if (!state.rating) return;
+                var text = textarea ? textarea.value.trim() : '';
+                if (text) {
+                    sendRating(state.rating, text);
+                    pushDataLayer({
+                        event: 'post_rating_feedback',
+                        rating: state.rating,
+                        post_id: config.postId || null,
+                        feedback_length: text.length
+                    });
+                }
+                showThanks();
+            });
+        }
+
+        if (skipBtn) {
+            skipBtn.addEventListener('click', function () { showThanks(); });
+        }
+
+        function showThanks() {
+            state.submitted = true;
+            if (feedback) feedback.classList.remove('is-shown');
+            if (thanks) thanks.classList.add('is-shown');
+            buttons.forEach(function (b) { b.disabled = true; });
+        }
+
+        function sendRating(rating, text) {
+            if (!config.restEndpoint || !config.postId) return;
+            try {
+                var body = {
+                    postId: config.postId,
+                    rating: rating,
+                    feedback: text || '',
+                    nonce: config.nonce || ''
+                };
+                fetch(config.restEndpoint, {
+                    method: 'POST',
+                    credentials: 'same-origin',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-WP-Nonce': config.nonce || ''
+                    },
+                    body: JSON.stringify(body)
+                }).then(function (response) {
+                    if (!response.ok && errorEl) {
+                        errorEl.textContent = config.errorMsg || 'Bitte erneut versuchen.';
+                        errorEl.classList.add('is-shown');
+                    }
+                }).catch(function () {
+                    if (errorEl) {
+                        errorEl.textContent = config.errorMsg || 'Bitte erneut versuchen.';
+                        errorEl.classList.add('is-shown');
+                    }
+                });
+            } catch (err) {
+                // No-op — silently swallow so the UX stays smooth even on
+                // restricted browsers.
+            }
+        }
+    }
+
+    /* ----------------------------------------------------------
+       Vertical share rail buttons (+ copy link)
+       ---------------------------------------------------------- */
+    function initShareButtons() {
+        var shareUrl = config.shareUrl || window.location.href;
+        var shareTitle = config.shareTitle || document.title;
+
+        document.querySelectorAll('[data-nexus-share]').forEach(function (btn) {
+            btn.addEventListener('click', function () {
+                var type = btn.getAttribute('data-nexus-share');
+                var encodedUrl = encodeURIComponent(shareUrl);
+                var encodedTitle = encodeURIComponent(shareTitle);
+                var target = '';
+                switch (type) {
+                    case 'linkedin':
+                        target = 'https://www.linkedin.com/sharing/share-offsite/?url=' + encodedUrl;
+                        break;
+                    case 'twitter':
+                    case 'x':
+                        target = 'https://twitter.com/intent/tweet?url=' + encodedUrl + '&text=' + encodedTitle;
+                        break;
+                    case 'email':
+                        window.location.href = 'mailto:?subject=' + encodedTitle + '&body=' + encodedUrl;
+                        return;
+                    case 'copy':
+                        copyToClipboard(shareUrl, btn);
+                        return;
+                }
+                if (target) {
+                    window.open(target, '_blank', 'noopener,width=600,height=520');
+                }
+                pushDataLayer({ event: 'post_share', method: type, post_id: config.postId || null });
+            });
+        });
+    }
+
+    function copyToClipboard(text, btn) {
+        var done = function () {
+            var original = btn.innerHTML;
+            btn.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>';
+            setTimeout(function () { btn.innerHTML = original; }, 2000);
+        };
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).then(done).catch(function () {});
+        } else {
+            var input = document.createElement('input');
+            input.value = text;
+            document.body.appendChild(input);
+            input.select();
+            try { document.execCommand('copy'); done(); } catch (e) {}
+            document.body.removeChild(input);
+        }
+    }
+
+    function pushDataLayer(data) {
+        try {
+            window.dataLayer = window.dataLayer || [];
+            window.dataLayer.push(data);
+        } catch (e) {}
+    }
+})();

--- a/blocksy-child/docs/implementation/single-post-editorial.md
+++ b/blocksy-child/docs/implementation/single-post-editorial.md
@@ -1,0 +1,230 @@
+# Single Post — Editorial Template
+
+Author: Haşim Üner · Stack: `single.php` + `assets/css/single-editorial.css` + `assets/js/single-editorial.js` + `inc/post-rating.php`
+
+This template turns every blog post (`single.php`) into a world-class editorial page. Hero, sticky TOC, share rail, progress bar, rating widget, author bio, related and footer-CTA are rendered automatically. Inside `the_content()` you can drop the block classes below to upgrade individual passages.
+
+---
+
+## Shell (rendered automatically by `single.php`)
+
+| Element | Where it appears |
+|---|---|
+| Reading progress bar | Fixed top, 3px copper gradient |
+| Sticky share rail (LinkedIn / X / Mail / Copy) | Fixed left, only ≥ 1280px |
+| Hero (Category · Date · Reading time · Title · Author) | `nexus-article-hero` |
+| Article context bridge | `nexus-article-context` (category-aware) |
+| TOC sidebar with scroll-spy | `sticky-toc` (left of content) |
+| Inline mid-content CTA | Auto-injected by `blog-inline-cta.js` |
+| Article-next CTAs | `nexus-article-next` |
+| Rating widget | `nexus-rating` (Helpful / Not helpful + free text) |
+| Blog notification subscribe | `nexus-blog-notify` |
+| Author bio card | `nexus-author-bio` |
+| Related content | `template-parts/related-content.php` |
+| Footer CTA | `template-parts/footer-cta.php` |
+| Back to top | `nexus-back-to-top` |
+
+---
+
+## Editor block classes
+
+Drop into the Gutenberg **Custom HTML** block (or via `wp_kses` allowed markup).
+
+### Lead paragraph + drop cap
+
+```html
+<p class="lead-para dropcap">Photovoltaik-Leads werden im Einkauf fast immer falsch bewertet.</p>
+```
+
+### Section divider with big chapter number
+
+```html
+<div class="section-divider">
+  <div class="section-divider-num">01</div>
+  <div class="section-divider-content">
+    <h2 id="sektion-1">Section title</h2>
+    <p class="section-divider-dek">One-line subhead that frames the section.</p>
+  </div>
+</div>
+```
+
+### Pull quote with attribution
+
+```html
+<blockquote class="pull-quote">
+  Ein Portal-Lead für 60 € kann teuer sein. Ein eigener Lead für 180 € kann billig sein.
+  <span class="pull-quote-attr">Kapitel 1 · Markt</span>
+</blockquote>
+```
+
+### Formula / code-style block
+
+Inline color helpers inside: `.accent` (copper), `.good`, `.bad`, `.warn`, `.comment`.
+
+```html
+<div class="formula-block"><span class="comment"># Cost per Order</span>
+<span class="accent">CPO</span> = Leadkosten / Abschlussquote</div>
+```
+
+### Stat row (3-column)
+
+```html
+<div class="stat-row">
+  <div class="stat-card">
+    <div class="stat-value">€ 1.500</div>
+    <div class="stat-label"><strong>Portal-Leads</strong><br>60 € CPL · 4 % Abschluss</div>
+  </div>
+  <!-- repeat -->
+</div>
+```
+
+### Callout box with inline CTA
+
+```html
+<div class="callout">
+  <div class="callout-label">Stopp · Bevor Sie weiterlesen</div>
+  <div class="callout-title">Prüfen Sie, ob Ihr Zielgebiet ein eigenes Anfrage-System trägt.</div>
+  <p class="callout-text">Der Marktcheck prüft Region, Projektvolumen und Vertriebsreife in 48 h.</p>
+  <a href="/marktcheck/" class="callout-cta">Marktcheck starten →</a>
+</div>
+```
+
+### Comparison table (3-column)
+
+```html
+<div class="comparison">
+  <div class="comparison-row header">
+    <div>Dimension</div><div>Portal-Miete</div><div>Eigene Strecke</div>
+  </div>
+  <div class="comparison-row">
+    <div>Abschlussquote</div><div>~ 4-7 %</div><div>~ 12-18 %</div>
+  </div>
+  <!-- repeat -->
+</div>
+```
+
+### Case study card
+
+```html
+<div class="casestudy">
+  <div class="casestudy-header">
+    <div>
+      <div class="casestudy-label">Fallstudie</div>
+      <div class="casestudy-name">E3 New Energy</div>
+    </div>
+    <div class="casestudy-meta">9 Monate<br>Vollkostenbasiert</div>
+  </div>
+  <div class="casestudy-stats">
+    <div class="casestudy-stat">
+      <div class="casestudy-stat-num">71 %</div>
+      <div class="casestudy-stat-from">CPO-Reduktion</div>
+      <div class="casestudy-stat-label">€ 5.000 → € 1.450</div>
+    </div>
+    <!-- 2 more -->
+  </div>
+  <blockquote class="casestudy-quote">Dieselben Verkäufer, bessere Anfragequelle.</blockquote>
+</div>
+```
+
+### FAQ accordion
+
+```html
+<section class="nexus-faq">
+  <ul class="faq-list">
+    <li class="faq-item">
+      <button class="faq-question" type="button">
+        Sind gekaufte Photovoltaik-Leads grundsätzlich schlecht?
+        <span class="faq-toggle"></span>
+      </button>
+      <div class="faq-answer"><div class="faq-answer-inner">
+        Nein. Kurzfristig sinnvoll für neue Regionen oder Validierung. Gefährlich als Dauerstrategie.
+      </div></div>
+    </li>
+    <!-- repeat -->
+  </ul>
+</section>
+```
+
+JS toggles `.is-open` on the `<li class="faq-item">` automatically — no inline event handlers required.
+
+### Highlight marker
+
+```html
+<p>Der Einkauf sieht den 60-Euro-Lead. <span class="highlight">Die Geschäftsführung muss den 1.500-Euro-Auftrag sehen.</span></p>
+```
+
+### Cover flow schematic (Modell A vs. B)
+
+Heavy block — drop above the first H2 when the article genuinely benefits.
+
+```html
+<div class="cover-schematic">
+  <div class="cover-grid">
+    <div class="cover-pane bad">
+      <div class="cover-pane-label">Modell A · Portal-Miete</div>
+      <div class="cover-pane-title">Geteilte Anfrage, geteilte Marge</div>
+      <div class="cover-nodes">
+        <div class="cover-node"><span class="dot"></span>Lead-Portal<span class="cover-node-meta">Aroundhome</span></div>
+        <div class="cover-node"><span class="dot"></span>Anbieter A<span class="cover-node-meta">4-7 %</span></div>
+      </div>
+      <div class="cover-cpo">
+        <div class="cover-cpo-label">Cost per Order</div>
+        <div class="cover-cpo-value">€ 2.500</div>
+      </div>
+    </div>
+    <div class="cover-divider">
+      <div class="cover-divider-line"></div><div class="cover-divider-vs">VS</div><div class="cover-divider-line"></div>
+    </div>
+    <div class="cover-pane good">
+      <div class="cover-pane-label">Modell B · Eigene Strecke</div>
+      <div class="cover-pane-title">Exklusiv, eigener Besitz</div>
+      <div class="cover-nodes">
+        <div class="cover-node"><span class="dot"></span>Money Page<span class="cover-node-meta">First-Party</span></div>
+        <div class="cover-node"><span class="dot"></span>Vertrieb<span class="cover-node-meta">~15 %</span></div>
+      </div>
+      <div class="cover-cpo">
+        <div class="cover-cpo-label">Cost per Order</div>
+        <div class="cover-cpo-value">€ 1.300</div>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+---
+
+## Hero opt-in: decorative ghost stat
+
+Add `data-hero-stat="71%"` and `data-hero-stat-label="Case Study"` to the `<header class="nexus-article-hero">` to render the giant transparent number top-right. Only renders ≥ 1100px.
+
+---
+
+## Rating widget
+
+- Renders by default on every single post.
+- POSTs to `wp-json/nexus/v1/post-rating` with WP REST nonce.
+- Stores aggregated counters + last 25 free-text feedbacks as post meta.
+- Admin: post-edit screen has a side meta-box "Artikel-Bewertungen"; the posts list has a sortable column.
+- Downstream hook for CRM/Brevo/n8n:
+  ```php
+  add_action( 'nexus_post_rating_received', function ( $post_id, $rating, $feedback, $context ) {
+      // forward to Brevo, n8n, etc.
+  }, 10, 4 );
+  ```
+
+GA4 events pushed to `window.dataLayer`:
+
+| Event | Payload |
+|---|---|
+| `post_rating` | `rating`, `post_id` |
+| `post_rating_feedback` | `rating`, `post_id`, `feedback_length` |
+| `post_share` | `method`, `post_id` |
+
+---
+
+## Performance notes
+
+- CSS loaded only on `is_singular('post')` via `inc/enqueue.php`.
+- JS deferred (via `hu_mark_script_for_defer`).
+- `IntersectionObserver` used for reveals; no continuous scroll work beyond a single `requestAnimationFrame`-throttled progress bar updater.
+- All shell elements respect `prefers-reduced-motion`.

--- a/blocksy-child/functions.php
+++ b/blocksy-child/functions.php
@@ -42,6 +42,7 @@ $modules = [
 	'system-diagnose-page.php', // Deutsche Analyse-Route plus Legacy-Redirect
 	'analysis-intake.php', // REST-Endpoint, CRM-Sync, Brevo-Mails und n8n-Webhook für die Analyse
 	'blog-notify.php',    // Blog-Benachrichtigungen, DOI und Artikel-Mails
+	'post-rating.php',    // Artikel-Bewertung (Hilfreich/Nicht hilfreich) + Admin-Spalte
 	'blog-provider-posts.php', // Einmalige Live-Anlage der Lead-Anbieter-Markteinordnungen
 	'blog-pillar-posts.php', // Einmalige Live-Anlage strategischer Pillar-Beiträge
 	'robots-txt.php',     // Dynamische /robots.txt-Route für Search- und KI-Crawler

--- a/blocksy-child/inc/enqueue.php
+++ b/blocksy-child/inc/enqueue.php
@@ -161,6 +161,24 @@ function hu_enqueue_assets() {
 		hu_enqueue_css( 'nexus-related-content-css', 'related-content.css', [ 'nexus-design-system' ] );
 		hu_enqueue_css( 'nexus-footer-cta-css', 'footer-cta.css', [ 'nexus-design-system' ] );
 		hu_enqueue_js( 'nexus-blog-inline-cta-js', 'blog-inline-cta.js', [ 'nexus-core-js' ] );
+
+		// Editorial layer: progress bar, share rail, FAQ, rating, author bio.
+		hu_enqueue_css( 'nexus-single-editorial-css', 'single-editorial.css', [ 'nexus-single-css' ] );
+		hu_enqueue_js( 'nexus-single-editorial-js', 'single-editorial.js', [ 'nexus-core-js' ] );
+
+		wp_localize_script(
+			'nexus-single-editorial-js',
+			'NexusSingleEditorial',
+			[
+				'restEndpoint' => esc_url_raw( rest_url( 'nexus/v1/post-rating' ) ),
+				'nonce'        => wp_create_nonce( 'wp_rest' ),
+				'postId'       => (int) get_the_ID(),
+				'successMsg'   => __( 'Danke für Ihr Feedback.', 'blocksy-child' ),
+				'errorMsg'     => __( 'Das hat gerade nicht funktioniert. Bitte erneut versuchen.', 'blocksy-child' ),
+				'shareUrl'     => esc_url_raw( get_permalink() ),
+				'shareTitle'   => wp_strip_all_tags( get_the_title() ),
+			]
+		);
 	}
 
 	if ( is_singular( 'post' ) || $is_seo_cornerstone_template ) {

--- a/blocksy-child/inc/post-rating.php
+++ b/blocksy-child/inc/post-rating.php
@@ -1,0 +1,296 @@
+<?php
+/**
+ * Post rating endpoint + admin meta-box.
+ *
+ * Lightweight "was this article helpful?" widget. Stores aggregated
+ * counts in post meta and the last few free-text feedbacks so the
+ * author can read them without leaving WP-Admin. No third-party
+ * dependency, no PII beyond what visitors voluntarily type.
+ *
+ * REST: POST /wp-json/nexus/v1/post-rating
+ *   body: { postId, rating ("yes" | "no"), feedback, nonce }
+ *
+ * Action hook for downstream automation (CRM, n8n, Brevo):
+ *   do_action( 'nexus_post_rating_received', $post_id, $rating, $feedback, $context );
+ *
+ * @package Blocksy_Child
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+const NEXUS_POST_RATING_META_COUNT_YES = '_nexus_rating_count_yes';
+const NEXUS_POST_RATING_META_COUNT_NO  = '_nexus_rating_count_no';
+const NEXUS_POST_RATING_META_FEEDBACK  = '_nexus_rating_feedback';
+const NEXUS_POST_RATING_FEEDBACK_LIMIT = 25;
+const NEXUS_POST_RATING_TEXT_LIMIT     = 1500;
+const NEXUS_POST_RATING_RATE_WINDOW    = 600;   // 10 min
+const NEXUS_POST_RATING_RATE_LIMIT     = 6;     // max submissions per window per IP+post
+
+/**
+ * Register the REST endpoint.
+ *
+ * @return void
+ */
+function nexus_register_post_rating_route() {
+	register_rest_route(
+		'nexus/v1',
+		'/post-rating',
+		[
+			'methods'             => WP_REST_Server::CREATABLE,
+			'callback'            => 'nexus_handle_post_rating_submission',
+			'permission_callback' => '__return_true',
+		]
+	);
+}
+add_action( 'rest_api_init', 'nexus_register_post_rating_route' );
+
+/**
+ * Handle rating submissions.
+ *
+ * @param WP_REST_Request $request REST request.
+ * @return WP_REST_Response
+ */
+function nexus_handle_post_rating_submission( WP_REST_Request $request ) {
+	$payload = $request->get_json_params();
+	if ( ! is_array( $payload ) || empty( $payload ) ) {
+		$payload = $request->get_body_params();
+	}
+
+	$post_id  = isset( $payload['postId'] ) ? absint( $payload['postId'] ) : 0;
+	$rating   = isset( $payload['rating'] ) ? sanitize_key( $payload['rating'] ) : '';
+	$feedback = isset( $payload['feedback'] ) ? (string) $payload['feedback'] : '';
+
+	if ( ! $post_id || 'publish' !== get_post_status( $post_id ) ) {
+		return new WP_REST_Response(
+			[ 'ok' => false, 'error' => 'invalid_post' ],
+			400
+		);
+	}
+
+	if ( 'yes' !== $rating && 'no' !== $rating ) {
+		return new WP_REST_Response(
+			[ 'ok' => false, 'error' => 'invalid_rating' ],
+			400
+		);
+	}
+
+	if ( nexus_post_rating_is_rate_limited( $post_id ) ) {
+		return new WP_REST_Response(
+			[ 'ok' => false, 'error' => 'rate_limited' ],
+			429
+		);
+	}
+
+	// Counter increment.
+	$meta_key = 'yes' === $rating ? NEXUS_POST_RATING_META_COUNT_YES : NEXUS_POST_RATING_META_COUNT_NO;
+	$current  = (int) get_post_meta( $post_id, $meta_key, true );
+	update_post_meta( $post_id, $meta_key, $current + 1 );
+
+	// Optional feedback (only stored if non-empty).
+	$feedback = trim( wp_strip_all_tags( $feedback ) );
+	if ( '' !== $feedback ) {
+		if ( function_exists( 'mb_substr' ) ) {
+			$feedback = mb_substr( $feedback, 0, NEXUS_POST_RATING_TEXT_LIMIT );
+		} else {
+			$feedback = substr( $feedback, 0, NEXUS_POST_RATING_TEXT_LIMIT );
+		}
+
+		$entries = get_post_meta( $post_id, NEXUS_POST_RATING_META_FEEDBACK, true );
+		if ( ! is_array( $entries ) ) {
+			$entries = [];
+		}
+
+		array_unshift(
+			$entries,
+			[
+				'rating'    => $rating,
+				'text'      => $feedback,
+				'timestamp' => time(),
+				'ip_hash'   => nexus_post_rating_hash_ip(),
+			]
+		);
+
+		$entries = array_slice( $entries, 0, NEXUS_POST_RATING_FEEDBACK_LIMIT );
+		update_post_meta( $post_id, NEXUS_POST_RATING_META_FEEDBACK, $entries );
+	}
+
+	/**
+	 * Fires after a rating is recorded so downstream automations
+	 * (CRM, Brevo, n8n) can react. Receives:
+	 *   $post_id, $rating ('yes'|'no'), $feedback (string), $context (array)
+	 */
+	do_action(
+		'nexus_post_rating_received',
+		$post_id,
+		$rating,
+		$feedback,
+		[
+			'post_title' => get_the_title( $post_id ),
+			'permalink'  => get_permalink( $post_id ),
+		]
+	);
+
+	return new WP_REST_Response(
+		[
+			'ok'      => true,
+			'message' => __( 'Danke für Ihr Feedback.', 'blocksy-child' ),
+		],
+		200
+	);
+}
+
+/**
+ * Hash the requester IP so we can rate-limit without storing PII.
+ *
+ * @return string
+ */
+function nexus_post_rating_hash_ip() {
+	$ip = '';
+	if ( ! empty( $_SERVER['REMOTE_ADDR'] ) ) {
+		$ip = (string) $_SERVER['REMOTE_ADDR']; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+	}
+	if ( '' === $ip ) {
+		return '';
+	}
+	return substr( hash( 'sha256', $ip . wp_salt( 'auth' ) ), 0, 16 );
+}
+
+/**
+ * Rate limit check per IP+post using a transient.
+ *
+ * @param int $post_id Post ID.
+ * @return bool True if blocked.
+ */
+function nexus_post_rating_is_rate_limited( $post_id ) {
+	$ip_hash = nexus_post_rating_hash_ip();
+	if ( '' === $ip_hash ) {
+		return false;
+	}
+	$key   = 'nexus_rate_post_rating_' . $post_id . '_' . $ip_hash;
+	$count = (int) get_transient( $key );
+	if ( $count >= NEXUS_POST_RATING_RATE_LIMIT ) {
+		return true;
+	}
+	set_transient( $key, $count + 1, NEXUS_POST_RATING_RATE_WINDOW );
+	return false;
+}
+
+/**
+ * Return rating totals for a post.
+ *
+ * @param int $post_id Post ID.
+ * @return array{yes:int, no:int, total:int, ratio:float}
+ */
+function nexus_get_post_rating_totals( $post_id ) {
+	$yes = (int) get_post_meta( $post_id, NEXUS_POST_RATING_META_COUNT_YES, true );
+	$no  = (int) get_post_meta( $post_id, NEXUS_POST_RATING_META_COUNT_NO, true );
+	$total = $yes + $no;
+	$ratio = $total > 0 ? round( ( $yes / $total ) * 100, 1 ) : 0.0;
+	return [
+		'yes'   => $yes,
+		'no'    => $no,
+		'total' => $total,
+		'ratio' => $ratio,
+	];
+}
+
+/**
+ * Register admin meta-box on posts.
+ *
+ * @return void
+ */
+function nexus_register_post_rating_metabox() {
+	add_meta_box(
+		'nexus-post-rating',
+		__( 'Artikel-Bewertungen', 'blocksy-child' ),
+		'nexus_render_post_rating_metabox',
+		'post',
+		'side',
+		'default'
+	);
+}
+add_action( 'add_meta_boxes', 'nexus_register_post_rating_metabox' );
+
+/**
+ * Render the admin meta-box.
+ *
+ * @param WP_Post $post Post object.
+ * @return void
+ */
+function nexus_render_post_rating_metabox( $post ) {
+	$totals   = nexus_get_post_rating_totals( $post->ID );
+	$entries  = get_post_meta( $post->ID, NEXUS_POST_RATING_META_FEEDBACK, true );
+	$entries  = is_array( $entries ) ? $entries : [];
+
+	echo '<p style="margin:0 0 0.6rem;font-size:13px;color:#555;">';
+	echo esc_html__( 'Aggregierte Lesermeinung zu diesem Artikel.', 'blocksy-child' );
+	echo '</p>';
+
+	echo '<div style="display:grid;grid-template-columns:repeat(3,1fr);gap:6px;text-align:center;margin-bottom:0.8rem;">';
+	echo '<div style="padding:8px 6px;border:1px solid #ddd;border-radius:8px;"><div style="font-size:11px;color:#666;text-transform:uppercase;letter-spacing:0.08em;">Hilfreich</div><div style="font-size:18px;font-weight:700;color:#1e7a3f;">' . esc_html( (string) $totals['yes'] ) . '</div></div>';
+	echo '<div style="padding:8px 6px;border:1px solid #ddd;border-radius:8px;"><div style="font-size:11px;color:#666;text-transform:uppercase;letter-spacing:0.08em;">Nicht</div><div style="font-size:18px;font-weight:700;color:#a83434;">' . esc_html( (string) $totals['no'] ) . '</div></div>';
+	echo '<div style="padding:8px 6px;border:1px solid #ddd;border-radius:8px;"><div style="font-size:11px;color:#666;text-transform:uppercase;letter-spacing:0.08em;">Ratio</div><div style="font-size:18px;font-weight:700;color:#b46a3c;">' . esc_html( (string) $totals['ratio'] ) . '%</div></div>';
+	echo '</div>';
+
+	if ( empty( $entries ) ) {
+		echo '<p style="margin:0;font-size:12px;color:#888;">' . esc_html__( 'Noch kein Freitext-Feedback eingegangen.', 'blocksy-child' ) . '</p>';
+		return;
+	}
+
+	echo '<p style="margin:0 0 0.4rem;font-size:12px;color:#555;font-weight:600;">' . esc_html__( 'Letzte Rückmeldungen', 'blocksy-child' ) . '</p>';
+	echo '<ul style="list-style:none;margin:0;padding:0;max-height:320px;overflow:auto;">';
+	foreach ( $entries as $entry ) {
+		$rating = isset( $entry['rating'] ) ? (string) $entry['rating'] : '';
+		$text   = isset( $entry['text'] ) ? (string) $entry['text'] : '';
+		$time   = isset( $entry['timestamp'] ) ? (int) $entry['timestamp'] : 0;
+		$badge  = 'yes' === $rating ? '👍' : '👎';
+		$color  = 'yes' === $rating ? '#1e7a3f' : '#a83434';
+		echo '<li style="padding:8px;border:1px solid #eee;border-radius:6px;margin-bottom:6px;background:#fafafa;">';
+		echo '<div style="font-size:11px;color:' . esc_attr( $color ) . ';margin-bottom:4px;">' . esc_html( $badge ) . ' ';
+		echo esc_html( $time ? wp_date( 'd.m.Y · H:i', $time ) : '' );
+		echo '</div>';
+		echo '<div style="font-size:13px;line-height:1.4;color:#222;white-space:pre-wrap;">' . esc_html( $text ) . '</div>';
+		echo '</li>';
+	}
+	echo '</ul>';
+}
+
+/**
+ * Add a sortable "Bewertung" column to the posts list table.
+ *
+ * @param array $columns Existing columns.
+ * @return array
+ */
+function nexus_post_rating_columns( $columns ) {
+	$columns['nexus_rating'] = __( 'Bewertung', 'blocksy-child' );
+	return $columns;
+}
+add_filter( 'manage_post_posts_columns', 'nexus_post_rating_columns' );
+
+/**
+ * Render the rating column.
+ *
+ * @param string $column  Column name.
+ * @param int    $post_id Post ID.
+ * @return void
+ */
+function nexus_post_rating_render_column( $column, $post_id ) {
+	if ( 'nexus_rating' !== $column ) {
+		return;
+	}
+	$totals = nexus_get_post_rating_totals( $post_id );
+	if ( 0 === $totals['total'] ) {
+		echo '<span style="color:#aaa;">—</span>';
+		return;
+	}
+	printf(
+		'<span title="%1$s">%2$d&nbsp;👍 / %3$d&nbsp;👎 · %4$s%%</span>',
+		esc_attr__( 'Hilfreich / Nicht hilfreich / Ratio', 'blocksy-child' ),
+		(int) $totals['yes'],
+		(int) $totals['no'],
+		esc_html( (string) $totals['ratio'] )
+	);
+}
+add_action( 'manage_post_posts_custom_column', 'nexus_post_rating_render_column', 10, 2 );

--- a/blocksy-child/single.php
+++ b/blocksy-child/single.php
@@ -14,7 +14,25 @@ get_header();
 get_template_part( 'template-parts/blog-header' );
 ?>
 
-<main id="main" class="site-main nexus-single-container nexus-single-container--with-blog-header">
+<div class="nexus-reading-progress" aria-hidden="true"></div>
+
+<aside class="nexus-share-rail" aria-label="<?php esc_attr_e( 'Artikel teilen', 'blocksy-child' ); ?>">
+	<span class="nexus-share-rail__label"><?php esc_html_e( 'Teilen', 'blocksy-child' ); ?></span>
+	<button class="nexus-share-rail__btn" type="button" data-nexus-share="linkedin" aria-label="LinkedIn">
+		<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false"><path d="M19 0h-14c-2.761 0-5 2.239-5 5v14c0 2.761 2.239 5 5 5h14c2.762 0 5-2.239 5-5v-14c0-2.761-2.238-5-5-5zm-11 19h-3v-11h3v11zm-1.5-12.268c-.966 0-1.75-.79-1.75-1.764s.784-1.764 1.75-1.764 1.75.79 1.75 1.764-.783 1.764-1.75 1.764zm13.5 12.268h-3v-5.604c0-3.368-4-3.113-4 0v5.604h-3v-11h3v1.765c1.396-2.586 7-2.777 7 2.476v6.759z"/></svg>
+	</button>
+	<button class="nexus-share-rail__btn" type="button" data-nexus-share="x" aria-label="X">
+		<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
+	</button>
+	<button class="nexus-share-rail__btn" type="button" data-nexus-share="email" aria-label="<?php esc_attr_e( 'Per E-Mail teilen', 'blocksy-child' ); ?>">
+		<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
+	</button>
+	<button class="nexus-share-rail__btn" type="button" data-nexus-share="copy" aria-label="<?php esc_attr_e( 'Link kopieren', 'blocksy-child' ); ?>">
+		<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+	</button>
+</aside>
+
+<main id="main" class="site-main nexus-single-container nexus-single-container--with-blog-header nexus-single-container--editorial hu-hp">
 
 	<?php while ( have_posts() ) : the_post(); ?>
 
@@ -306,6 +324,40 @@ get_template_part( 'template-parts/blog-header' );
 			</div>
 		</section>
 
+		<?php if ( is_singular( 'post' ) ) : ?>
+		<section class="nexus-rating nexus-reveal" data-track-section="article_rating" aria-labelledby="nexus-rating-title">
+			<div class="nexus-rating__label"><?php esc_html_e( 'Feedback', 'blocksy-child' ); ?></div>
+			<h2 id="nexus-rating-title" class="nexus-rating__title"><?php esc_html_e( 'War dieser Artikel hilfreich?', 'blocksy-child' ); ?></h2>
+			<p class="nexus-rating__sub"><?php esc_html_e( 'Ihre Rückmeldung verbessert die nächsten Beiträge — kein Login nötig.', 'blocksy-child' ); ?></p>
+
+			<div class="nexus-rating__buttons">
+				<button class="nexus-rating__btn" type="button" data-rating="yes" data-track-action="post_rating_yes" data-track-category="engagement">
+					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M7 10v12"/><path d="M15 5.88 14 10h5.83a2 2 0 0 1 1.92 2.56l-2.33 8A2 2 0 0 1 17.5 22H7V10l5-8 1.74 1.16A2 2 0 0 1 14.5 5l.5.88z"/></svg>
+					<?php esc_html_e( 'Hilfreich', 'blocksy-child' ); ?>
+				</button>
+				<button class="nexus-rating__btn" type="button" data-rating="no" data-track-action="post_rating_no" data-track-category="engagement">
+					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M17 14V2"/><path d="M9 18.12 10 14H4.17a2 2 0 0 1-1.92-2.56l2.33-8A2 2 0 0 1 6.5 2H17v12l-5 8-1.74-1.16A2 2 0 0 1 9.5 19l-.5-.88z"/></svg>
+					<?php esc_html_e( 'Nicht hilfreich', 'blocksy-child' ); ?>
+				</button>
+			</div>
+
+			<div class="nexus-rating__feedback" aria-live="polite">
+				<label class="screen-reader-text" for="nexus-rating-text"><?php esc_html_e( 'Optionale Rückmeldung', 'blocksy-child' ); ?></label>
+				<textarea id="nexus-rating-text" placeholder="<?php esc_attr_e( 'Was hat gefehlt? Welcher Punkt blieb unklar? (optional)', 'blocksy-child' ); ?>"></textarea>
+				<div class="nexus-rating__feedback-actions">
+					<button class="nexus-rating__skip" type="button"><?php esc_html_e( 'Überspringen', 'blocksy-child' ); ?></button>
+					<button class="nexus-rating__submit" type="button">
+						<?php esc_html_e( 'Feedback senden', 'blocksy-child' ); ?>
+						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+					</button>
+				</div>
+			</div>
+
+			<p class="nexus-rating__thanks" role="status"><?php esc_html_e( '✓ Danke für Ihr Feedback.', 'blocksy-child' ); ?></p>
+			<p class="nexus-rating__error" role="alert"></p>
+		</section>
+		<?php endif; ?>
+
 		<?php get_template_part( 'template-parts/blog-notify', null, [ 'variant' => 'full' ] ); ?>
 
 		<?php if ( is_singular( 'post' ) ) : ?>
@@ -313,6 +365,80 @@ get_template_part( 'template-parts/blog-header' );
 			<h3><?php esc_html_e( 'Diesen Artikel teilen', 'blocksy-child' ); ?></h3>
 			<?php if ( function_exists( 'nexus_render_share_buttons' ) ) { nexus_render_share_buttons(); } ?>
 		</div>
+
+		<?php
+		$author_id          = get_the_author_meta( 'ID' );
+		$author_name        = get_the_author();
+		$author_description = get_the_author_meta( 'description' );
+		$author_avatar      = get_avatar( $author_id, 96, '', $author_name, [ 'class' => 'nexus-author-bio__avatar-img' ] );
+		$author_initials    = '';
+		if ( $author_name ) {
+			$parts = preg_split( '/\s+/', trim( wp_strip_all_tags( $author_name ) ) );
+			foreach ( (array) $parts as $part ) {
+				if ( '' === $part ) {
+					continue;
+				}
+				$author_initials .= function_exists( 'mb_substr' ) ? mb_substr( $part, 0, 1 ) : substr( $part, 0, 1 );
+				if ( strlen( $author_initials ) >= 2 ) {
+					break;
+				}
+			}
+		}
+		$author_role     = trim( (string) get_the_author_meta( 'hu_author_role' ) );
+		if ( '' === $author_role ) {
+			$author_role = __( 'Architekt für eigene Anfrage-Systeme · Hannover', 'blocksy-child' );
+		}
+		if ( '' === trim( (string) $author_description ) ) {
+			$author_description = __( 'Ich baue Solar- und Wärmepumpen-Anbietern im DACH-Raum eigene Anfrage-Systeme, die Portal-Abhängigkeit ablösen und Leadkosten messbar senken. Diagnose vor Pitch. Klarheit vor Feature-Count.', 'blocksy-child' );
+		}
+		?>
+		<section class="nexus-author-bio nexus-reveal" data-track-section="article_author_bio" aria-labelledby="nexus-author-bio-name">
+			<div class="nexus-author-bio__avatar" aria-hidden="true">
+				<?php if ( $author_avatar ) : ?>
+					<?php echo $author_avatar; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped — get_avatar() returns safe HTML. ?>
+				<?php else : ?>
+					<?php echo esc_html( strtoupper( $author_initials ?: 'HÜ' ) ); ?>
+				<?php endif; ?>
+			</div>
+			<div class="nexus-author-bio__content">
+				<span class="nexus-author-bio__label"><?php esc_html_e( 'Über den Autor', 'blocksy-child' ); ?></span>
+				<h2 id="nexus-author-bio-name" class="nexus-author-bio__name"><?php echo esc_html( $author_name ); ?></h2>
+				<p class="nexus-author-bio__role"><?php echo esc_html( $author_role ); ?></p>
+				<p class="nexus-author-bio__text"><?php echo esc_html( $author_description ); ?></p>
+				<div class="nexus-author-bio__links">
+					<a
+						href="<?php echo esc_url( $audit_url ); ?>"
+						class="nexus-author-bio__link"
+						data-track-action="cta_author_bio_marktcheck"
+						data-track-category="lead_gen"
+					>
+						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+						<?php esc_html_e( 'Marktcheck starten', 'blocksy-child' ); ?>
+					</a>
+					<?php $about_url = function_exists( 'nexus_get_page_url' ) ? nexus_get_page_url( [ 'uber-mich', 'ueber-mich', 'ueber-hasim' ], home_url( '/uber-mich/' ) ) : home_url( '/uber-mich/' ); ?>
+					<a
+						href="<?php echo esc_url( $about_url ); ?>"
+						class="nexus-author-bio__link"
+						data-track-action="cta_author_bio_about"
+						data-track-category="internal_link"
+					>
+						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4M12 8h.01"/></svg>
+						<?php esc_html_e( 'Mehr über Haşim', 'blocksy-child' ); ?>
+					</a>
+					<a
+						href="https://www.linkedin.com/in/hasim-uener"
+						class="nexus-author-bio__link"
+						rel="noopener"
+						target="_blank"
+						data-track-action="cta_author_bio_linkedin"
+						data-track-category="external_link"
+					>
+						<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false"><path d="M19 0h-14c-2.761 0-5 2.239-5 5v14c0 2.761 2.239 5 5 5h14c2.762 0 5-2.239 5-5v-14c0-2.761-2.238-5-5-5zm-11 19h-3v-11h3v11zm-1.5-12.268c-.966 0-1.75-.79-1.75-1.764s.784-1.764 1.75-1.764 1.75.79 1.75 1.764-.783 1.764-1.75 1.764zm13.5 12.268h-3v-5.604c0-3.368-4-3.113-4 0v5.604h-3v-11h3v1.765c1.396-2.586 7-2.777 7 2.476v6.759z"/></svg>
+						<?php esc_html_e( 'LinkedIn', 'blocksy-child' ); ?>
+					</a>
+				</div>
+			</div>
+		</section>
 		<?php endif; ?>
 
 		<?php
@@ -328,6 +454,10 @@ get_template_part( 'template-parts/blog-header' );
 	<?php endwhile; ?>
 
 </main>
+
+<button class="nexus-back-to-top" type="button" aria-label="<?php esc_attr_e( 'Zum Seitenanfang', 'blocksy-child' ); ?>">
+	<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="m18 15-6-6-6 6"/></svg>
+</button>
 
 <?php
 get_footer();


### PR DESCRIPTION
Single posts now render a Champions-League editorial shell on top of the existing nexus-single container — progress bar, sticky share rail, rating widget, author bio, back-to-top — plus reusable block classes (section-divider, pull-quote, formula-block, stat-row, callout, comparison, casestudy, faq, highlight, cover-schematic, dropcap) that ship as the production template for every future article.

Rating data persists as post meta and surfaces via an admin meta-box and a sortable posts-list column. A nexus_post_rating_received action hook is available for downstream CRM/Brevo/n8n forwarding.