### PR TITLE
ci: phpstan-baseline an neue category.php-Anker-Labels angepasst

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,7 +1,7 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Offset 'label' on array\\{label\\: 'Alle Analysen'\\|'Anfrage\\-Systeme'\\|'Core Web Vitals'\\|'CPL/CPO\\-Rechnung'\\|'CRO\\-System'\\|'Portalvergleich'\\|'Regionaler…'\\|'Server\\-Side Tracking'\\|'Technisches SEO'\\|'WordPress Agentur…', url\\: mixed\\} in empty\\(\\) always exists and is not falsy\\.$#"
+			message: "#^Offset 'label' on array\\{label\\: 'Alle Analysen'\\|'Anfrage\\-Systeme'\\|'Asset\\-Eigentum…'\\|'Core Web Vitals'\\|'CPL/CPO\\-Rechnung'\\|'CRO\\-System'\\|'Portal vs\\. eigenes…'\\|'Regionaler…'\\|'Server\\-Side Tracking'\\|'Strategischer…'\\|'TCO\\-Vergleich 24…'\\|'Technisches SEO'\\|'WordPress Agentur…', url\\: mixed\\} in empty\\(\\) always exists and is not falsy\\.$#"
 			count: 1
 			path: blocksy-child/category.php
 


### PR DESCRIPTION
## Kontext

PR #77 (Phase 2 — Anker-Text-Audit, commit 8778f27) wurde mit rotem CI gemerged. Die `validate`-Pipeline scheitert seitdem an PHPStan, weil die Baseline einen exakten Union-Type-Regex der `label`-Strings in `blocksy-child/category.php` pinnt — und Phase 2 hat vier dieser Labels ersetzt:

- `'Portalvergleich'` fiel weg (war 4x in category.php)
- Neu hinzugekommen: `'Asset-Eigentum Vergleichsmatrix'`, `'Portal vs. eigenes System (TCO)'`, `'Strategischer Portal-Vergleich'`, `'TCO-Vergleich 24 Monate'`

PHPStan inferiert daraus einen anderen Union-Type, die Baseline-Regel matched nicht mehr → CI fail.

## Fix

Die Baseline-Regel ist eine Phantom-Warning-Unterdrueckung (PHPStan sagt, das `empty($entry['label'])` sei redundant). Sie bleibt inhaltlich korrekt, der Union-Regex muss nur die aktuellen Literal-Strings abbilden. PHPStan kuerzt lange Strings mit Hellip; das neue Pattern uebernimmt die abgekuerzte Form aus der lokalen phpstan-Ausgabe.

## Verifikation

Lokal mit `composer install` + `vendor/bin/phpstan analyse`:
- Exit-Code: 0
- Ausgabe: `[OK] No errors`

## Test plan
- [ ] CI `validate` wird gruen
- [ ] Keine weiteren PHPStan-Errors

---
_Generated by [Claude Code](https://claude.ai/code/session_01YbuYqeGhAbfpPqNsWrE2zR)_