### PR TITLE
fix(hero): Trust-Item entkoppelt von Site-Feature-Versprechen

### DIFF
--- a/blocksy-child/page-solar-waermepumpen-leadgenerierung.php
+++ b/blocksy-child/page-solar-waermepumpen-leadgenerierung.php
@@ -52,7 +52,7 @@ $hero_metrics = [
 $trust_items = [
 	'B2B · DACH · eigener Vertrieb',
 	'Server in Frankfurt · DSGVO',
-	'Server-Side-Tracking · CAPI',
+	'Server-Side · CAPI im Stack',
 	'Hardcoded WordPress · kein Page-Builder',
 	'1:1 Senior · keine Junior-Kette',
 	'System-Intake kostenfrei',


### PR DESCRIPTION
Der Trust-Strip-Eintrag "Server-Side-Tracking · CAPI" konnte in Verbindung mit "Server in Frankfurt · DSGVO" als Aussage ueber diese Marketing-Seite gelesen werden, obwohl SST/CAPI Bestandteil der Auslieferungs-Methodik ist und auf der Marketing-Seite selbst noch nicht eingebunden ist. "im Stack" framet die Aussage eindeutig als Architektur-Komponente und schliesst die Glaubwuerdigkeitsluecke, ohne das Versprechen abzuschwaechen.