### PR TITLE
seo(cluster): Related-Content-Block am Footer der Vergleichsseiten

### DIFF
--- a/blocksy-child/page-eigene-leadgenerierung-vs-portale.php
+++ b/blocksy-child/page-eigene-leadgenerierung-vs-portale.php
@@ -22,6 +22,29 @@ $solar_money_url = function_exists( 'nexus_get_energy_systems_url' )
 $marktcheck_url  = trailingslashit( $solar_money_url ) . '#marktcheck';
 $e3_url          = home_url( '/e3-new-energy/' );
 
+$linked_assets = [
+	[
+		't'   => 'CPL pro Anfrage: Solar Leads kaufen oder eigenes System?',
+		's'   => 'Die konkrete Kosten-pro-Anfrage-Rechnung mit E3-Benchmark und Portal-Preisspannen.',
+		'url' => home_url( '/solar-leads-kaufen-alternative/' ),
+	],
+	[
+		't'   => 'Lead-Funnel Solar (Pillar)',
+		's'   => 'Funnel-Architektur fürs eigene Anfrage-System — was nach der Entscheidung gegen Portale folgt.',
+		'url' => home_url( '/lead-funnel-solar/' ),
+	],
+	[
+		't'   => 'Cost per Lead Photovoltaik',
+		's'   => 'CPL-Drill-down mit drei Szenarien — die Zahlen-Tiefe hinter dem strategischen TCO-Vergleich.',
+		'url' => home_url( '/cost-per-lead-photovoltaik/' ),
+	],
+	[
+		't'   => 'B2B Solar Leads für gewerbliche Projekte',
+		's'   => 'Buying-Center-Funnel für gewerbliche Photovoltaik ab 50.000 € — Pendant zum B2C-Vergleich.',
+		'url' => home_url( '/b2b-solar-leads/' ),
+	],
+];
+
 // ── E3-Canon ──────────────────────────────────────────────────
 $e3_canon            = function_exists( 'hu_e3_canon' ) ? hu_e3_canon() : [];
 $e3_metrics          = isset( $e3_canon['metrics'] ) && is_array( $e3_canon['metrics'] ) ? $e3_canon['metrics'] : [];
@@ -312,6 +335,20 @@ get_header();
 				<?php foreach ( $when_rent_makes_sense as $item ) : ?>
 					<article class="hu-intercept__card">
 						<h3 class="hu-intercept__card-title"><?php echo esc_html( $item['t'] ); ?></h3>
+						<p class="hu-intercept__card-text"><?php echo esc_html( $item['s'] ); ?></p>
+					</article>
+				<?php endforeach; ?>
+			</div>
+		</div>
+	</section>
+
+	<section class="hu-intercept__why" id="vertiefung" aria-labelledby="hu-vs-linked-title">
+		<div class="hu-intercept__container">
+			<h2 class="hu-intercept__h2" id="hu-vs-linked-title">Vertiefende Bausteine: vom Vergleich zur Umsetzung</h2>
+			<div class="hu-intercept__grid hu-intercept__grid--four">
+				<?php foreach ( $linked_assets as $item ) : ?>
+					<article class="hu-intercept__card">
+						<h3 class="hu-intercept__card-title"><a href="<?php echo esc_url( $item['url'] ); ?>"><?php echo esc_html( $item['t'] ); ?></a></h3>
 						<p class="hu-intercept__card-text"><?php echo esc_html( $item['s'] ); ?></p>
 					</article>
 				<?php endforeach; ?>

--- a/blocksy-child/page-solar-leads-kaufen-alternative.php
+++ b/blocksy-child/page-solar-leads-kaufen-alternative.php
@@ -22,6 +22,29 @@ $marktcheck_url  = trailingslashit( $solar_money_url ) . '#marktcheck';
 $e3_url          = home_url( '/e3-new-energy/' );
 $contact_url     = home_url( '/kontakt/' );
 
+$linked_assets = [
+	[
+		't'   => 'Strategischer TCO-Vergleich über 24 Monate',
+		's'   => 'Portal-Leads gegen eigenes Anfrage-System mit CAPEX-vs-OPEX-Logik und Asset-Eigentum.',
+		'url' => home_url( '/eigene-leadgenerierung-vs-portale/' ),
+	],
+	[
+		't'   => 'Lead-Funnel Solar (Pillar)',
+		's'   => 'Die 5 Funnel-Stufen vom Erstkontakt zur qualifizierten Anfrage — und die häufigsten Fehler.',
+		'url' => home_url( '/lead-funnel-solar/' ),
+	],
+	[
+		't'   => 'Cost per Lead Photovoltaik',
+		's'   => 'Drei CPL-Szenarien im Vergleich und welche versteckten Kostentreiber den CPL hochtreiben.',
+		'url' => home_url( '/cost-per-lead-photovoltaik/' ),
+	],
+	[
+		't'   => 'Kunden gewinnen für Solarteure',
+		's'   => 'Wie Solar- und Wärmepumpen-Anbieter im DACH-Mittelstand ohne DAA, Aroundhome und Check24 wachsen.',
+		'url' => home_url( '/kunden-gewinnen-solarteure/' ),
+	],
+];
+
 // ── E3-Proof-Canon ─────────────────────────────────────────────
 $e3_canon            = function_exists( 'hu_e3_canon' ) ? hu_e3_canon() : [];
 $e3_metrics          = isset( $e3_canon['metrics'] ) && is_array( $e3_canon['metrics'] ) ? $e3_canon['metrics'] : [];
@@ -360,6 +383,20 @@ get_header();
 					</li>
 				<?php endforeach; ?>
 			</ol>
+		</div>
+	</section>
+
+	<section class="hu-intercept__why" id="vertiefung" aria-labelledby="hu-intercept-linked-title">
+		<div class="hu-intercept__container">
+			<h2 class="hu-intercept__h2" id="hu-intercept-linked-title">Vertiefende Bausteine im Anfrage-System</h2>
+			<div class="hu-intercept__grid hu-intercept__grid--four">
+				<?php foreach ( $linked_assets as $item ) : ?>
+					<article class="hu-intercept__card">
+						<h3 class="hu-intercept__card-title"><a href="<?php echo esc_url( $item['url'] ); ?>"><?php echo esc_html( $item['t'] ); ?></a></h3>
+						<p class="hu-intercept__card-text"><?php echo esc_html( $item['s'] ); ?></p>
+					</article>
+				<?php endforeach; ?>
+			</div>
 		</div>
 	</section>
 


### PR DESCRIPTION
## Summary

Phase 3 des SEO-Hebel-Pakets. Beide Vergleichsseiten bekommen einen kuratierten "Vertiefende Bausteine"-Block direkt vor der FAQ, mit je 4 Cards. Etabliertes `hu-intercept__why` + `grid--four`-Pattern (wie page-lead-funnel-solar). Keine neuen CSS-Klassen.

## Warum

Beide Vergleichsseiten endeten bisher abrupt mit FAQ → Final-CTA, ohne dass Google das umliegende Cluster (Lead-Funnel, CPL-Photovoltaik, kunden-gewinnen-solarteure, b2b-solar-leads) als zusammengehoerigen Topical-Authority-Block erkennen konnte. Der Block schliesst diese Luecke.

## Kuration

**`/solar-leads-kaufen-alternative/` (transactional)** linkt auf:
- Strategischer TCO-Vergleich (Page B)
- Lead-Funnel Solar (Pillar)
- Cost per Lead Photovoltaik (CPL-Drill-down)
- Kunden gewinnen fuer Solarteure (adjacent transactional)

**`/eigene-leadgenerierung-vs-portale/` (strategisch)** linkt auf:
- CPL-Rechnung pro Anfrage (Page A)
- Lead-Funnel Solar (Pillar)
- Cost per Lead Photovoltaik (Drill-down)
- B2B Solar Leads (gewerbliches Pendant)

Anker-Texte folgen der Phase-2-Hierarchie: distinct zueinander und distinct gegen die Hero-Cross-Links. H2s sind absichtlich unterschiedlich, damit nicht erneut Sektions-Titel kollidieren.

## Verifikation
- `php -l`: beide Pages clean
- `vendor/bin/phpstan analyse`: Exit 0, `[OK] No errors`

## Test plan
- [ ] CI gruen (validate, german-copy, link-checker)
- [ ] Optisch: 4-Card-Grid rendert vor FAQ auf beiden Pages
- [ ] Links funktionieren und tracken (keine `data-track-*` noetig hier — bewusst, weil die Cards sich von CTA-Klicks unterscheiden sollen)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YbuYqeGhAbfpPqNsWrE2zR)_