### PR TITLE
Strengthen conversion copy on homepage, solar LP, E3 case

### DIFF
--- a/blocksy-child/front-page.php
+++ b/blocksy-child/front-page.php
@@ -567,6 +567,30 @@ get_header();
 	</section>
 
 	<!-- ═══════════════════════════════════════════════════
+	     06b / KATEGORIE-BRUCH — Architektur statt Webdesign
+	     ═══════════════════════════════════════════════════ -->
+	<section class="hu-section hu-section--cream" id="kategorie" data-track-section="06b">
+		<div class="hu-container" style="max-width:880px">
+			<div class="hu-proof-headline hu-reveal">
+				<span class="hu-eyebrow" style="color:var(--ink-2)">06b / Kategorie</span>
+				<h2 style="color:var(--ink)">Warum dies kein Webdesign-Projekt ist.</h2>
+			</div>
+
+			<div class="hu-category-prose hu-reveal" style="max-width:680px;margin:32px auto 0;color:var(--ink-2);font-size:18px;line-height:1.62">
+				<p style="margin:0 0 18px">
+					Eine Standard-Agentur klickt Plugins und Page-Builder im WordPress-Backend zusammen. Bei jedem Theme- oder Plugin-Update zerschießt eine fremde Hand die LCP-Performance — und kein Mensch im Betrieb kann nachvollziehen, warum die Anfragen plötzlich einbrechen.
+				</p>
+				<p style="margin:0 0 18px">
+					Hier wird anders gearbeitet: System-Logik und Daten-Pfade liegen versioniert im GitHub-Repository. WordPress dient nur als performantes Frontend — kein Page-Builder, kein Plugin-Stack als Software-Fassade. Jede Änderung ist nachvollziehbar, jedes Rollback in Minuten möglich.
+				</p>
+				<p style="margin:0">
+					Das Resultat für den Betrieb: Sie mieten keine Agentur-Software, Sie besitzen den Code. Server-Side Tracking, CRM-Anbindung und Conversion-Pfad gehören Ihnen — übergebbar, prüfbar, unabhängig von mir.
+				</p>
+			</div>
+		</div>
+	</section>
+
+	<!-- ═══════════════════════════════════════════════════
 	     07 / ÜBER MICH — Trust-Anker (Metaphern-Leck korrigiert)
 	     ═══════════════════════════════════════════════════ -->
 	<section class="hu-section hu-section--cream" id="about" data-track-section="07">

--- a/blocksy-child/page-e3-new-energy.php
+++ b/blocksy-child/page-e3-new-energy.php
@@ -103,6 +103,30 @@ $cta_features = [
 	'Kein Pflicht-Termin, kein Pitch-Call',
 ];
 
+$tracking_repair_steps = [
+	[
+		'label' => 'Befund',
+		'title' => 'Safari-ITP löschte First-Party-Cookies nach 24 Stunden.',
+		'body'  => 'Im Ausgangszustand kam ein erheblicher Teil der Conversions nie in den Werbe-Konten an. Apples Intelligent Tracking Prevention beschneidet First-Party-Cookies, die per JavaScript gesetzt werden, auf 24 Stunden Lebensdauer. Wer am Donnerstag klickt und am Sonntag konvertiert, fehlt in der Attribution. Meta- und Google-Algorithmen optimierten dadurch gegen ein lückenhaftes Signal — sie lernten, falsche Klicker zu finden.',
+	],
+	[
+		'label' => 'Eingriff',
+		'title' => 'Server-Side-Setup auf eigener Subdomain.',
+		'body'  => 'Statt Browser-Tags wurde ein dediziertes Server-Side-Tracking auf einer eigenen Subdomain aufgesetzt. Conversion-Events laufen über GA4 Measurement Protocol und Meta Conversions API direkt aus dem CRM in die Werbe-Konten — vorbei an ITP, vorbei an Adblockern, mit Consent Mode v2 als rechtlichem Rahmen.',
+	],
+	[
+		'label' => 'Wirkung',
+		'title' => 'Algorithmen sahen erstmals echte Käufer.',
+		'body'  => 'Erst mit dieser First-Party-Attribution bekamen Meta und Google die belastbaren Kauf-Signale, die ihre Optimierung braucht. Der CPL-Sturz war ab Monat 3 keine Marketing-Magie, sondern eine zwingende Folge: Wer den Algorithmen sagt, wer wirklich gekauft hat, bekommt mehr von genau diesen Leuten — und weniger Klick-Touristen.',
+	],
+];
+
+$insight_body = sprintf(
+	'Höheres Werbebudget skaliert bei taubem Tracking nur den Verlust. Erst als der Vertrieb (CRM) und der Werbe-Algorithmus über First-Party-Attribution dieselbe Sprache sprachen, konnte die KI der Werbekanäle kaufbereite Hausbesitzer von Klick-Touristen unterscheiden. Der CPL-Endpunkt von %s nach %s war keine Optimierungsleistung — er war die mathematische Folge sauberer Daten.',
+	function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'cpl_after' ) : '22 €',
+	function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'timeframe', 'display_dative' ) : '6 Monaten'
+);
+
 $e3_deeper = [
 	[
 		't'   => 'Cost per Lead Photovoltaik',
@@ -213,6 +237,28 @@ get_header();
 			</div>
 		</section>
 
+		<section class="e3-section e3-section--paper-2" id="datenbereinigung" <?php echo $tracking_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> aria-labelledby="datenbereinigung-title">
+			<div class="e3-section__inner">
+				<div class="e3-section__head" data-reveal>
+					<p class="e3-kicker">Believability · Monat 1–2</p>
+					<h2 class="e3-section__title" id="datenbereinigung-title">Bereinigung der unsichtbaren Datenlecks.</h2>
+					<p class="e3-section__lede">Bevor irgendeine Optimierung greifen konnte, musste die Attribution stimmen. Ohne diesen Schritt wäre der CPL-Sturz von <?php echo esc_html( function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'cpl_before' ) : '150 €' ); ?> auf <?php echo esc_html( function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'cpl_after' ) : '22 €' ); ?> nicht reproduzierbar.</p>
+				</div>
+
+				<div class="e3-implementation-list">
+					<?php foreach ( $tracking_repair_steps as $step ) : ?>
+						<article class="e3-implementation" data-reveal>
+							<div class="e3-implementation__label"><?php echo esc_html( $step['label'] ); ?></div>
+							<div class="e3-implementation__body">
+								<h3><?php echo esc_html( $step['title'] ); ?></h3>
+								<p><?php echo esc_html( $step['body'] ); ?></p>
+							</div>
+						</article>
+					<?php endforeach; ?>
+				</div>
+			</div>
+		</section>
+
 		<section class="e3-section e3-section--paper" id="verlauf" <?php echo $tracking_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> aria-labelledby="verlauf-title">
 			<div class="e3-section__inner">
 				<div class="e3-section__head" data-reveal>
@@ -260,6 +306,19 @@ get_header();
 						</ul>
 					</div>
 				</div>
+			</div>
+		</section>
+
+		<section class="e3-section e3-section--paper" id="insight" <?php echo $tracking_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> aria-labelledby="insight-title">
+			<div class="e3-section__inner">
+				<div class="e3-section__head" data-reveal>
+					<p class="e3-kicker">True Insight</p>
+					<h2 class="e3-section__title" id="insight-title">Die fundamentale Erkenntnis aus <?php echo esc_html( function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'timeframe', 'display_dative' ) : '6 Monaten' ); ?> E3.</h2>
+				</div>
+
+				<aside class="e3-pullquote" data-reveal>
+					<p><?php echo esc_html( $insight_body ); ?></p>
+				</aside>
 			</div>
 		</section>
 

--- a/blocksy-child/page-solar-waermepumpen-leadgenerierung.php
+++ b/blocksy-child/page-solar-waermepumpen-leadgenerierung.php
@@ -1264,6 +1264,38 @@ get_header();
 		</section>
 
 		<!-- ════════════════════════════════════════════════════════════
+		     FOUNDING COHORT 2026 — Aufnahme-Protokoll
+		     ════════════════════════════════════════════════════════════ -->
+		<?php
+		$founding = function_exists( 'hu_founding_canon' ) ? hu_founding_canon() : [
+			'label'           => 'Founding Cohort 2026',
+			'slots_total'     => 3,
+			'slots_remaining' => 3,
+			'end_date'        => '2026-09-30',
+		];
+		$founding_end_iso = isset( $founding['end_date'] ) ? (string) $founding['end_date'] : '2026-09-30';
+		$founding_end_ts  = strtotime( $founding_end_iso );
+		$founding_end_de  = $founding_end_ts ? wp_date( 'd.m.Y', $founding_end_ts ) : '30.09.2026';
+		?>
+		<section class="sol-section" id="founding" data-track-section="founding_cohort">
+			<div class="sol-wrap" style="max-width:760px">
+				<div class="sol-eyebrow"><?php echo esc_html( $founding['label'] ); ?></div>
+				<h2 class="sol-display" style="margin-bottom:18px">
+					Aufnahme-Protokoll für <em><?php echo (int) $founding['slots_total']; ?> Solar- oder SHK-Betriebe</em>.
+				</h2>
+				<p style="color:var(--sol-fg-dim);font-size:18px;line-height:1.6;margin:0 0 28px">
+					Damit jede Region in Diagnose, Daten-Pipeline und Vertriebsanschluss persönlich abgebildet werden kann, nehme ich 2026 maximal <?php echo (int) $founding['slots_total']; ?> Betriebe als Founding-Partner auf. Stichtag für die Bewerbung ist der <?php echo esc_html( $founding_end_de ); ?>. Der System-Intake entscheidet, ob die Architektur zu Ihrer Region passt — keine Verkaufslogik, keine Lock-in-Klausel.
+				</p>
+				<ul class="sol-mono" style="display:grid;gap:12px;padding:0;margin:0 0 28px;list-style:none;color:var(--sol-fg);font-size:13px;letter-spacing:.04em">
+					<li><span style="color:var(--sol-accent);margin-right:10px">·</span>Plätze 2026: <?php echo (int) $founding['slots_remaining']; ?> von <?php echo (int) $founding['slots_total']; ?> noch offen</li>
+					<li><span style="color:var(--sol-accent);margin-right:10px">·</span>Bewerbungsfrist: <?php echo esc_html( $founding_end_de ); ?></li>
+					<li><span style="color:var(--sol-accent);margin-right:10px">·</span>Entscheidung: nach System-Intake · händisch · in 48 h</li>
+					<li><span style="color:var(--sol-accent);margin-right:10px">·</span>Bedingung: eigener Vertrieb · klares Zielgebiet · 12–24-Monate-Horizont</li>
+				</ul>
+			</div>
+		</section>
+
+		<!-- ════════════════════════════════════════════════════════════
 		     FINAL CTA — zurück zum Marktcheck im Hero
 		     ════════════════════════════════════════════════════════════ -->
 		<section class="sol-section sol-final" data-track-section="final_cta">


### PR DESCRIPTION
## Summary

Three text-only conversion levers, surgically inserted on the three core revenue pages. No structural rewrites, no canon changes, no infrastructure touches. Closes the gaps a Plickat-style desire/identification/belief audit surfaced against the existing copy.

- **`page-e3-new-energy.php` (+59)** — New chapter *Bereinigung der unsichtbaren Datenlecks (Monat 1–2)* between implementation and timeline, framing the Safari-ITP → server-side → first-party-attribution sequence as the believability bridge that makes the 150 € → 22 € CPL drop mathematically reproducible. New *True Insight* pullquote before the deeper section. All KPI references via `hu_e3_metric()`.
- **`front-page.php` (+24)** — New section 06b *Warum dies kein Webdesign-Projekt ist* between portal-comparison and about. Category break against standard agencies via GitHub-repo ownership and hardcoded WordPress as a performant frontend.
- **`page-solar-waermepumpen-leadgenerierung.php` (+32)** — Founding-cohort intake protocol between FAQ and final CTA, pulling slot count and deadline live from `hu_founding_canon()`.

## What was deliberately not changed

- No edits to `e3-proof-canon.php` or `founding-canon.php` — numbers stay fixed.
- No fabricated terminology like "Diaspora-Architektur" or "9 Monate E3" that Gemini's analysis suggested but the repo canon contradicts.
- No "Region blockieren" CTA — would require an actual regional exclusivity offering, which doesn't exist yet.
- No CTA-microcopy churn — existing labels are already outcome-driven.
- No infrastructure/CI changes — the 10/10 setup stays frozen.

## Test plan

- [x] `php -l` on all three modified templates
- [x] `bash scripts/lint-e3-canon.sh`
- [x] `bash scripts/validate-architecture.sh`
- [x] `bash scripts/lint-canon-drift.sh`
- [x] `bash scripts/check-german-copy.sh`
- [x] `vendor/bin/phpstan analyse` (level 5)
- [x] Grep for forbidden phrases (`Diaspora`, `9 Monate`, `Region blockieren`, `Growth Audit`, `WGOS`, `KI-Integration`) — 0 hits in the diff
- [ ] Visual check on staging: section rhythm (dark/cream alternation around the new homepage section), text width ≤ 720 px, single primary CTA per section
- [ ] Lighthouse/CWV snapshot before/after — no LCP regression expected (text-only inserts)

---
_Generated by [Claude Code](https://claude.ai/code/session_0127s63c4isg9YrcxMPVGdE5)_