### PR TITLE
CRO: Primären Marktcheck-CTA im Homepage-Hero ergänzen

### DIFF
--- a/blocksy-child/assets/css/homepage-redesign.css
+++ b/blocksy-child/assets/css/homepage-redesign.css
@@ -273,7 +273,13 @@
   align-items: center;
   gap: 18px;
   flex-wrap: wrap;
-  margin-bottom: 20px;
+  margin-bottom: 12px;
+}
+.hu-hp .hu-hero__cta-note {
+  color: var(--fg-2);
+  font-size: 13px;
+  margin: 0 0 24px;
+  opacity: 0.85;
 }
 .hu-hp .hu-hero__bullets {
   list-style: none;

--- a/blocksy-child/front-page.php
+++ b/blocksy-child/front-page.php
@@ -142,6 +142,19 @@ get_header();
 					Ich prüfe, wo Website, Vorqualifizierung, Tracking und Werbekanäle aktuell Anfragen verlieren — und welche Hebel zuerst greifen.
 				</p>
 
+				<div class="hu-hero__ctas">
+					<a href="<?php echo esc_url( $analysis_url ); ?>" class="hu-btn hu-btn-primary"
+					   data-track-action="cta_home_hero_marktcheck" data-track-category="lead_gen" data-track-section="01">
+						Marktcheck starten — 60 Sekunden
+						<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+					</a>
+					<a href="<?php echo esc_url( $e3_case_url ); ?>" class="hu-btn hu-btn-link"
+					   data-track-action="cta_home_hero_proof" data-track-category="proof" data-track-section="01">
+						E3-Case ansehen
+					</a>
+				</div>
+				<p class="hu-hero__cta-note">Keine neue Website auf Verdacht. Erst Diagnose, dann Entscheidung.</p>
+
 				<div class="hu-hero__stats">
 					<div>
 						<div class="hu-stat-num"><?php echo esc_html( $e3_lead_count ); ?></div>


### PR DESCRIPTION
Der Hero hatte bisher keinen eigenen CTA-Button — kalter Traffic musste erst zur Gateway-Band scrollen, um den ersten klickbaren Schritt zu finden. Das ist die wichtigste Conversion-Fläche vor dem Akquise-Start.

- Primär-CTA "Marktcheck starten — 60 Sekunden" auf $analysis_url
- Sekundär-Link "E3-Case ansehen" auf den Proof-Case
- Reassurance-Microcopy "Erst Diagnose, dann Entscheidung" (Audit P1.4)
- Tracking-Events cta_home_hero_marktcheck / cta_home_hero_proof (deckt den im Conversion-Audit geforderten "hero marketcheck CTA click")
- Nutzt die bereits im Stylesheet vorhandene, aber ungenutzte .hu-hero__ctas-Klasse inkl. Mobile-Full-Width; .hu-hero__cta-note ergänzt

https://claude.ai/code/session_01EjQKSosuVigFTaPUMT4A8P