### PR TITLE
Über-mich (Editorial) neu texten: belegter Karriere-Bogen statt Herkunfts-DNA

### DIFF
--- a/blocksy-child/template-about-editorial.php
+++ b/blocksy-child/template-about-editorial.php
@@ -21,16 +21,16 @@ $portrait_path = get_stylesheet_directory() . '/assets/img/hasim-portrait.png';
 // Biografischer Pfad — von Herkunft zur Methode.
 $about_hero_path = [
 	[
-		't' => 'Die Unternehmer-DNA',
-		's' => 'Aufgewachsen im Bauunternehmen des Vaters. Vertrieb, Margendruck und das wirtschaftliche Risiko von Kindesbeinen an verstanden.',
+		't' => 'Die Vertriebs-Schule',
+		's' => 'Aufgewachsen im – bis heute aktiven – Bauunternehmen des Vaters. Danach acht Jahre B2B-Beratung am echten Entscheider: Bedarf erkennen, Einwände auflösen, verbindlich abschließen. Gelernt im Gespräch, nicht im Seminar.',
 	],
 	[
-		't' => 'Die medienwissenschaftliche Struktur',
-		's' => 'Systeme dekonstruieren. Analysieren, wie digitale Zeichen, Signale und Kanäle Märkte und menschliche Entscheidungen steuern.',
+		't' => 'Der analytische Blick',
+		's' => 'Medienwissenschaft als Werkzeugkasten, nicht als Elfenbeinturm. Ich sehe, wo Daten fließen, wo Aufmerksamkeit im Funnel versickert und welches Signal über Vertrauen oder Wegklicken entscheidet.',
 	],
 	[
-		't' => 'Die Fusion im Anfrage-System',
-		's' => 'Vertriebs-Verstand trifft präzise Daten-Integrität. Für Betriebe, die ihre eigene Nachfrage besitzen wollen, statt Leads zu mieten.',
+		't' => 'Der eigene Beweis',
+		's' => 'Eigenen Shop von Null aufgebaut und am eigenen Geld gespürt, was Plattform-Abhängigkeit kostet. Dieselbe Logik auf Energie skaliert — und bei E3 New Energy bewiesen.',
 	],
 ];
 
@@ -40,18 +40,18 @@ $about_work_principles = [
 		'eyebrow' => 'Überzeugung I',
 		'title'   => 'Code muss verkaufen, nicht informieren.',
 		'body'    => 'Die meisten Websites sind digitale Hochglanz-Prospekte. Wer selbst aus dem Vertrieb kommt, weiß: Eine B2B-Website hat eine Aufgabe — Abschlüsse vorzubereiten. Ein eigenes Anfrage-System ist kein Informationsfriedhof, sondern ein scharf kalkulierter Filter, der unqualifizierte Anfragen abweist und kaufbereite Entscheider isoliert.',
-		'detail'  => 'Wenn die technische Struktur die Sprache des Vertriebs nicht spricht, ist sie wertlos.',
+		'detail'  => 'Wer acht Jahre im B2B-Vertrieb stand, weiß: Wenn die technische Struktur die Sprache des Vertriebs nicht spricht, ist sie wertlos.',
 	],
 	[
 		'eyebrow' => 'Überzeugung II',
 		'title'   => 'Mieten ist teuer. Eigentum ist planbar.',
 		'body'    => 'Im Bau- und Energiesektor gilt: Wer Maschinen, Hallen und Grundstücke nur mietet, macht sich erpressbar. Beim wichtigsten Gut — den Kundenanfragen — tun viele Betriebe genau das. Wer Leads bei Portalen kauft, füttert fremde Plattformen, teilt sich Kontakte mit Mitbewerbern und steht unter dauerhaftem Margendruck.',
-		'detail'  => 'Eigentum schlägt Miete. Auch im Vertrieb.',
+		'detail'  => 'Ich habe das nicht nur beobachtet — ich habe meinen eigenen Shop aufgebaut und am eigenen Umsatz gespürt, was es heißt, die eigene Nachfrage zu besitzen statt zu mieten. Eigentum schlägt Miete. Auch im Vertrieb.',
 	],
 	[
 		'eyebrow' => 'Überzeugung III',
 		'title'   => 'Daten-Integrität schlägt Bauchgefühl.',
-		'body'    => 'Wenn Tracking nur Klicks statt unterschriebene Werkverträge misst, verbrennt Werbebudget auf den falschen Kanälen. Erst wenn serverseitiges Tracking und CRM nahtlos verschmelzen, sehen die Werbekanäle, wo der echte Profit liegt — und optimieren auf Umsatz statt auf bunte Grafiken.',
+		'body'    => 'Wenn Tracking nur Klicks statt unterschriebene Werkverträge misst, verbrennt Werbebudget auf den falschen Kanälen. Erst wenn serverseitiges Tracking und CRM nahtlos verschmelzen, sehen die Werbekanäle, wo der echte Profit liegt — und optimieren auf Umsatz statt auf Klicks, die niemand bezahlt hat.',
 		'detail'  => 'Saubere Datenarchitektur ist der einzige Hebel für planbare Skalierung.',
 	],
 ];
@@ -66,7 +66,7 @@ get_header();
 			<!-- HERO -->
 			<header class="about-editorial__hero">
 				<span class="about-editorial__kicker">Inquiry Systems Architect</span>
-				<h1 class="about-editorial__h1">Vertriebs-Pragmatismus trifft Mediensystem-Analyse.</h1>
+				<h1 class="about-editorial__h1">Ich habe am Küchentisch gelernt, was eine schlechte Anfrage kostet.</h1>
 				<p class="about-editorial__lead">
 					Ich entwerfe keine austauschbaren Webseiten. Ich konstruiere autarke Anfrage-Systeme für den inhabergeführten Solar- und SHK-Mittelstand.
 				</p>
@@ -111,7 +111,7 @@ get_header();
 						</div>
 						<div class="about-editorial__meta-row">
 							<dt>Methode</dt>
-							<dd>Sovereign Demand System</dd>
+							<dd>Anfrage-Kraftwerk</dd>
 						</div>
 					</dl>
 				</aside>
@@ -138,9 +138,11 @@ get_header();
 			<section class="about-editorial__bio" id="about-editorial-hintergrund">
 				<h2 class="about-editorial__section-kicker">Der Hintergrund</h2>
 				<div class="about-editorial__bio-prose">
-					<p class="about-editorial__dropcap">Mein Vater war Bauunternehmer. Ich bin mit dem Wissen aufgewachsen, was es bedeutet, Verantwortung für Projekte, Margen und ein fest angestelltes Team zu tragen. Vertrieb und Unternehmertum wurden mir nicht in Seminaren beigebracht — sie sind meine DNA.</p>
-					<p>Mein Studium der Medienwissenschaft an der Universität Paderborn war kein Elfenbeinturm, sondern ein logischer Werkzeugkasten. Ich habe gelernt, komplexe Informationssysteme radikal zu dekonstruieren. Ich schaue nicht darauf, was auf einer Website schön aussieht. Ich analysiere, wie Daten fließen, wo Aufmerksamkeit im Funnel versickert und welche unsichtbaren Signale zwischen einer digitalen Oberfläche und einem B2B-Entscheider übertragen werden müssen, damit echtes Vertrauen entsteht.</p>
-					<p>Die meisten WordPress-Websites scheitern, weil sie von Designern gebaut wurden, die nie ein echtes Verkaufsgespräch geführt haben. Sie informieren den Nutzer zu Tode, statt Entscheidungen zu provozieren. Ich fusioniere den Vertriebs-Pragmatismus des Bauwesens mit der analytischen Präzision der Medienwissenschaft. Seit dem Case bei E3 New Energy wende ich diese Methode exklusiv auf den Solar- und Wärmepumpen-Mittelstand an.</p>
+					<p class="about-editorial__dropcap">Mein Vater ist Bauunternehmer. Ich bin mit dem Wissen aufgewachsen, was es heißt, Verantwortung für Projekte, Margen und ein fest angestelltes Team zu tragen — und trage es bis heute mit, wenn am Küchentisch über Auftragslage und Zahlungsmoral geredet wird.</p>
+					<p>Vertrieb habe ich danach nicht in Seminaren gelernt, sondern in acht Jahren B2B-Beratung: Bedarf strukturiert aufnehmen, mit Entscheidern verbindlich kommunizieren, langfristige Beziehungen über zuverlässige Follow-ups halten.</p>
+					<p>Dann habe ich selbst gegründet — einen eigenen Online-Shop, von der ersten Zeile Code bis zur letzten Conversion. Dort habe ich am eigenen Geld erlebt, was es bedeutet, seine Nachfrage selbst zu erzeugen, statt sie von Plattformen zu mieten. Genau diese Erfahrung ist der Kern dessen, was ich heute baue.</p>
+					<p>Mein Studium der Medienwissenschaft an der Universität Paderborn war dabei der analytische Werkzeugkasten: Ich schaue nicht darauf, was auf einer Website schön aussieht, sondern wie Daten fließen, wo Aufmerksamkeit versickert und welche Signale zwischen Oberfläche und B2B-Entscheider übertragen werden müssen, damit Vertrauen entsteht.</p>
+					<p>Die meisten WordPress-Websites scheitern, weil sie von Designern gebaut wurden, die nie ein echtes Verkaufsgespräch geführt haben. Sie informieren den Nutzer zu Tode, statt Entscheidungen zu provozieren. Ich verbinde acht Jahre Vertriebs-Pragmatismus mit analytischer Präzision — und seit dem Case bei E3 New Energy (−83 % Cost-per-Lead, über 1.750 qualifizierte Anfragen in neun Monaten) wende ich diese Methode exklusiv auf den Solar- und Wärmepumpen-Mittelstand an.</p>
 				</div>
 			</section>
 


### PR DESCRIPTION
## Ziel
Verlagert das Gewicht der Über-mich-Seite (`/uber-mich/`) von einer Herkunfts-Behauptung ("Vertrieb ist meine DNA, von Kindesbeinen an") auf einen belegten Karriere-Bogen: 8 Jahre B2B-Beratung → eigener Shop → E3-Ergebnis. Konkretes statt Schicksal.

**Nur Copy geändert.** Layout, Struktur, Klassen, Komponenten und der CTA-Block bleiben unangetastet (16 insertions / 14 deletions in einer Datei).

## Quelle
`blocksy-child/template-about-editorial.php` (Template "Über Mich (Editorial)"). Die neue Copy passt 1:1 auf dessen Struktur (Eyebrow *Inquiry Systems Architect*, *Evolution der Methode*, Profil-Karte, *Unternehmer-Manifest*, *Der Hintergrund*).

> Hinweis: Welches der beiden Über-mich-Templates die Live-Seite nutzt, ist editor-/DB-seitig festgelegt. Damit diese Änderungen sichtbar werden, muss der Seite `/uber-mich/` das Template **„Über Mich (Editorial)"** zugewiesen sein.

## Änderungen
- **H1** → "Ich habe am Küchentisch gelernt, was eine schlechte Anfrage kostet." (Subline unverändert)
- **Evolution der Methode** als realer Bogen: Vertriebs-Schule → analytischer Blick → eigener Beweis
- **Tempus:** Vater "war" → "ist" (Betrieb aktiv); durchgehend Präsens
- **Eine Leitmetapher:** "Anfrage-Kraftwerk"; "Sovereign Demand System" ersatzlos gestrichen
- **Manifest:** je 1 Beleg-Satz für Überzeugung I (8 Jahre B2B) und II (eigener Shop); III "bunte Grafiken" → "Klicks, die niemand bezahlt hat"
- **Der Hintergrund** komplett neu: B2B-Beratung + eigener Shop + E3-Beleg
- "dekonstruieren" entfernt (vorher 2×, jetzt 0×), Akademik runtergefahren

## Verifikation
- ✅ kein "Vater war" mehr
- ✅ kein "Sovereign Demand System"
- ✅ "dekonstruieren" ≤ 1× (= 0)
- ✅ kein politischer / `.org` / Zwischenräume-Bezug
- ✅ E3-Zahlen vorhanden (−83 % CPL, 1.750+ Anfragen)
- ✅ `php -l` ohne Syntaxfehler

## Offener Punkt zur Klärung
Die in der Vorgabe genannten E3-Zahlen (**−83 % CPL**, **neun Monate**) weichen vom Repo-Canon `blocksy-child/inc/canon/e3-proof-canon.php` ab (dort **über 85 %** und **6 Monate**, `1.750+` deckt sich). Ich habe die Vorgabe 1:1 umgesetzt — falls Canon-Konsistenz gewünscht ist, bitte kurz Bescheid geben.

https://claude.ai/code/session_01T8sTsLh4ijfjFJxmgiH6B7

---
_Generated by [Claude Code](https://claude.ai/code/session_01T8sTsLh4ijfjFJxmgiH6B7)_