### PR TITLE
Solar-LP v2: Ink/Creme-Redesign auf hu-hp-Kit + Marktcheck-CRO mit PLZ-Feld

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## 2026-06
 
+### Solar-Landingpage v2: Ink/Creme-Redesign + Marktcheck-CRO
+
+- `/solar-waermepumpen-leadgenerierung/` komplett auf das geteilte `.hu-hp`-Brand-System umgestellt (Ink `#0B0F12` im Wechsel mit Creme-Sektionen, Kupfer `#E08A3C`) — Basis ist der Claude-Design-Handoff „Solar-Leadgenerierung v2"; `homepage-redesign.css` wird wiederverwendet, das Page-CSS ist nur noch ein schlankes Delta (~3.100 → ~950 Zeilen).
+- Neuer Hero: Headline „Hören Sie auf, Anfragen zu mieten." mit Kupfer-Akzent, rotierende Kupfer-Sonne (32 Strahlen, SVG, `prefers-reduced-motion`-sicher), animiertes CPL-Balken-Chart (150 € → 22 € aus `hu_e3_canon`), Count-up-Stats; Marktcheck-Formular bleibt above the fold in der rechten Spalte (dunkle Card).
+- Marktcheck-CRO: Frage-Copy verkürzt („Wer verkauft bei Ihnen?" / „Was kostet Sie Akquise heute?" / „Wohin darf der Befund?"), Telefon-Feld entfernt, **Firmen-PLZ-Feld neu** (`postal_code`, fünfstellig validiert — speist die Regions-Verfügbarkeitsprüfung, Backend-Feld existierte bereits); REST-Kontrakt, Attribution, GA4-Events und Success-Logik unverändert (Smoke-Test grün).
+- Sektionen auf Kit-Komponenten umgezogen: Kostenkarten, Compare („Portal-Miete vs. eigener Anfrageweg"), Phasen mit Asset-Panel, CAPEX/OPEX als Modell-Karten (12/24/36-Toggle erhalten), E3-Proof als Vorher/Nachher + Stats, Fit-Grid, Risiko-Umkehr „Diagnose vor Pitch.", Vertiefung, FAQ (alle 11 Items + Schema erhalten); Founding-Cohort- und Final-CTA-Sektion zu einem `hu-final-cta`-Block gemerged.
+- System-Diagramm-Sektion (`#system-bild`) aufgelöst — Inhalt kondensiert ins Phasen-Asset-Panel; Canon-Fix: kundenseitige „Module" durchgängig zu „Bausteinen".
+
 ### CRO-Microcopy & CTA-Konsistenz
 
 - Trust-Microcopy „kostenlos & unverbindlich" für den Marktcheck am Homepage-Hero und in der Solar-Quiz-Card (SSR-Bullet + JS-Fineprint) — Kostenunsicherheit war der größte Reibungspunkt für kalten Traffic; die bezahlte Diagnose bleibt davon klar getrennt.

--- a/blocksy-child/assets/css/solar-leadgenerierung-solara.css
+++ b/blocksy-child/assets/css/solar-leadgenerierung-solara.css
@@ -1,2016 +1,649 @@
 /* ══════════════════════════════════════════════════════════════
-   /solar-waermepumpen-leadgenerierung/ — SOLARA visual language
-   Premium · cinematic · minimalistisch mit AHA-Wirkung.
-   HYBRID-Theme: warm-cremes Grundtuch (B2B-Mittelstand-Vertrauen),
-   dunkle Sonne nur als zentrales Visual & Final-CTA-Anker.
-   Scope: alles unter .solara-landing.
-   Tokens: Satoshi · Figtree · JetBrains Mono · Copper #b46a3c.
+   /solar-waermepumpen-leadgenerierung/ — SOLARA v2 (Ink/Creme)
+   Page-Delta zum geteilten .hu-hp-Brand-Kit (homepage-redesign.css).
+   Der Wrapper trägt beide Klassen: <div class="solara-landing hu-hp">.
+   - Kit liefert Tokens + Komponenten (hu-section, hu-compare, hu-models,
+     hu-proof-*, hu-fit-*, hu-process-*, hu-deeper-*, hu-final-cta …).
+   - Diese Datei liefert nur: Kit-Drift-Overrides, Hero-Spezifika
+     (Sonne, CPL-Balken), Marktcheck-Quiz-Skin, Trust/Nav/Sticky-CTA.
+   Währungs-Doktrin: ausnahmslos EUR (€).
    ══════════════════════════════════════════════════════════════ */
 
+/* ─── 1) Wrapper & Theme-Bleed-Schutz ───────────────────────── */
 .solara-landing {
-  /* warm-cream Grundpalette (Mittelstand-credible) */
-  --sol-bg:       oklch(0.97 0.008 80);
-  --sol-bg-2:     oklch(0.95 0.010 78);
-  --sol-bg-3:     oklch(0.92 0.014 75);
-  --sol-bg-warm:  oklch(0.94 0.020 70);
+  background: var(--bg);
+  overflow-x: clip;
+}
+.solara-landing ::selection { background: #E08A3C; color: #1A0F05; }
+.solara-landing .sol-mono { font-family: 'JetBrains Mono', 'Fira Code', ui-monospace, monospace; }
 
-  --sol-line:     oklch(0.88 0.010 75);
-  --sol-line-2:   oklch(0.80 0.012 70);
-  --sol-line-3:   oklch(0.72 0.014 65);
+/* Headings: Satoshi-Display + korrekte Farben je Sektionstyp.
+   Niedrige Spezifität als Basis, damit Kit-Komponenten (hu-final-cta h2
+   etc.) ihre Maße behalten; Farbe/Font müssen aber Theme-Bleed schlagen. */
+.hu-hp.solara-landing :is(h1, h2, h3, h4) {
+  font-family: 'Satoshi', 'Figtree', sans-serif;
+  color: var(--fg);
+}
+.hu-hp.solara-landing .hu-section--cream :is(h2, h3, h4) { color: var(--ink); }
+.hu-hp.solara-landing .hu-display { font-family: 'Satoshi', 'Figtree', sans-serif; }
+.solara-landing p { margin-top: 0; }
 
-  --sol-fg:       oklch(0.18 0.012 60);
-  --sol-fg-mute:  oklch(0.42 0.014 60);
-  --sol-fg-dim:  oklch(0.58 0.014 60);
+/* Sektions-Rhythmus etwas dichter als Homepage (Landingpage-Tempo) */
+.hu-hp.solara-landing .hu-section { padding: clamp(56px, 8vw, 112px) 0; }
 
-  /* Copper-Akzent aus Hasim's Design-System */
-  --sol-accent:     #b46a3c;
-  --sol-accent-2:   #c97a1a;
-  --sol-accent-ink: #ffffff;
-  --sol-accent-tint:    rgba(180,106,60,.08);
-  --sol-accent-tint-2:  rgba(180,106,60,.18);
-
-  /* Status-Farben (semantisch) */
-  --sol-good:       oklch(0.52 0.16 145);
-  --sol-info:       oklch(0.48 0.14 230);
-
-  --sol-t-fast: 160ms;
-  --sol-t-med:  240ms;
-  --sol-gutter: clamp(20px, 4vw, 56px);
-  --sol-maxw:   1320px;
-  --sol-radius: 14px;
-
-  --sol-font-display: 'Satoshi', 'Figtree', -apple-system, BlinkMacSystemFont, sans-serif;
-  --sol-font-body:    'Figtree', -apple-system, BlinkMacSystemFont, sans-serif;
-  --sol-font-mono:    'JetBrains Mono', 'Fira Code', ui-monospace, monospace;
-
-  position: relative;
-  background: var(--sol-bg);
-  color: var(--sol-fg);
-  font-family: var(--sol-font-body);
-  line-height: 1.5;
-  overflow-x: hidden;
-  -webkit-font-smoothing: antialiased;
-}
-
-/* sehr feines Raster — Engineering-Atmosphäre statt Dekor */
-.solara-landing::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  z-index: 1;
-  background-image:
-    linear-gradient(oklch(0.30 0.012 60 / 0.04) 1px, transparent 1px),
-    linear-gradient(90deg, oklch(0.30 0.012 60 / 0.04) 1px, transparent 1px);
-  background-size: 64px 64px;
-  opacity: 0.5;
-}
-
-.solara-landing * { box-sizing: border-box; }
-
-/* ── Layout-Basis ─────────────────────────────────────────── */
-.solara-landing .sol-wrap {
-  max-width: var(--sol-maxw);
-  margin: 0 auto;
-  padding-left: var(--sol-gutter);
-  padding-right: var(--sol-gutter);
-  position: relative;
-  z-index: 3;
-}
-.solara-landing .sol-section {
-  padding: clamp(80px, 11vw, 160px) 0;
-  position: relative;
-  z-index: 3;
-}
-.solara-landing .sol-section--tinted { background: var(--sol-bg-2); }
-.solara-landing .sol-section--warm   { background: var(--sol-bg-warm); }
-
-/* ── Typo ─────────────────────────────────────────────────── */
-.solara-landing .sol-display {
-  font-family: var(--sol-font-display);
-  font-weight: 600;
-  line-height: 0.95;
-  letter-spacing: -0.035em;
-  text-wrap: balance;
-  color: var(--sol-fg);
-}
-.solara-landing .sol-display em {
-  font-style: normal;
-  color: var(--sol-accent);
-}
-.solara-landing .sol-mono {
-  font-family: var(--sol-font-mono);
-  font-size: 11px;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--sol-fg-mute);
-}
-.solara-landing .sol-eyebrow {
-  font-family: var(--sol-font-mono);
-  font-size: 11px;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--sol-accent);
-  display: inline-flex;
-  align-items: center;
-  gap: 0.6em;
-}
-.solara-landing .sol-eyebrow::before {
-  content: "";
-  width: 18px;
-  height: 1px;
-  background: currentColor;
-  opacity: 0.6;
-}
-
-/* ── Buttons ──────────────────────────────────────────────── */
-.solara-landing .sol-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 10px;
-  padding: 14px 22px;
-  border-radius: 999px;
-  font-family: var(--sol-font-body);
-  font-weight: 600;
-  font-size: 14px;
-  line-height: 1;
-  letter-spacing: 0.01em;
-  border: 1px solid transparent;
-  cursor: pointer;
-  text-decoration: none;
-  transition: transform var(--sol-t-fast), background var(--sol-t-fast), color var(--sol-t-fast), border-color var(--sol-t-fast), box-shadow var(--sol-t-fast);
-  white-space: nowrap;
-}
-.solara-landing .sol-btn-primary {
-  background: var(--sol-accent);
-  color: var(--sol-accent-ink);
-  box-shadow: 0 10px 24px -8px rgba(180,106,60,.45);
-}
-.solara-landing .sol-btn-primary:hover {
-  background: var(--sol-accent-2);
-  transform: translateY(-1px);
-  box-shadow: 0 14px 28px -8px rgba(201,122,26,.5);
-}
-.solara-landing .sol-btn-ghost {
-  background: transparent;
-  color: var(--sol-fg);
-  border-color: var(--sol-line-2);
-}
-.solara-landing .sol-btn-ghost:hover {
-  background: var(--sol-accent-tint);
-  border-color: var(--sol-accent);
-  color: var(--sol-accent);
-}
-.solara-landing .sol-btn-arrow {
-  width: 24px;
-  height: 24px;
-  border-radius: 50%;
-  background: currentColor;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
-.solara-landing .sol-btn-primary .sol-btn-arrow {
-  background: rgba(255,255,255,.22);
-  color: var(--sol-accent-ink);
-}
-.solara-landing .sol-btn-arrow svg { width: 12px; height: 12px; }
-
-/* ── Selection & Focus ────────────────────────────────────── */
-.solara-landing ::selection { background: var(--sol-accent); color: var(--sol-accent-ink); }
-.solara-landing a:focus-visible,
-.solara-landing button:focus-visible {
-  outline: 2px solid var(--sol-accent);
-  outline-offset: 3px;
-  border-radius: 6px;
-}
-
-/* ══════════════════════════════════════════════════════════════
-   HERO — warm-cremes Sonnenfeld (hybrid: helles AHA-Visual)
-   ══════════════════════════════════════════════════════════════ */
-.solara-landing .sol-hero {
-  position: relative;
-  isolation: isolate;
-  padding: clamp(40px, 6vw, 80px) 0 clamp(80px, 11vw, 140px);
-  overflow: hidden;
-  min-height: 86vh;
-}
-.solara-landing .sol-hero-sky {
-  position: absolute;
-  inset: 0;
-  z-index: -2;
-  pointer-events: none;
-  background:
-    radial-gradient(ellipse 70% 55% at 50% 110%, oklch(0.86 0.16 65 / 0.55), transparent 55%),
-    linear-gradient(180deg, oklch(0.97 0.008 80) 0%, oklch(0.95 0.020 72) 55%, oklch(0.91 0.060 60) 100%);
-}
-.solara-landing .sol-hero-sun {
-  position: absolute;
-  left: 50%;
-  bottom: -28%;
-  z-index: -1;
-  width: min(1100px, 110vw);
-  aspect-ratio: 1;
-  transform: translate(-50%, 0);
-  pointer-events: none;
-}
-.solara-landing .sol-hero-sun-disc {
-  position: absolute;
-  inset: 22%;
-  border-radius: 50%;
-  background:
-    radial-gradient(circle at 50% 45%,
-      oklch(0.95 0.16 80) 0%,
-      oklch(0.85 0.18 65) 38%,
-      oklch(0.70 0.20 50) 70%,
-      transparent 100%);
-  filter: blur(2px);
-  animation: sol-pulse 7s ease-in-out infinite;
-  opacity: 0.85;
-}
-.solara-landing .sol-hero-sun-halo {
-  position: absolute;
-  inset: -8%;
-  border-radius: 50%;
-  background: radial-gradient(circle, rgba(201,122,26,.22) 0%, transparent 60%);
-  filter: blur(28px);
-  animation: sol-pulse 9s ease-in-out infinite reverse;
-}
-.solara-landing .sol-hero-sun-rays {
-  position: absolute;
-  inset: 0;
-  display: grid;
-  place-items: center;
-  opacity: 0.18;
-  animation: sol-spin 240s linear infinite;
-}
-.solara-landing .sol-hero-sun-ray {
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  width: 1px;
-  height: 56%;
-  background: linear-gradient(0deg, transparent 0%, var(--sol-accent) 60%, transparent 100%);
-  transform-origin: center top;
-}
-.solara-landing .sol-hero-horizon {
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 22%;
-  z-index: 0;
-  height: 1px;
-  background: linear-gradient(90deg, transparent, var(--sol-accent) 25%, var(--sol-accent) 75%, transparent);
-  opacity: 0.55;
-}
-
-@keyframes sol-pulse {
-  0%, 100% { transform: scale(1); opacity: 0.9; }
-  50%      { transform: scale(1.03); opacity: 1; }
-}
-@keyframes sol-spin { to { transform: rotate(360deg); } }
-@keyframes sol-pulse-dot { 50% { transform: scale(1.3); opacity: 0.6; } }
-
+/* ─── 2) Hero ───────────────────────────────────────────────── */
+.solara-landing .sol-hero { z-index: 0; }
 .solara-landing .sol-hero-inner {
-  display: grid;
-  grid-template-columns: minmax(0, 1.1fr) minmax(420px, 0.9fr);
-  gap: clamp(32px, 5vw, 80px);
   align-items: start;
-  padding-top: clamp(40px, 7vw, 90px);
+  z-index: 1;
 }
-.solara-landing .sol-hero-left {
-  display: flex;
-  flex-direction: column;
-  gap: clamp(20px, 2.4vw, 32px);
-  padding-top: 12px;
-}
-.solara-landing .sol-hero-h1 {
-  font-size: clamp(44px, 7vw, 104px);
-  margin: 6px 0 0;
-}
-.solara-landing .sol-hero-claim {
-  margin: 0;
-  max-width: 28ch;
-  color: var(--sol-fg);
-  font-family: var(--sol-font-display);
-  font-size: clamp(20px, 1.7vw, 28px);
-  line-height: 1.35;
-  letter-spacing: -0.01em;
-  font-style: italic;
-  font-weight: 500;
-}
-.solara-landing .sol-hero-sub {
-  margin: 0;
-  max-width: 52ch;
-  color: var(--sol-fg-mute);
-  font-size: clamp(16px, 1.25vw, 19px);
-  line-height: 1.55;
-}
-.solara-landing .sol-hero-metrics {
-  display: flex;
-  gap: clamp(20px, 3vw, 44px);
-  margin-top: 12px;
-  padding-top: 24px;
-  border-top: 1px solid var(--sol-line);
-}
-.solara-landing .sol-metric { display: flex; flex-direction: column; }
-.solara-landing .sol-metric-n {
-  font-family: var(--sol-font-display);
-  font-size: clamp(28px, 3.2vw, 44px);
-  color: var(--sol-fg);
-  font-weight: 600;
-  letter-spacing: -0.03em;
-  line-height: 1;
-}
-.solara-landing .sol-metric-l { margin-top: 6px; }
-.solara-landing .sol-hero-right { position: relative; z-index: 5; }
+.solara-landing .sol-hero-left { position: relative; }
+.solara-landing .sol-hero-h1 { margin: 18px 0 0; }
+.solara-landing .sol-hero .hu-hero__sub { margin: 18px 0 4px; }
+.solara-landing .sol-hero .hu-hero__stats { margin-top: 24px; }
+.solara-landing .sol-hero .hu-hero__bullets { margin-top: 16px; }
 
-@media (max-width: 960px) {
-  .solara-landing .sol-hero-inner { grid-template-columns: 1fr; }
-  .solara-landing .sol-hero-h1 { font-size: clamp(40px, 11vw, 72px); }
-  .solara-landing .sol-hero-claim { font-size: clamp(18px, 3.6vw, 24px); max-width: 100%; }
-  .solara-landing .sol-hero-metrics { flex-wrap: wrap; gap: 20px; }
+.solara-landing .sol-hero-callink {
+  margin: 18px 0 0;
+  font-size: 13px;
+  color: var(--fg-3);
 }
-
-@media (max-width: 560px) {
-  .solara-landing {
-    overflow-x: clip;
-  }
-
-  .solara-landing .sol-wrap {
-    padding-left: 18px;
-    padding-right: 18px;
-  }
-
-  .solara-landing .sol-hero-h1 {
-    font-size: 2.5rem;
-    line-height: 1;
-    letter-spacing: 0;
-    overflow-wrap: anywhere;
-  }
-
-  .solara-landing .sol-btn {
-    width: 100%;
-    line-height: 1.15;
-    text-align: center;
-    white-space: normal;
-  }
+.solara-landing .sol-hero-callink a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  margin-left: 6px;
 }
+.solara-landing .sol-hero-callink a:hover { color: #EA9A4F; }
 
-/* ── Hero-CTA-Card ────────────────────────────────────────── */
+/* Kupfer-Sonne (ruhig rotierende Strahlen, rein dekorativ) */
+.solara-landing .sol-sun {
+  position: absolute;
+  top: -190px;
+  right: -160px;
+  width: min(580px, 55vw);
+  height: auto;
+  pointer-events: none;
+  z-index: 0;
+}
+.solara-landing .sol-sun-rays {
+  animation: sol-sun-spin 150s linear infinite;
+  transform-origin: 300px 300px;
+}
+@keyframes sol-sun-spin { to { transform: rotate(360deg); } }
+
+/* CPL-Telemetrie-Panel (Balken-Chart im hu-diagram-Rahmen) */
+.solara-landing .sol-cpl {
+  min-height: 0;
+  margin: 26px 0 0;
+  padding: 24px 26px 20px;
+}
+.solara-landing .sol-cpl svg { width: 100%; height: auto; margin-top: 16px; }
+.solara-landing .sol-bar {
+  transform-box: fill-box;
+  transform-origin: bottom;
+  animation: sol-bar-grow .7s cubic-bezier(0.16, 1, 0.3, 1) backwards;
+}
+@keyframes sol-bar-grow { from { transform: scaleY(0); } }
+.solara-landing .sol-bar-label { animation: sol-fade .45s ease backwards; }
+@keyframes sol-fade { from { opacity: 0; } }
+
+/* ─── 3) Marktcheck-Card (Hero rechts) ──────────────────────── */
 .solara-landing .sol-cta-card {
   position: relative;
-  background: linear-gradient(180deg, rgba(255,255,255,.92), rgba(255,255,255,.78));
-  border: 1px solid var(--sol-line);
-  border-radius: 18px;
-  padding: clamp(24px, 2.4vw, 30px);
-  box-shadow:
-    0 1px 0 rgba(255,255,255,.7) inset,
-    0 32px 60px -16px rgba(180,106,60,.16),
-    0 0 0 1px oklch(0.30 0.012 60 / 0.04);
-  backdrop-filter: blur(20px) saturate(140%);
-  -webkit-backdrop-filter: blur(20px) saturate(140%);
-}
-.solara-landing .sol-cta-card::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  pointer-events: none;
-  background: linear-gradient(135deg, rgba(255,170,90,.08), transparent 40%);
-}
-/* Subtle copper glow behind the form — pulses slowly. */
-.solara-landing .sol-cta-card::after {
-  content: "";
-  position: absolute;
-  inset: -28px;
-  z-index: -1;
+  padding: 28px;
+  border: 1px solid rgba(224, 138, 60, .35);
+  border-radius: 20px;
   background:
-    radial-gradient(ellipse 65% 50% at 20% 20%, rgba(180,106,60,.22), transparent 65%),
-    radial-gradient(ellipse 70% 55% at 85% 75%, rgba(201,122,26,.18), transparent 65%);
-  filter: blur(38px);
-  animation: sol-cta-glow 8s ease-in-out infinite;
-  pointer-events: none;
-  border-radius: inherit;
+    radial-gradient(ellipse 90% 60% at 50% 0%, rgba(224, 138, 60, .10), transparent 65%),
+    var(--bg-2);
+  box-shadow: 0 30px 90px -60px rgba(0, 0, 0, .85);
+  scroll-margin-top: 96px;
 }
-@keyframes sol-cta-glow {
-  0%, 100% { opacity: 0.7; transform: scale(1); }
-  50%      { opacity: 1;   transform: scale(1.04); }
-}
-/* Floating particles inside the card · 3 stück, slow drift */
-.solara-landing .sol-cta-card .sol-cta-particles {
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  overflow: hidden;
-  border-radius: inherit;
-}
-.solara-landing .sol-cta-card .sol-cta-particle {
-  position: absolute;
-  width: 60px;
-  height: 60px;
-  border-radius: 50%;
-  background: radial-gradient(circle, rgba(180,106,60,.28), transparent 65%);
-  filter: blur(8px);
-  animation: sol-cta-float 7s ease-in-out infinite;
-}
-.solara-landing .sol-cta-card .sol-cta-particle:nth-child(1) { top: 8%;  left: 6%;   animation-delay: 0s; }
-.solara-landing .sol-cta-card .sol-cta-particle:nth-child(2) { top: 32%; right: 8%;  animation-delay: 2.3s; width: 44px; height: 44px; }
-.solara-landing .sol-cta-card .sol-cta-particle:nth-child(3) { bottom: 14%; left: 18%; animation-delay: 4.6s; width: 36px; height: 36px; }
-@keyframes sol-cta-float {
-  0%, 100% { transform: translateY(0)   scale(1);   opacity: 0.55; }
-  50%      { transform: translateY(-14px) scale(1.08); opacity: 0.95; }
-}
+@media (max-width: 640px) { .solara-landing .sol-cta-card { padding: 22px 18px; } }
+
 .solara-landing .sol-cta-head {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  margin-bottom: 18px;
+  gap: 14px;
+  margin-bottom: 16px;
 }
 .solara-landing .sol-cta-tag {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  padding: 6px 10px;
-  border: 1px solid var(--sol-line);
+  padding: 6px 12px;
+  border: 1px solid var(--line-2);
   border-radius: 999px;
-  background: rgba(255,255,255,.6);
+  font-size: 10px;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+  color: var(--fg-2);
 }
 .solara-landing .sol-cta-tag-dot {
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: var(--sol-accent);
-  box-shadow: 0 0 0 4px rgba(180,106,60,.18);
-  animation: sol-pulse-dot 2s ease-in-out infinite;
+  background: var(--good);
+  box-shadow: 0 0 0 4px rgba(107, 161, 122, .15);
+  flex-shrink: 0;
 }
 .solara-landing .sol-cta-head-right {
-  color: var(--sol-accent);
-  font-weight: 600;
+  font-size: 10px;
+  letter-spacing: .16em;
+  text-transform: uppercase;
+  color: var(--fg-3);
 }
-
 .solara-landing .sol-cta-title {
-  font-family: var(--sol-font-display);
-  font-size: clamp(22px, 2.4vw, 30px);
-  margin: 0 0 8px;
-  line-height: 1.15;
-  letter-spacing: -0.03em;
-  font-weight: 600;
-  color: var(--sol-fg);
+  font-family: 'Satoshi', 'Figtree', sans-serif;
+  font-size: clamp(22px, 2vw, 26px);
+  font-weight: 800;
+  letter-spacing: -.02em;
+  line-height: 1.1;
+  margin: 0 0 10px;
+  color: var(--fg);
 }
 .solara-landing .sol-cta-hint {
-  color: var(--sol-fg-mute);
-  margin: 0 0 22px;
-  font-size: 14px;
+  color: var(--fg-2);
+  font-size: 14.5px;
   line-height: 1.55;
+  margin: 0 0 16px;
 }
-
-.solara-landing .sol-cta-list {
+.solara-landing .sol-cta-bullets {
   list-style: none;
-  margin: 0 0 22px;
-  padding: 0;
   display: flex;
   flex-direction: column;
   gap: 8px;
-}
-.solara-landing .sol-cta-list li {
-  display: flex;
-  align-items: flex-start;
-  gap: 12px;
-  padding: 12px 14px;
-  background: rgba(255,255,255,.55);
-  border: 1px solid var(--sol-line);
-  border-radius: 12px;
-  font-size: 14px;
-  line-height: 1.4;
-  transition: border-color var(--sol-t-fast), background var(--sol-t-fast);
-}
-.solara-landing .sol-cta-list li:hover {
-  border-color: var(--sol-accent);
-  background: rgba(255,255,255,.85);
-}
-.solara-landing .sol-cta-list-num {
-  color: var(--sol-accent);
-  font-family: var(--sol-font-mono);
+  padding: 0;
+  margin: 0 0 16px;
   font-size: 11px;
-  letter-spacing: 0.06em;
-  flex-shrink: 0;
-  padding-top: 2px;
-  font-weight: 600;
+  letter-spacing: .04em;
+  color: var(--fg-2);
 }
-.solara-landing .sol-cta-list-body { display: flex; flex-direction: column; gap: 2px; }
-.solara-landing .sol-cta-list-t { color: var(--sol-fg); font-weight: 500; }
-.solara-landing .sol-cta-list-s { color: var(--sol-fg-dim); font-size: 12px; }
+.solara-landing .sol-cta-bullets li { display: flex; gap: 10px; align-items: baseline; }
+.solara-landing .sol-cta-bullets-tick { color: var(--accent); font-weight: 700; flex-shrink: 0; }
+.solara-landing .sol-cta-fineprint {
+  margin: 0;
+  font-size: 12px;
+  color: var(--fg-3);
+}
 
+/* Noscript-/SSR-Fallback-Button */
 .solara-landing .sol-cta-submit {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  width: 100%;
-  padding: 16px 22px;
-  border: 0;
-  border-radius: 999px;
-  background: var(--sol-accent);
-  color: var(--sol-accent-ink);
-  font: 600 15px/1 var(--sol-font-body);
-  text-decoration: none;
-  cursor: pointer;
-  transition: background var(--sol-t-fast), transform var(--sol-t-fast), box-shadow var(--sol-t-fast);
-  box-shadow: 0 12px 24px -10px rgba(180,106,60,.5);
-}
-.solara-landing .sol-cta-submit:hover {
-  background: var(--sol-accent-2);
-  transform: translateY(-1px);
-  box-shadow: 0 16px 30px -10px rgba(201,122,26,.55);
-}
-.solara-landing .sol-cta-submit-arrow {
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
-  background: rgba(255,255,255,.22);
-  color: var(--sol-accent-ink);
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  gap: 10px;
+  width: 100%;
+  padding: 16px 24px;
+  border-radius: 999px;
+  background: var(--accent);
+  color: #1A0F05;
+  font-weight: 600;
+  font-size: 16px;
+  box-shadow: 0 1px 0 rgba(255, 255, 255, .18) inset, 0 8px 24px -12px rgba(224, 138, 60, .6);
+  transition: transform .15s, background .2s;
 }
-.solara-landing .sol-cta-submit-arrow svg { width: 14px; height: 14px; }
+.solara-landing .sol-cta-submit:hover { background: #EA9A4F; transform: translateY(-1px); }
+.solara-landing .sol-cta-submit-arrow,
+.solara-landing .sol-quiz-submit-arrow {
+  display: inline-flex;
+  width: 16px;
+  height: 16px;
+}
+.solara-landing .sol-cta-submit-arrow svg,
+.solara-landing .sol-quiz-submit-arrow svg { width: 16px; height: 16px; }
 
-.solara-landing .sol-cta-fineprint {
-  color: var(--sol-fg-dim);
-  margin: 14px 0 0;
-  text-align: center;
-  font-size: 10.5px !important;
-  letter-spacing: 0.06em;
-  font-family: var(--sol-font-mono);
-  text-transform: uppercase;
-}
+/* ─── 4) Quiz-Skin (3-Schritte-Marktcheck) ──────────────────── */
+.solara-landing .sol-quiz { display: flex; flex-direction: column; gap: 16px; }
 
-/* ══════════════════════════════════════════════════════════════
-   QUIZ (interaktives 6-Step-Formular im Hero)
-   ══════════════════════════════════════════════════════════════ */
-.solara-landing .sol-quiz {
-  display: flex;
-  flex-direction: column;
-  gap: 18px;
-  min-height: 480px;
-}
 .solara-landing .sol-quiz-progress { display: flex; flex-direction: column; gap: 8px; }
 .solara-landing .sol-quiz-progress-meta {
   display: flex;
   justify-content: space-between;
-  font-family: var(--sol-font-mono);
-  font-size: 11px;
-  letter-spacing: 0.06em;
-  color: var(--sol-fg-dim);
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: .14em;
   text-transform: uppercase;
+  color: var(--fg-3);
 }
 .solara-landing .sol-quiz-progress-track {
-  height: 3px;
-  background: rgba(0, 0, 0, 0.07);
-  border-radius: 999px;
+  height: 4px;
+  border-radius: 2px;
+  background: var(--line-2);
   overflow: hidden;
 }
 .solara-landing .sol-quiz-progress-fill {
   position: relative;
   height: 100%;
-  width: 0%;
-  background: linear-gradient(90deg, var(--sol-accent), var(--sol-accent-2));
-  transition: width var(--sol-t-med) cubic-bezier(.2,.7,.2,1);
-  box-shadow: 0 0 12px rgba(180,106,60,.5);
-  overflow: hidden;
-  border-radius: 999px;
+  border-radius: 2px;
+  background: var(--accent);
+  transition: width .35s cubic-bezier(0.16, 1, 0.3, 1);
 }
 .solara-landing .sol-quiz-progress-shimmer {
   position: absolute;
-  top: 0;
-  left: -40%;
-  width: 40%;
-  height: 100%;
-  background: linear-gradient(90deg, transparent, rgba(255,255,255,.65), transparent);
-  animation: sol-quiz-shimmer 2.4s linear infinite;
-  pointer-events: none;
-}
-@keyframes sol-quiz-shimmer {
-  0%   { transform: translateX(0%); }
-  100% { transform: translateX(350%); }
-}
-
-/* Step-Dots unter dem Progress · ✓ bei erledigten */
-.solara-landing .sol-quiz-dots {
-  display: flex;
-  gap: 6px;
-  margin-top: 8px;
-  justify-content: space-between;
-}
-.solara-landing .sol-quiz-dot {
-  flex: 1;
-  height: 6px;
-  border-radius: 999px;
-  background: rgba(0,0,0,.08);
-  border: 0;
-  cursor: default;
-  padding: 0;
-  position: relative;
-  transition: background var(--sol-t-fast), transform var(--sol-t-fast);
-}
-.solara-landing .sol-quiz-dot.is-done {
-  background: var(--sol-accent);
-  cursor: pointer;
-}
-.solara-landing .sol-quiz-dot.is-done:hover { transform: scaleY(1.4); }
-.solara-landing .sol-quiz-dot.is-active {
-  background: linear-gradient(90deg, var(--sol-accent), var(--sol-accent-2));
-  box-shadow: 0 0 8px rgba(180,106,60,.45);
-}
-.solara-landing .sol-quiz-dot-check {
-  position: absolute;
   inset: 0;
-  display: grid;
-  place-items: center;
-  color: #fff;
-  font-size: 8px;
-  font-weight: 700;
-  line-height: 1;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, .35), transparent);
+  animation: sol-shimmer 2.2s ease-in-out infinite;
+}
+@keyframes sol-shimmer {
+  0%   { transform: translateX(-100%); }
+  60%, 100% { transform: translateX(100%); }
 }
 
-.solara-landing .sol-quiz-body { min-height: 280px; display: flex; flex-direction: column; gap: 14px; }
+.solara-landing .sol-quiz-dots { display: flex; gap: 6px; }
+.solara-landing .sol-quiz-dot {
+  width: 22px;
+  height: 4px;
+  border-radius: 2px;
+  background: var(--line-2);
+  padding: 0;
+  transition: background .2s;
+}
+.solara-landing .sol-quiz-dot.is-active,
+.solara-landing .sol-quiz-dot.is-cur { background: var(--accent); }
+.solara-landing .sol-quiz-dot.is-done { background: var(--accent-2); cursor: pointer; }
+.solara-landing .sol-quiz-dot-check { display: none; }
+
 .solara-landing .sol-quiz-label {
-  color: var(--sol-accent);
-  font-family: var(--sol-font-mono);
-  font-size: 11px;
-  letter-spacing: 0.12em;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: .16em;
   text-transform: uppercase;
-  font-weight: 600;
-  margin: 0;
+  color: var(--accent);
 }
 .solara-landing .sol-quiz-title {
-  font-family: var(--sol-font-display);
-  font-size: clamp(22px, 2.2vw, 28px);
-  font-weight: 600;
-  line-height: 1.2;
-  letter-spacing: -0.025em;
-  color: var(--sol-fg);
-  margin: 0;
-  text-wrap: balance;
+  font-family: 'Satoshi', 'Figtree', sans-serif;
+  font-size: 21px;
+  font-weight: 800;
+  letter-spacing: -.02em;
+  line-height: 1.15;
+  margin: 8px 0 6px;
+  color: var(--fg);
 }
 .solara-landing .sol-quiz-hint {
-  color: var(--sol-fg-mute);
-  margin: 0 0 6px;
+  margin: 0 0 16px;
+  color: var(--fg-2);
   font-size: 13.5px;
   line-height: 1.55;
 }
 
-.solara-landing .sol-quiz-options {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
+/* Antwort-Optionen */
+.solara-landing .sol-quiz-options { display: flex; flex-direction: column; gap: 10px; }
 .solara-landing .sol-quiz-opt {
-  appearance: none;
-  position: relative;
   display: flex;
   align-items: center;
-  gap: 14px;
+  gap: 12px;
   width: 100%;
-  text-align: left;
   padding: 13px 16px;
-  background: rgba(255, 255, 255, 0.55);
-  border: 1px solid var(--sol-line);
+  border: 1px solid var(--line-2);
   border-radius: 12px;
-  color: var(--sol-fg);
-  font: inherit;
+  background: var(--bg-3);
+  text-align: left;
+  color: var(--fg);
+  font-weight: 500;
+  font-size: 14.5px;
   cursor: pointer;
-  overflow: hidden;
-  transition: background var(--sol-t-fast), border-color var(--sol-t-fast), transform var(--sol-t-fast), box-shadow var(--sol-t-fast);
-  opacity: 0;
-  transform: translateX(-8px);
-  animation: sol-quiz-opt-in 0.45s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+  transition: border-color .15s, background .15s, color .15s;
+  animation: sol-fade .35s ease backwards;
   animation-delay: var(--sol-opt-delay, 0ms);
 }
-@keyframes sol-quiz-opt-in {
-  to { opacity: 1; transform: translateX(0); }
-}
-.solara-landing .sol-quiz-opt::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(135deg, rgba(180,106,60,.10), transparent 55%);
-  opacity: 0;
-  transition: opacity var(--sol-t-fast);
-  pointer-events: none;
-}
-.solara-landing .sol-quiz-opt:hover {
-  background: rgba(255, 255, 255, 0.92);
-  border-color: var(--sol-accent);
-  transform: translateX(3px);
-  box-shadow: 0 8px 22px -12px rgba(180,106,60,.4);
-}
-.solara-landing .sol-quiz-opt:hover::before { opacity: 1; }
+.solara-landing .sol-quiz-opt:hover,
 .solara-landing .sol-quiz-opt.is-sel {
-  border-color: var(--sol-accent);
-  background: rgba(180, 106, 60, 0.10);
-  box-shadow: inset 0 0 0 1px var(--sol-accent), 0 10px 26px -14px rgba(180,106,60,.45);
-  transform: translateX(3px) scale(1.005);
+  border-color: var(--accent);
+  background: rgba(224, 138, 60, .06);
 }
+.solara-landing .sol-quiz-opt.is-sel .sol-quiz-opt-t { color: var(--accent); }
 .solara-landing .sol-quiz-opt-bullet {
-  width: 18px;
-  height: 18px;
+  width: 16px;
+  height: 16px;
+  border: 1px solid var(--line-2);
   border-radius: 50%;
-  border: 1.5px solid var(--sol-line-2);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
+  display: grid;
+  place-items: center;
   flex-shrink: 0;
-  transition: border-color var(--sol-t-fast);
+  transition: border-color .15s;
 }
-.solara-landing .sol-quiz-opt.is-sel .sol-quiz-opt-bullet { border-color: var(--sol-accent); }
+.solara-landing .sol-quiz-opt.is-sel .sol-quiz-opt-bullet { border-color: var(--accent); }
 .solara-landing .sol-quiz-opt-bullet-dot {
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  background: var(--sol-accent);
-  transform: scale(0);
-  transition: transform var(--sol-t-fast);
+  background: var(--accent);
+  opacity: 0;
+  transition: opacity .15s;
 }
-.solara-landing .sol-quiz-opt.is-sel .sol-quiz-opt-bullet-dot { transform: scale(1); }
-.solara-landing .sol-quiz-opt-body { display: flex; flex-direction: column; flex: 1; gap: 2px; }
-.solara-landing .sol-quiz-opt-t { font-weight: 500; font-size: 15px; color: var(--sol-fg); }
-.solara-landing .sol-quiz-opt-s { font-size: 12px; color: var(--sol-fg-dim); }
+.solara-landing .sol-quiz-opt.is-sel .sol-quiz-opt-bullet-dot { opacity: 1; }
+.solara-landing .sol-quiz-opt-body { display: flex; flex-direction: column; gap: 3px; flex: 1; }
+.solara-landing .sol-quiz-opt-t { font-weight: 600; line-height: 1.3; }
+.solara-landing .sol-quiz-opt-s { font-size: 12.5px; color: var(--fg-3); line-height: 1.45; }
 .solara-landing .sol-quiz-opt-idx {
-  color: var(--sol-fg-dim);
-  font-family: var(--sol-font-mono);
-  font-size: 10.5px;
-  font-weight: 600;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10px;
+  color: var(--fg-4);
   flex-shrink: 0;
-  transition: opacity var(--sol-t-fast);
-}
-.solara-landing .sol-quiz-opt:hover .sol-quiz-opt-idx { opacity: 0; }
-.solara-landing .sol-quiz-opt-icon {
-  position: relative;
-  z-index: 1;
-  font-size: 22px;
-  line-height: 1;
-  width: 38px;
-  height: 38px;
-  display: grid;
-  place-items: center;
-  flex-shrink: 0;
-  background: rgba(255,255,255,.75);
-  border: 1px solid var(--sol-line);
-  border-radius: 10px;
-  filter: saturate(.9);
-  transition: transform var(--sol-t-fast), background var(--sol-t-fast), border-color var(--sol-t-fast);
-}
-.solara-landing .sol-quiz-opt:hover .sol-quiz-opt-icon {
-  transform: scale(1.08) rotate(-3deg);
-  background: #fff;
-  border-color: var(--sol-accent);
-  filter: saturate(1.15);
-}
-.solara-landing .sol-quiz-opt.is-sel .sol-quiz-opt-icon {
-  background: var(--sol-accent);
-  border-color: var(--sol-accent);
-  filter: saturate(1);
 }
 .solara-landing .sol-quiz-opt-arrow {
-  position: absolute;
-  right: 14px;
-  top: 50%;
-  width: 18px;
-  height: 18px;
-  color: var(--sol-accent);
-  opacity: 0;
-  transform: translate(-12px, -50%);
-  transition: opacity var(--sol-t-fast), transform var(--sol-t-fast);
-  pointer-events: none;
+  display: inline-flex;
+  width: 14px;
+  height: 14px;
+  color: var(--fg-4);
+  flex-shrink: 0;
+  transition: color .15s, transform .15s;
 }
-.solara-landing .sol-quiz-opt-arrow svg { width: 100%; height: 100%; }
+.solara-landing .sol-quiz-opt-arrow svg { width: 14px; height: 14px; }
 .solara-landing .sol-quiz-opt:hover .sol-quiz-opt-arrow {
-  opacity: 1;
-  transform: translate(0, -50%);
+  color: var(--accent);
+  transform: translateX(2px);
 }
 
+/* Schritt 3 — Formular (zweispaltiges Feld-Raster) */
 .solara-landing .sol-quiz-form {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 10px;
+  gap: 12px;
 }
-.solara-landing .sol-quiz-form > .sol-quiz-field--full { grid-column: 1 / -1; }
-.solara-landing .sol-quiz-field { display: flex; flex-direction: column; gap: 4px; }
-.solara-landing .sol-quiz-field-lbl {
-  font-family: var(--sol-font-mono);
-  font-size: 10.5px;
-  letter-spacing: 0.06em;
-  color: var(--sol-fg-mute);
+.solara-landing .sol-quiz-form > .sol-quiz-rationale,
+.solara-landing .sol-quiz-form > .sol-quiz-consent,
+.solara-landing .sol-quiz-form > .sol-quiz-error,
+.solara-landing .sol-quiz-form > .sol-quiz-submit,
+.solara-landing .sol-quiz-form > .sol-quiz-fineprint,
+.solara-landing .sol-quiz-form > .sol-quiz-field-err { grid-column: 1 / -1; }
+@media (max-width: 640px) {
+  .solara-landing .sol-quiz-form { grid-template-columns: 1fr; }
+}
+.solara-landing .sol-quiz-rationale {
+  padding: 12px 14px;
+  border: 1px solid var(--line);
+  border-left: 2px solid var(--accent);
+  border-radius: 10px;
+  background: var(--bg-3);
+}
+.solara-landing .sol-quiz-rationale-h {
+  margin: 0 0 4px;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: .14em;
   text-transform: uppercase;
-  font-weight: 600;
+  color: var(--accent);
 }
-.solara-landing .sol-quiz-field-lbl-req { color: var(--sol-accent); margin-left: 2px; }
+.solara-landing .sol-quiz-rationale-b {
+  margin: 0;
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--fg-2);
+}
+.solara-landing .sol-quiz-field { display: flex; flex-direction: column; gap: 6px; }
+.solara-landing .sol-quiz-field--full { grid-column: 1 / -1; }
+.solara-landing .sol-quiz-field-lbl {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: .16em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+}
+.solara-landing .sol-quiz-field-lbl-req { color: var(--accent); }
 .solara-landing .sol-quiz-field input,
 .solara-landing .sol-quiz-field select {
   width: 100%;
-  padding: 12px 14px;
-  background: rgba(255, 255, 255, 0.75);
-  border: 1px solid var(--sol-line);
-  border-radius: 10px;
-  color: var(--sol-fg);
-  font: 400 14px/1.2 var(--sol-font-body);
-  outline: none;
-  transition: border-color var(--sol-t-fast), background var(--sol-t-fast), box-shadow var(--sol-t-fast);
+  box-sizing: border-box;
+  padding: 13px 16px;
+  background: var(--bg-3);
+  border: 1px solid var(--line-2);
+  border-radius: 12px;
+  color: var(--fg);
+  font: inherit;
+  font-size: 15px;
+  transition: border-color .2s, box-shadow .2s;
 }
-.solara-landing .sol-quiz-field select {
-  appearance: none;
-  -webkit-appearance: none;
-  cursor: pointer;
-  padding-right: 36px;
-  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 8' fill='none' stroke='%23b46a3c' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round'><path d='M1 1.5l5 5 5-5'/></svg>");
-  background-repeat: no-repeat;
-  background-position: right 14px center;
-  background-size: 12px 8px;
-}
-.solara-landing .sol-quiz-field input::placeholder { color: var(--sol-fg-dim); }
+.solara-landing .sol-quiz-field select { appearance: none; cursor: pointer; }
+.solara-landing .sol-quiz-field input::placeholder { color: var(--fg-4); }
 .solara-landing .sol-quiz-field input:focus,
 .solara-landing .sol-quiz-field select:focus {
-  border-color: var(--sol-accent);
-  background-color: rgba(255, 255, 255, 1);
-  box-shadow: 0 0 0 3px rgba(180, 106, 60, 0.18);
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(224, 138, 60, .18);
 }
 .solara-landing .sol-quiz-field.is-err input,
-.solara-landing .sol-quiz-field.is-err select { border-color: oklch(0.55 0.20 25); }
-.solara-landing .sol-quiz-field-err { color: oklch(0.50 0.20 25); font-size: 11px; font-family: var(--sol-font-mono); letter-spacing: 0.04em; }
-.solara-landing .sol-quiz-hp { position: absolute; left: -9999px; top: -9999px; }
-
+.solara-landing .sol-quiz-field.is-err select { border-color: var(--bad); }
+.solara-landing .sol-quiz-field-err {
+  font-size: 12px;
+  line-height: 1.45;
+  color: #D88673;
+}
+.solara-landing .sol-quiz-hp {
+  position: absolute !important;
+  left: -9999px !important;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
 .solara-landing .sol-quiz-consent {
   display: flex;
   gap: 10px;
   align-items: flex-start;
   font-size: 12.5px;
-  color: var(--sol-fg-mute);
   line-height: 1.5;
-  grid-column: 1 / -1;
-  margin-top: 4px;
+  color: var(--fg-2);
   cursor: pointer;
 }
-.solara-landing .sol-quiz-consent input[type="checkbox"] {
-  margin-top: 3px;
+.solara-landing .sol-quiz-consent input {
+  margin-top: 2px;
+  accent-color: var(--accent);
   flex-shrink: 0;
-  accent-color: var(--sol-accent);
-  width: 16px;
-  height: 16px;
 }
-.solara-landing .sol-quiz-consent a { color: var(--sol-accent); text-decoration: underline; text-underline-offset: 2px; }
-.solara-landing .sol-quiz-consent.is-err { color: oklch(0.55 0.20 25); }
-.solara-landing .sol-quiz-consent.is-err input[type="checkbox"] { outline: 2px solid oklch(0.55 0.20 25); outline-offset: 2px; }
-
+.solara-landing .sol-quiz-consent a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.solara-landing .sol-quiz-consent.is-err { color: #D88673; }
+.solara-landing .sol-quiz-error {
+  padding: 10px 14px;
+  border-radius: 10px;
+  border: 1px solid rgba(224, 138, 60, .4);
+  background: rgba(224, 138, 60, .08);
+  color: var(--accent);
+  font-size: 13.5px;
+  line-height: 1.5;
+}
 .solara-landing .sol-quiz-submit {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  width: 100%;
-  padding: 16px 22px;
-  border: 0;
-  border-radius: 999px;
-  background: var(--sol-accent);
-  color: var(--sol-accent-ink);
-  font: 600 15px/1 var(--sol-font-body);
-  cursor: pointer;
-  margin-top: 6px;
-  transition: background var(--sol-t-fast), transform var(--sol-t-fast), opacity var(--sol-t-fast), box-shadow var(--sol-t-fast);
-  box-shadow: 0 12px 24px -10px rgba(180,106,60,.5);
-}
-.solara-landing .sol-quiz-submit:hover:not(.is-dis):not(.is-loading) {
-  background: var(--sol-accent-2);
-  transform: translateY(-1px);
-  box-shadow: 0 16px 30px -10px rgba(201,122,26,.55);
-}
-.solara-landing .sol-quiz-submit.is-dis { opacity: 0.5; pointer-events: none; }
-.solara-landing .sol-quiz-submit.is-loading {
-  pointer-events: none;
-  background: var(--sol-accent-2);
-}
-.solara-landing .sol-quiz-submit.is-loading .sol-quiz-submit-arrow {
-  animation: sol-spin 1s linear infinite;
-}
-.solara-landing .sol-quiz-submit-arrow {
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
-  background: rgba(255,255,255,.22);
-  color: var(--sol-accent-ink);
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  gap: 10px;
+  width: 100%;
+  padding: 16px 24px;
+  border-radius: 999px;
+  background: var(--accent);
+  color: #1A0F05;
+  font-weight: 600;
+  font-size: 16px;
+  cursor: pointer;
+  box-shadow: 0 1px 0 rgba(255, 255, 255, .18) inset, 0 8px 24px -12px rgba(224, 138, 60, .6);
+  transition: transform .15s, background .2s, opacity .2s;
 }
-.solara-landing .sol-quiz-submit-arrow svg { width: 14px; height: 14px; }
-
+.solara-landing .sol-quiz-submit:hover { background: #EA9A4F; transform: translateY(-1px); }
+.solara-landing .sol-quiz-submit.is-dis { opacity: .55; cursor: not-allowed; }
+.solara-landing .sol-quiz-submit.is-dis:hover { background: var(--accent); transform: none; }
+.solara-landing .sol-quiz-submit.is-loading { opacity: .75; cursor: progress; }
 .solara-landing .sol-quiz-fineprint {
-  color: var(--sol-fg-dim);
-  margin: 10px 0 0;
-  text-align: center;
-  font-size: 10.5px !important;
-  letter-spacing: 0.08em;
-  font-family: var(--sol-font-mono);
-  text-transform: uppercase;
+  margin: 0;
+  font-size: 11.5px;
+  color: var(--fg-3);
 }
 
-.solara-landing .sol-quiz-error {
-  margin-top: 6px;
-  padding: 10px 14px;
-  border-radius: 10px;
-  background: oklch(0.93 0.05 25);
-  border: 1px solid oklch(0.80 0.10 25);
-  color: oklch(0.40 0.20 25);
-  font-size: 13px;
-  line-height: 1.45;
-}
-
+/* Quiz-Navigation (Zurück / Weiter) */
 .solara-landing .sol-quiz-nav {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  margin-top: 14px;
-  padding-top: 16px;
-  border-top: 1px solid var(--sol-line);
 }
 .solara-landing .sol-quiz-back,
 .solara-landing .sol-quiz-next {
-  appearance: none;
-  border: 0;
-  background: transparent;
-  color: var(--sol-fg-mute);
-  font: 500 12px/1 var(--sol-font-body);
-  padding: 8px 0;
+  font-size: 13px;
+  color: var(--fg-3);
   cursor: pointer;
-  transition: color var(--sol-t-fast);
+  padding: 6px 2px;
+  transition: color .15s;
 }
 .solara-landing .sol-quiz-back:hover,
-.solara-landing .sol-quiz-next:hover { color: var(--sol-fg); }
+.solara-landing .sol-quiz-next:hover { color: var(--fg); }
+.solara-landing .sol-quiz-next { color: var(--accent); font-weight: 600; }
+.solara-landing .sol-quiz-next:hover { color: #EA9A4F; }
 .solara-landing .sol-quiz-back.is-dis,
-.solara-landing .sol-quiz-next.is-dis { opacity: 0.3; pointer-events: none; }
-
-.solara-landing .sol-quiz-dots { display: flex; gap: 6px; }
-.solara-landing .sol-quiz-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--sol-line-2);
-  transition: all var(--sol-t-fast);
-}
-.solara-landing .sol-quiz-dot.is-done { background: var(--sol-fg-mute); }
-.solara-landing .sol-quiz-dot.is-cur {
-  width: 22px;
-  border-radius: 999px;
-  background: var(--sol-accent);
+.solara-landing .sol-quiz-next.is-dis {
+  opacity: .35;
+  cursor: default;
+  pointer-events: none;
 }
 
+/* Success-Screen */
 .solara-landing .sol-quiz-success {
-  text-align: center;
-  padding: 18px 6px 0;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 14px;
+  gap: 12px;
+  text-align: left;
 }
-.solara-landing .sol-quiz-success-icon {
-  width: 64px;
-  height: 64px;
-  border-radius: 50%;
-  background: rgba(180, 106, 60, 0.10);
-  border: 1px solid rgba(180, 106, 60, 0.32);
-  color: var(--sol-accent);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
-.solara-landing .sol-quiz-success-icon svg { width: 28px; height: 28px; }
+.solara-landing .sol-quiz-success-icon { width: 44px; height: 44px; color: var(--good); }
+.solara-landing .sol-quiz-success-icon svg { width: 44px; height: 44px; }
 .solara-landing .sol-quiz-success-h {
-  font-family: var(--sol-font-display);
-  font-size: clamp(24px, 2.6vw, 32px);
-  font-weight: 600;
-  letter-spacing: -0.025em;
-  line-height: 1.15;
-  color: var(--sol-fg);
+  font-family: 'Satoshi', 'Figtree', sans-serif;
+  font-size: 24px;
+  font-weight: 800;
+  letter-spacing: -.02em;
   margin: 0;
+  color: var(--accent);
 }
-.solara-landing .sol-quiz-success-sub {
-  color: var(--sol-fg-mute);
-  font-size: 14.5px;
-  line-height: 1.55;
-  margin: 0;
-  max-width: 38ch;
-}
-.solara-landing .sol-quiz-success-row {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  width: 100%;
-  margin-top: 8px;
-}
-.solara-landing .sol-quiz-success-row a {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 14px 20px;
-  border-radius: 999px;
-  font: 600 14px/1 var(--sol-font-body);
-  text-decoration: none;
-  transition: transform var(--sol-t-fast), background var(--sol-t-fast), border-color var(--sol-t-fast), box-shadow var(--sol-t-fast);
-}
-.solara-landing .sol-quiz-success-row .is-primary {
-  background: var(--sol-accent);
-  color: var(--sol-accent-ink);
-  box-shadow: 0 12px 24px -10px rgba(180,106,60,.5);
-}
-.solara-landing .sol-quiz-success-row .is-primary:hover {
-  background: var(--sol-accent-2);
-  transform: translateY(-1px);
-}
-.solara-landing .sol-quiz-success-row .is-ghost {
-  background: transparent;
-  color: var(--sol-fg);
-  border: 1px solid var(--sol-line-2);
-}
-.solara-landing .sol-quiz-success-row .is-ghost:hover { border-color: var(--sol-accent); color: var(--sol-accent); }
-.solara-landing .sol-quiz-success-row span:last-child {
-  width: 24px;
-  height: 24px;
-  border-radius: 50%;
-  background: currentColor;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
-.solara-landing .sol-quiz-success-row .is-primary span:last-child { background: rgba(255,255,255,0.22); }
-.solara-landing .sol-quiz-success-row span:last-child svg { width: 12px; height: 12px; color: var(--sol-bg); }
-.solara-landing .sol-quiz-success-row .is-primary span:last-child svg { color: var(--sol-accent-ink); }
-.solara-landing .sol-quiz-success-row .is-ghost span:last-child svg { color: var(--sol-bg); }
-
-.solara-landing .sol-quiz-success-fineprint {
-  margin-top: 4px;
-  font-family: var(--sol-font-mono);
-  font-size: 10.5px;
-  color: var(--sol-fg-dim);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
 .solara-landing .sol-quiz-success-ticket {
-  margin: -4px 0 6px;
   font-size: 11px;
-  color: var(--sol-fg-dim);
-  letter-spacing: 0.12em;
+  letter-spacing: .1em;
   text-transform: uppercase;
+  color: var(--fg-3);
+  margin: 0;
 }
-.solara-landing .sol-quiz-success-ticket-id {
-  color: var(--sol-accent);
-  font-weight: 600;
+.solara-landing .sol-quiz-success-ticket-id { color: var(--fg); }
+.solara-landing .sol-quiz-success-sub {
+  margin: 0;
+  font-size: 14.5px;
+  line-height: 1.6;
+  color: var(--fg-2);
 }
-
 .solara-landing .sol-quiz-success-deadline {
-  margin: 6px 0 0;
+  margin: 0;
   font-size: 13.5px;
-  line-height: 1.5;
-  color: var(--sol-fg);
+  color: var(--fg-2);
 }
-.solara-landing .sol-quiz-success-deadline-label {
-  color: var(--sol-fg-dim);
-}
-.solara-landing .sol-quiz-success-deadline strong {
-  color: var(--sol-fg);
-  font-weight: 600;
-}
-
+.solara-landing .sol-quiz-success-deadline strong { color: var(--fg); }
 .solara-landing .sol-quiz-success-proof {
-  margin: 14px 0 4px;
   padding: 14px 16px;
-  border: 1px solid rgba(255,255,255,0.08);
-  border-left: 2px solid var(--sol-accent);
-  border-radius: 10px;
-  background: rgba(255,255,255,0.02);
-  display: block;
+  border: 1px solid rgba(224, 138, 60, .35);
+  border-radius: 12px;
+  background: rgba(224, 138, 60, .06);
 }
 .solara-landing .sol-quiz-success-proof-label {
   display: block;
   font-size: 10px;
-  letter-spacing: 0.12em;
+  letter-spacing: .16em;
   text-transform: uppercase;
-  color: var(--sol-fg-dim);
-  margin-bottom: 4px;
+  color: var(--accent);
+  margin-bottom: 6px;
 }
 .solara-landing .sol-quiz-success-proof-body {
   margin: 0;
-  font-size: 13.5px;
+  font-size: 13px;
   line-height: 1.55;
-  color: var(--sol-fg);
+  color: var(--fg-2);
+}
+.solara-landing .sol-quiz-success-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 4px;
+}
+.solara-landing .sol-quiz-success-row a {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 13px 20px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 14.5px;
+  transition: transform .15s, background .2s, border-color .2s;
+}
+.solara-landing .sol-quiz-success-row a svg { width: 15px; height: 15px; }
+.solara-landing .sol-quiz-success-row a.is-primary {
+  background: var(--accent);
+  color: #1A0F05;
+  box-shadow: 0 1px 0 rgba(255, 255, 255, .18) inset, 0 8px 24px -12px rgba(224, 138, 60, .6);
+}
+.solara-landing .sol-quiz-success-row a.is-primary:hover { background: #EA9A4F; transform: translateY(-1px); }
+.solara-landing .sol-quiz-success-row a.is-ghost {
+  border: 1px solid var(--line-2);
+  color: var(--fg);
+}
+.solara-landing .sol-quiz-success-row a.is-ghost:hover { border-color: var(--fg-3); background: var(--bg-3); }
+.solara-landing .sol-quiz-success-fineprint {
+  margin: 0;
+  font-size: 12px;
+  color: var(--fg-3);
 }
 
-@media (max-width: 560px) {
-  .solara-landing .sol-quiz-form { grid-template-columns: 1fr; }
-}
-
-/* ══════════════════════════════════════════════════════════════
-   TRUST STRIP
-   ══════════════════════════════════════════════════════════════ */
+/* ─── 5) Trust-Strip ────────────────────────────────────────── */
 .solara-landing .sol-trust {
-  padding: 28px 0;
-  border-top: 1px solid var(--sol-line);
-  border-bottom: 1px solid var(--sol-line);
-  background: var(--sol-bg-2);
-  position: relative;
-  z-index: 3;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+  padding: 16px 0;
+  background: var(--bg);
 }
 .solara-landing .sol-trust-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 32px;
-  row-gap: 12px;
-  align-items: center;
-  justify-content: space-between;
+  gap: 10px 26px;
+  justify-content: center;
 }
 .solara-landing .sol-trust-item {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  color: var(--sol-fg-mute);
-  font-size: 10.5px !important;
+  font-size: 10.5px;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  color: var(--fg-3);
 }
 .solara-landing .sol-trust-dot {
-  width: 4px;
-  height: 4px;
+  width: 5px;
+  height: 5px;
   border-radius: 50%;
-  background: var(--sol-accent);
-}
-
-/* ══════════════════════════════════════════════════════════════
-   PROBLEM
-   ══════════════════════════════════════════════════════════════ */
-.solara-landing .sol-problem-h {
-  font-size: clamp(36px, 5.4vw, 84px);
-  max-width: 22ch;
-  margin: 18px 0 60px;
-}
-.solara-landing .sol-problem-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 1px;
-  background: var(--sol-line);
-  border: 1px solid var(--sol-line);
-  border-radius: 16px;
-  overflow: hidden;
-}
-.solara-landing .sol-problem-card {
-  padding: clamp(28px, 3.6vw, 44px);
-  background: var(--sol-bg);
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-.solara-landing .sol-problem-card-n {
-  color: var(--sol-accent);
-  font-size: 12px;
-  font-family: var(--sol-font-mono);
-  letter-spacing: 0.08em;
-  font-weight: 600;
-}
-.solara-landing .sol-problem-card-t {
-  font-family: var(--sol-font-display);
-  font-size: clamp(22px, 2.2vw, 28px);
-  font-weight: 600;
-  line-height: 1.2;
-  letter-spacing: -0.02em;
-  color: var(--sol-fg);
-}
-.solara-landing .sol-problem-card-s {
-  color: var(--sol-fg-mute);
-  margin: 0;
-  font-size: 15px;
-  line-height: 1.6;
-}
-@media (max-width: 880px) {
-  .solara-landing .sol-problem-grid { grid-template-columns: 1fr; }
-}
-
-/* ══════════════════════════════════════════════════════════════
-   METHOD / SYSTEM
-   ══════════════════════════════════════════════════════════════ */
-.solara-landing .sol-method {
-  background: var(--sol-bg-2);
-  border-top: 1px solid var(--sol-line);
-  border-bottom: 1px solid var(--sol-line);
-}
-.solara-landing .sol-method-head {
-  max-width: 800px;
-  margin-bottom: clamp(48px, 6vw, 80px);
-}
-.solara-landing .sol-method-h {
-  font-size: clamp(40px, 5.6vw, 88px);
-  margin: 18px 0 0;
-}
-.solara-landing .sol-method-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: clamp(16px, 2vw, 24px);
-}
-@media (max-width: 880px) {
-  .solara-landing .sol-method-grid { grid-template-columns: 1fr; }
-}
-.solara-landing .sol-method-card {
-  position: relative;
-  padding: clamp(28px, 3.4vw, 40px);
-  background: var(--sol-bg);
-  border: 1px solid var(--sol-line);
-  border-radius: 16px;
-  display: flex;
-  flex-direction: column;
-  min-height: 340px;
-  transition: transform var(--sol-t-med), border-color var(--sol-t-med), box-shadow var(--sol-t-med);
-}
-.solara-landing .sol-method-card:hover {
-  transform: translateY(-4px);
-  border-color: var(--sol-accent);
-  box-shadow: 0 30px 60px -28px rgba(180,106,60,.22);
-}
-.solara-landing .sol-method-card-top {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-}
-.solara-landing .sol-method-card-n {
-  font-family: var(--sol-font-display);
-  font-size: clamp(60px, 7vw, 96px);
-  color: var(--sol-accent);
-  line-height: 0.85;
-  margin-bottom: 24px;
-  letter-spacing: -0.04em;
-  font-weight: 600;
-}
-.solara-landing .sol-method-card-pill {
-  padding: 5px 10px;
-  border: 1px solid var(--sol-line);
-  border-radius: 999px;
-  color: var(--sol-fg-mute);
-  font-family: var(--sol-font-mono);
-  font-size: 10.5px;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  background: var(--sol-bg-2);
-}
-.solara-landing .sol-method-card-t {
-  font-family: var(--sol-font-display);
-  font-size: clamp(22px, 2vw, 28px);
-  margin: 8px 0 12px;
-  line-height: 1.15;
-  letter-spacing: -0.02em;
-  font-weight: 600;
-  color: var(--sol-fg);
-}
-.solara-landing .sol-method-card-s {
-  color: var(--sol-fg-mute);
-  margin: 0 0 22px;
-  font-size: 14.5px;
-  line-height: 1.6;
-}
-.solara-landing .sol-method-card-s a {
-  color: var(--sol-fg);
-  text-decoration: underline;
-  text-decoration-color: color-mix(in oklab, var(--sol-accent) 50%, transparent);
-  text-decoration-thickness: 1px;
-  text-underline-offset: 3px;
-  transition: text-decoration-color .2s ease, color .2s ease;
-}
-.solara-landing .sol-method-card-s a:hover,
-.solara-landing .sol-method-card-s a:focus-visible {
-  color: var(--sol-accent);
-  text-decoration-color: var(--sol-accent);
-}
-.solara-landing .sol-method-card-list {
-  list-style: none;
-  padding: 18px 0 0;
-  margin: auto 0 0;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  border-top: 1px solid var(--sol-line);
-}
-.solara-landing .sol-method-card-list li {
-  display: flex;
-  gap: 10px;
-  font-size: 13.5px;
-  color: var(--sol-fg-mute);
-  align-items: center;
-}
-.solara-landing .sol-method-tick {
-  color: var(--sol-accent);
-  font-family: var(--sol-font-mono);
-  font-weight: 600;
-}
-
-/* ══════════════════════════════════════════════════════════════
-   RESULTS / DASHBOARD-MOCK
-   ══════════════════════════════════════════════════════════════ */
-.solara-landing .sol-results-inner {
-  display: grid;
-  grid-template-columns: 1fr 1.1fr;
-  gap: clamp(40px, 5vw, 80px);
-  align-items: center;
-}
-@media (max-width: 960px) {
-  .solara-landing .sol-results-inner { grid-template-columns: 1fr; }
-}
-.solara-landing .sol-results-h {
-  font-size: clamp(40px, 5.6vw, 84px);
-  margin: 14px 0 22px;
-}
-.solara-landing .sol-results-sub {
-  color: var(--sol-fg-mute);
-  font-size: 16px;
-  line-height: 1.6;
-  max-width: 46ch;
-  margin: 0 0 32px;
-}
-.solara-landing .sol-results-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-.solara-landing .sol-results-list li {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-  padding: 14px 0;
-  border-bottom: 1px solid var(--sol-line);
-  font-size: 15px;
-  color: var(--sol-fg);
-}
-.solara-landing .sol-results-list-v {
-  color: var(--sol-accent);
-  font-weight: 600;
-}
-
-.solara-landing .sol-results-mock {
-  background: var(--sol-bg);
-  border: 1px solid var(--sol-line);
-  border-radius: var(--sol-radius);
-  overflow: hidden;
-  box-shadow: 0 30px 60px -28px rgba(180,106,60,.22), 0 0 0 1px oklch(0.30 0.012 60 / 0.03);
-}
-.solara-landing .sol-results-mock-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 12px 16px;
-  border-bottom: 1px solid var(--sol-line);
-  background: var(--sol-bg-2);
-}
-.solara-landing .sol-results-mock-dots {
-  display: flex;
-  gap: 5px;
-}
-.solara-landing .sol-results-mock-dots span {
-  width: 9px;
-  height: 9px;
-  border-radius: 50%;
-  background: var(--sol-line-2);
-}
-.solara-landing .sol-results-mock-title { color: var(--sol-fg-mute); }
-.solara-landing .sol-results-mock-live {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  color: var(--sol-good);
-}
-.solara-landing .sol-live-dot {
-  width: 6px;
-  height: 6px;
-  background: var(--sol-good);
-  border-radius: 50%;
-  animation: sol-pulse-dot 1.8s ease-in-out infinite;
-}
-.solara-landing .sol-results-mock-body {
-  padding: 22px;
-  display: flex;
-  flex-direction: column;
-  gap: 22px;
-}
-.solara-landing .sol-results-mock-row {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 14px;
-}
-.solara-landing .sol-results-mock-stat {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  padding: 14px;
-  background: var(--sol-bg-2);
-  border: 1px solid var(--sol-line);
-  border-radius: 10px;
-}
-.solara-landing .sol-results-mock-big {
-  font-family: var(--sol-font-display);
-  font-size: clamp(26px, 2.8vw, 36px);
-  color: var(--sol-fg);
-  letter-spacing: -0.03em;
-  font-weight: 600;
-  line-height: 1;
-}
-.solara-landing .sol-results-mock-delta {
-  color: var(--sol-good);
-  font-size: 11px;
-  font-family: var(--sol-font-mono);
-  font-weight: 600;
-}
-.solara-landing .sol-results-mock-chart { position: relative; padding: 10px 0 0; }
-.solara-landing .sol-results-mock-axis {
-  display: flex;
-  justify-content: space-between;
-  color: var(--sol-fg-dim);
-  padding: 8px 4px 0;
-  font-size: 10px !important;
-  font-family: var(--sol-font-mono);
-}
-.solara-landing .sol-results-mock-list {
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
-  background: var(--sol-line);
-  border: 1px solid var(--sol-line);
-  border-radius: 10px;
-  overflow: hidden;
-}
-.solara-landing .sol-results-mock-item {
-  display: grid;
-  grid-template-columns: auto 1fr auto auto;
-  gap: 14px;
-  align-items: center;
-  padding: 12px 14px;
-  background: var(--sol-bg);
-  font-size: 13px;
-}
-.solara-landing .sol-results-mock-tag {
-  font-family: var(--sol-font-mono);
-  font-size: 9.5px;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  padding: 3px 8px;
-  border-radius: 999px;
-  font-weight: 600;
-}
-.solara-landing .sol-results-mock-tag.is-new {
-  color: var(--sol-accent);
-  background: rgba(180,106,60,.1);
-  border: 1px solid rgba(180,106,60,.3);
-}
-.solara-landing .sol-results-mock-tag.is-call {
-  color: var(--sol-info);
-  background: oklch(0.48 0.14 230 / .1);
-  border: 1px solid oklch(0.48 0.14 230 / .3);
-}
-.solara-landing .sol-results-mock-tag.is-booked {
-  color: var(--sol-good);
-  background: oklch(0.52 0.16 145 / .1);
-  border: 1px solid oklch(0.52 0.16 145 / .3);
-}
-.solara-landing .sol-results-mock-prod {
-  color: var(--sol-fg-mute);
-  font-size: 11px;
-}
-.solara-landing .sol-results-mock-time {
-  color: var(--sol-fg-dim);
-  font-size: 11px;
-  font-family: var(--sol-font-mono);
-}
-
-/* ══════════════════════════════════════════════════════════════
-   GUARANTEE — warm-cremes Risiko-Umkehr
-   ══════════════════════════════════════════════════════════════ */
-.solara-landing .sol-guarantee {
-  position: relative;
-  overflow: hidden;
-  background: var(--sol-bg-warm);
-}
-.solara-landing .sol-guarantee-inner {
-  max-width: 880px;
-  margin: 0 auto;
-  text-align: center;
-  position: relative;
-}
-.solara-landing .sol-guarantee-glow {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 720px;
-  height: 720px;
-  background: radial-gradient(circle, rgba(201,122,26,.20) 0%, transparent 60%);
-  filter: blur(40px);
-  pointer-events: none;
-  z-index: -1;
-}
-.solara-landing .sol-guarantee-h {
-  font-size: clamp(44px, 6.8vw, 100px);
-  margin: 22px 0 24px;
-}
-.solara-landing .sol-guarantee-sub {
-  color: var(--sol-fg-mute);
-  font-size: clamp(16px, 1.3vw, 19px);
-  line-height: 1.55;
-  max-width: 56ch;
-  margin: 0 auto 50px;
-}
-.solara-landing .sol-guarantee-points {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: clamp(16px, 2vw, 28px);
-  text-align: left;
-}
-@media (max-width: 760px) {
-  .solara-landing .sol-guarantee-points { grid-template-columns: 1fr; }
-}
-.solara-landing .sol-guarantee-point {
-  display: flex;
-  gap: 14px;
-  align-items: flex-start;
-  padding: 24px;
-  border: 1px solid var(--sol-line);
-  border-radius: 14px;
-  background: var(--sol-bg);
-}
-.solara-landing .sol-guarantee-point-mark {
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
-  background: rgba(180,106,60,.1);
-  color: var(--sol-accent);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid rgba(180,106,60,.3);
+  background: var(--accent);
   flex-shrink: 0;
 }
-.solara-landing .sol-guarantee-point-mark svg { width: 16px; height: 16px; }
-.solara-landing .sol-guarantee-point-t {
-  font-weight: 600;
-  font-size: 16px;
-  margin-bottom: 4px;
-  color: var(--sol-fg);
-}
-.solara-landing .sol-guarantee-point-s {
-  color: var(--sol-fg-mute);
-  font-size: 13.5px;
-  line-height: 1.6;
-}
 
-/* ══════════════════════════════════════════════════════════════
-   Vertiefung — Themen-Hub für SEO-Sub-Pages (Champions-League-Polish)
-   ══════════════════════════════════════════════════════════════ */
-.solara-landing .sol-deeper {
-  background: var(--sol-bg-2);
-  border-top: 1px solid var(--sol-line);
-}
-.solara-landing .sol-deeper-inner {
-  max-width: 1180px;
-  margin: 0 auto;
-  text-align: center;
-}
-.solara-landing .sol-deeper-h {
-  font-size: clamp(36px, 5.4vw, 72px);
-  margin: 22px 0 18px;
-  color: var(--sol-fg);
-}
-.solara-landing .sol-deeper-sub {
-  color: var(--sol-fg-mute);
-  font-size: clamp(15px, 1.2vw, 18px);
-  line-height: 1.55;
-  max-width: 62ch;
-  margin: 0 auto 48px;
-}
-.solara-landing .sol-deeper-clusters {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: clamp(20px, 2.4vw, 32px);
-  text-align: left;
-}
-@media (max-width: 760px) {
-  .solara-landing .sol-deeper-clusters { grid-template-columns: 1fr; }
-}
-.solara-landing .sol-deeper-cluster {
-  position: relative;
-  padding: clamp(28px, 3vw, 40px);
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  border-radius: 18px;
-  background:
-    linear-gradient(160deg, rgba(180, 106, 60, 0.05) 0%, transparent 55%),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.02) 0%, rgba(0, 0, 0, 0.08) 100%),
-    var(--sol-bg);
-  box-shadow:
-    0 1px 0 rgba(255, 255, 255, 0.04) inset,
-    0 24px 48px -24px rgba(0, 0, 0, 0.45);
-  transition: transform 0.28s cubic-bezier(0.22, 1, 0.36, 1),
-              border-color 0.28s ease,
-              box-shadow 0.28s ease;
-}
-.solara-landing .sol-deeper-cluster:hover {
-  transform: translateY(-2px);
-  border-color: rgba(180, 106, 60, 0.32);
-  box-shadow:
-    0 1px 0 rgba(255, 255, 255, 0.06) inset,
-    0 32px 56px -24px rgba(0, 0, 0, 0.55),
-    0 0 0 1px rgba(180, 106, 60, 0.18);
-}
-.solara-landing .sol-deeper-cluster-h {
-  font-family: 'JetBrains Mono', 'Fira Code', ui-monospace, monospace;
-  font-size: 11px;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  font-weight: 600;
-  margin: 0 0 22px;
-  color: var(--sol-accent);
-}
-.solara-landing .sol-deeper-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0;
-}
-.solara-landing .sol-deeper-item {
-  border-top: 1px solid rgba(255, 255, 255, 0.06);
-}
-.solara-landing .sol-deeper-item:first-child {
-  border-top: 0;
-}
-.solara-landing .sol-deeper-link {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 16px;
-  padding: 18px 0;
-  text-decoration: none;
-  color: var(--sol-fg);
-  transition: color 0.18s ease, padding-left 0.18s ease;
-  border-radius: 4px;
-}
-.solara-landing .sol-deeper-link::after {
-  content: '→';
-  flex-shrink: 0;
-  align-self: center;
-  font-size: 18px;
-  line-height: 1;
-  color: rgba(255, 255, 255, 0.28);
-  transform: translateX(-4px);
-  transition: color 0.18s ease, transform 0.22s ease;
-}
-.solara-landing .sol-deeper-link:hover,
-.solara-landing .sol-deeper-link:focus-visible {
-  color: var(--sol-accent);
-  padding-left: 4px;
-}
-.solara-landing .sol-deeper-link:hover::after,
-.solara-landing .sol-deeper-link:focus-visible::after {
-  color: var(--sol-accent);
-  transform: translateX(0);
-}
-.solara-landing .sol-deeper-link:focus-visible {
-  outline: 2px solid var(--sol-accent);
-  outline-offset: 4px;
-}
-.solara-landing .sol-deeper-link-t {
-  display: block;
-  font-weight: 600;
-  font-size: 17px;
-  line-height: 1.3;
-  margin-bottom: 6px;
-  color: var(--sol-fg);
-  transition: color 0.18s ease;
-}
-.solara-landing .sol-deeper-link:hover .sol-deeper-link-t,
-.solara-landing .sol-deeper-link:focus-visible .sol-deeper-link-t {
-  color: var(--sol-accent);
-}
-.solara-landing .sol-deeper-link-s {
-  display: block;
-  color: var(--sol-fg-mute);
-  font-size: 14px;
-  line-height: 1.55;
-}
-@media (prefers-reduced-motion: reduce) {
-  .solara-landing .sol-deeper-cluster,
-  .solara-landing .sol-deeper-link,
-  .solara-landing .sol-deeper-link::after,
-  .solara-landing .sol-deeper-link-t {
-    transition: none;
-  }
-  .solara-landing .sol-deeper-cluster:hover {
-    transform: none;
-  }
-}
-
-/* ══════════════════════════════════════════════════════════════
-   FAQ
-   ══════════════════════════════════════════════════════════════ */
-.solara-landing .sol-faq {
-  border-top: 1px solid var(--sol-line);
-}
-.solara-landing .sol-faq-inner {
-  display: grid;
-  grid-template-columns: 1fr 1.4fr;
-  gap: clamp(40px, 6vw, 100px);
-  align-items: start;
-}
-@media (max-width: 960px) {
-  .solara-landing .sol-faq-inner { grid-template-columns: 1fr; }
-  .solara-landing .sol-faq-left { position: static; }
-}
-.solara-landing .sol-faq-left {
-  position: sticky;
-  top: 100px;
-}
-.solara-landing .sol-faq-h {
-  font-size: clamp(40px, 5.6vw, 80px);
-  margin: 14px 0 22px;
-}
-.solara-landing .sol-faq-sub {
-  color: var(--sol-fg-mute);
-  font-size: 15px;
-  line-height: 1.6;
-  max-width: 36ch;
-}
-.solara-landing .sol-faq-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: flex;
-  flex-direction: column;
-}
-.solara-landing .sol-faq-item { border-top: 1px solid var(--sol-line); }
-.solara-landing .sol-faq-item:last-child { border-bottom: 1px solid var(--sol-line); }
-.solara-landing .sol-faq-q {
-  appearance: none;
-  border: 0;
-  background: transparent;
-  color: var(--sol-fg);
-  display: flex;
-  align-items: center;
-  gap: 22px;
-  width: 100%;
-  text-align: left;
-  padding: 24px 0;
-  font: 500 clamp(16px, 1.5vw, 19px)/1.35 var(--sol-font-body);
-  cursor: pointer;
-}
-.solara-landing .sol-faq-q-n {
-  color: var(--sol-fg-dim);
-  flex-shrink: 0;
-  font-family: var(--sol-font-mono);
-  font-size: 11px;
-  letter-spacing: 0.06em;
-  font-weight: 600;
-}
-.solara-landing .sol-faq-q-t { flex: 1; }
-.solara-landing .sol-faq-q-mark {
-  position: relative;
-  width: 14px;
-  height: 14px;
-  flex-shrink: 0;
-}
-.solara-landing .sol-faq-q-mark span {
-  position: absolute;
-  background: var(--sol-fg-mute);
-  transition: transform var(--sol-t-fast), background var(--sol-t-fast);
-}
-.solara-landing .sol-faq-q-mark span:nth-child(1) {
-  left: 0;
-  right: 0;
-  top: 50%;
-  height: 1.5px;
-  transform: translateY(-50%);
-}
-.solara-landing .sol-faq-q-mark span:nth-child(2) {
-  top: 0;
-  bottom: 0;
-  left: 50%;
-  width: 1.5px;
-  transform: translateX(-50%);
-}
-.solara-landing .sol-faq-item.is-open .sol-faq-q-mark span:nth-child(2) {
-  transform: translateX(-50%) scaleY(0);
-}
-.solara-landing .sol-faq-item.is-open .sol-faq-q-mark span { background: var(--sol-accent); }
-.solara-landing .sol-faq-a-wrap {
-  display: grid;
-  grid-template-rows: 0fr;
-  transition: grid-template-rows 360ms cubic-bezier(.2,.7,.2,1);
-}
-.solara-landing .sol-faq-item.is-open .sol-faq-a-wrap { grid-template-rows: 1fr; }
-.solara-landing .sol-faq-a-wrap > .sol-faq-a {
-  overflow: hidden;
-  min-height: 0;
-}
-.solara-landing .sol-faq-a {
-  color: var(--sol-fg-mute);
-  font-size: 15px;
-  line-height: 1.65;
-  padding: 0 40px 24px calc(11px + 22px);
-  max-width: 60ch;
-}
-
-/* ══════════════════════════════════════════════════════════════
-   FINAL CTA — warmes Sonnenfeld als Reim auf den Hero
-   ══════════════════════════════════════════════════════════════ */
-.solara-landing .sol-final {
-  position: relative;
-  overflow: hidden;
-  padding-bottom: 0;
-}
-.solara-landing .sol-final-inner {
-  position: relative;
-  padding: clamp(60px, 9vw, 140px) clamp(24px, 4vw, 64px);
-  text-align: center;
-  border: 1px solid var(--sol-line);
-  border-radius: 24px;
-  overflow: hidden;
-  background: linear-gradient(180deg, var(--sol-bg-warm) 0%, oklch(0.90 0.060 60) 100%);
-  isolation: isolate;
-}
-.solara-landing .sol-final-sun {
-  position: absolute;
-  left: 50%;
-  top: 120%;
-  transform: translateX(-50%);
-  width: 900px;
-  height: 900px;
-  z-index: -1;
-  pointer-events: none;
-}
-.solara-landing .sol-final-sun-disc {
-  position: absolute;
-  inset: 0;
-  border-radius: 50%;
-  background: radial-gradient(circle at 50% 40%, oklch(0.92 0.16 80) 0%, oklch(0.78 0.18 55) 30%, transparent 60%);
-  filter: blur(2px);
-  animation: sol-pulse 7s ease-in-out infinite;
-}
-.solara-landing .sol-final-h {
-  font-size: clamp(44px, 7vw, 104px);
-  margin: 18px 0 22px;
-}
-.solara-landing .sol-final-sub {
-  color: var(--sol-fg-mute);
-  font-size: clamp(15px, 1.2vw, 17px);
-  margin: 0 0 36px;
-}
-.solara-landing .sol-final-btn {
-  padding: 18px 28px;
-  font-size: 16px;
-}
-.solara-landing .sol-final-btn .sol-btn-arrow {
-  width: 28px;
-  height: 28px;
-}
-.solara-landing .sol-final-btn .sol-btn-arrow svg {
-  width: 13px;
-  height: 13px;
-}
-.solara-landing .sol-final-micro {
-  margin-top: 24px;
-  color: var(--sol-fg-dim);
-  font-family: var(--sol-font-mono);
-  font-size: 10.5px;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-/* ══════════════════════════════════════════════════════════════
-   STICKY MOBILE CTA
-   ══════════════════════════════════════════════════════════════ */
-.solara-landing .sol-sticky-cta { display: none; }
-@media (max-width: 760px) {
-  .solara-landing .sol-sticky-cta {
-    display: flex;
-    position: fixed;
-    left: 12px;
-    right: 12px;
-    bottom: 12px;
-    z-index: 50;
-    padding: 14px 18px;
-    border-radius: 999px;
-    background: var(--sol-accent);
-    color: var(--sol-accent-ink);
-    font: 600 15px/1 var(--sol-font-body);
-    text-decoration: none;
-    box-shadow: 0 12px 40px rgba(180,106,60,.35), 0 0 0 1px rgba(0,0,0,.05);
-    align-items: center;
-    justify-content: space-between;
-    opacity: 0;
-    transform: translateY(120%);
-    transition: opacity var(--sol-t-med), transform var(--sol-t-med);
-    pointer-events: none;
-  }
-  .solara-landing .sol-sticky-cta.is-visible {
-    opacity: 1;
-    transform: translateY(0);
-    pointer-events: auto;
-  }
-  .solara-landing .sol-sticky-cta-arrow {
-    display: inline-flex;
-    width: 26px;
-    height: 26px;
-    border-radius: 50%;
-    background: rgba(255,255,255,.22);
-    align-items: center;
-    justify-content: center;
-  }
-}
-
-@media (max-width: 560px) {
-  .solara-landing .sol-sticky-cta {
-    left: 10px;
-    right: 10px;
-    padding: 12px 14px;
-    border-radius: 18px;
-    gap: 10px;
-    line-height: 1.15;
-    white-space: normal;
-  }
-}
-
-@media (max-width: 360px) {
-  .solara-landing .sol-sticky-cta-arrow {
-    display: none;
-  }
-}
-
-/* ── prefers-reduced-motion ───────────────────────────────── */
-@media (prefers-reduced-motion: reduce) {
-  .solara-landing .sol-hero-sun-disc,
-  .solara-landing .sol-hero-sun-halo,
-  .solara-landing .sol-hero-sun-rays,
-  .solara-landing .sol-final-sun-disc,
-  .solara-landing .sol-cta-tag-dot,
-  .solara-landing .sol-live-dot,
-  .solara-landing .sol-cta-card::after,
-  .solara-landing .sol-cta-particle,
-  .solara-landing .sol-quiz-progress-shimmer {
-    animation: none !important;
-  }
-  .solara-landing .sol-quiz-opt {
-    opacity: 1 !important;
-    transform: none !important;
-    animation: none !important;
-  }
-}
-
-/* ── Theme-Title-Bar verbergen (Hero füllt H1 selbst) ────── */
-body.page-template-page-solar-waermepumpen-leadgenerierung .entry-header,
-body.page-template-page-solar-waermepumpen-leadgenerierung .ct-page-title,
-body.page-template-page-solar-waermepumpen-leadgenerierung-php .entry-header,
-body.page-template-page-solar-waermepumpen-leadgenerierung-php .ct-page-title {
-  display: none !important;
-}
-
-/* ══════════════════════════════════════════════════════════════
-   CRO ADD-ON (2026-05-15) — Design-Import aus Solar Leadgen CRO
-   Neue Sektionen: Section-Nav · Compare · System-Diagramm ·
-   CAPEX vs OPEX · Fit-Check.
-   Stilistisch eingebettet in das warm-creme SOLARA-Vokabular
-   (kein dark-mode-Bruch zum Bestand).
-   ══════════════════════════════════════════════════════════════ */
-
-/* ── In-Page Section Nav · sticky unter dem globalen Header ───
-   Position-Top wird durch sol-hero.js gesetzt (CSS-Var --sol-nav-top),
-   sodass der Blocksy-Sticky-Header nicht den In-Page-Nav verdeckt.
-   Fallback ohne JS: top:0. */
+/* ─── 6) Sticky Section-Nav ─────────────────────────────────── */
 .solara-landing .sol-section-nav {
   position: sticky;
   top: var(--sol-nav-top, 0px);
-  z-index: 28;
-  background: oklch(0.97 0.008 80 / 0.92);
+  z-index: 40;
+  background: rgba(11, 15, 18, .82);
   backdrop-filter: blur(14px) saturate(140%);
   -webkit-backdrop-filter: blur(14px) saturate(140%);
-  border-bottom: 1px solid var(--sol-line);
-  font-size: 12px;
+  border-bottom: 1px solid var(--line);
 }
 .solara-landing .sol-section-nav-inner {
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: 18px;
   padding: 10px 0;
 }
 .solara-landing .sol-section-nav-label {
-  color: var(--sol-fg-dim);
+  font-size: 10px;
+  letter-spacing: .16em;
+  text-transform: uppercase;
+  color: var(--fg-4);
   flex-shrink: 0;
-  white-space: nowrap;
 }
 .solara-landing .sol-section-nav-list {
   display: flex;
@@ -2020,1077 +653,315 @@ body.page-template-page-solar-waermepumpen-leadgenerierung-php .ct-page-title {
   margin: 0;
   overflow-x: auto;
   scrollbar-width: none;
-  -webkit-overflow-scrolling: touch;
   flex: 1;
-  min-width: 0;
 }
 .solara-landing .sol-section-nav-list::-webkit-scrollbar { display: none; }
 .solara-landing .sol-section-nav-list a {
-  display: inline-flex;
-  align-items: center;
+  display: inline-block;
   padding: 6px 10px;
   border-radius: 999px;
-  color: var(--sol-fg-mute);
-  text-decoration: none;
   font-size: 11px;
-  letter-spacing: 0.05em;
+  letter-spacing: .06em;
+  color: var(--fg-2);
   white-space: nowrap;
-  transition: color var(--sol-t-fast), background var(--sol-t-fast);
+  transition: color .15s, background .15s;
 }
 .solara-landing .sol-section-nav-list a:hover {
-  color: var(--sol-accent);
-  background: var(--sol-accent-tint);
+  color: var(--accent);
+  background: rgba(224, 138, 60, .08);
 }
 .solara-landing .sol-section-nav-cta {
   flex-shrink: 0;
-  padding: 8px 14px;
+  padding: 8px 16px;
   border-radius: 999px;
-  background: var(--sol-accent);
-  color: var(--sol-accent-ink);
-  text-decoration: none;
-  font-size: 11px;
-  letter-spacing: 0.05em;
+  background: var(--accent);
+  color: #1A0F05;
+  font-size: 11.5px;
   font-weight: 600;
-  transition: background var(--sol-t-fast), transform var(--sol-t-fast);
+  letter-spacing: .04em;
+  transition: background .15s, transform .15s;
 }
-.solara-landing .sol-section-nav-cta:hover {
-  background: var(--sol-accent-2);
-  transform: translateY(-1px);
-}
-@media (max-width: 720px) {
+.solara-landing .sol-section-nav-cta:hover { background: #EA9A4F; transform: translateY(-1px); }
+@media (max-width: 820px) {
   .solara-landing .sol-section-nav-label { display: none; }
 }
 
-/* ── Compare · Markt-Standard vs Eigener Weg ────────────────── */
-.solara-landing .sol-compare-h {
-  font-size: clamp(34px, 4.5vw, 64px);
-  margin: 12px 0 14px;
-  max-width: 22ch;
-}
-.solara-landing .sol-compare-sub {
-  margin: 0 0 44px;
-  color: var(--sol-fg-mute);
-  max-width: 60ch;
-  font-size: clamp(15px, 1.1vw, 18px);
-}
-.solara-landing .sol-compare {
-  display: grid;
-  grid-template-columns: 1fr 64px 1fr;
-  align-items: stretch;
-  border: 1px solid var(--sol-line);
-  border-radius: 20px;
-  overflow: hidden;
-  background: #fff;
-  position: relative;
-}
-.solara-landing .sol-compare-col {
-  padding: 36px 32px;
-  position: relative;
-}
-.solara-landing .sol-compare-col--bad {
-  background:
-    repeating-linear-gradient(135deg, transparent 0 18px, rgba(199,112,95,.03) 18px 19px),
-    linear-gradient(180deg, rgba(199,112,95,.05), transparent 60%);
-}
-.solara-landing .sol-compare-col--good {
-  background:
-    radial-gradient(ellipse 60% 50% at 50% 0%, var(--sol-accent-tint-2), transparent 70%),
-    linear-gradient(180deg, var(--sol-accent-tint), transparent 60%);
-  box-shadow: inset 0 0 0 1px var(--sol-accent-tint-2);
-}
-.solara-landing .sol-compare-tag {
-  position: absolute;
-  top: 18px;
-  right: 22px;
-  font-size: 10px;
-  letter-spacing: 0.14em;
-  color: #c25a48;
-  opacity: 0.7;
-}
-.solara-landing .sol-compare-tag--good {
-  color: var(--sol-accent);
-  opacity: 1;
-  font-weight: 600;
-}
-.solara-landing .sol-compare-head {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  font-weight: 700;
-  font-size: 17px;
-  color: var(--sol-fg);
-  margin-bottom: 26px;
-  font-family: var(--sol-font-display);
-}
-.solara-landing .sol-compare-icon {
-  width: 30px;
-  height: 30px;
-  display: grid;
-  place-items: center;
-  border-radius: 8px;
-  font-weight: 700;
-  font-size: 14px;
-  flex-shrink: 0;
-}
-.solara-landing .sol-compare-icon--bad {
-  background: rgba(199,112,95,.18);
-  color: #c25a48;
-}
-.solara-landing .sol-compare-icon--good {
-  background: var(--sol-accent);
-  color: var(--sol-accent-ink);
-  box-shadow: 0 0 0 4px var(--sol-accent-tint);
-}
-.solara-landing .sol-compare-icon--good svg { width: 16px; height: 16px; }
-.solara-landing .sol-compare-row {
-  padding: 16px 0;
-  border-top: 1px solid var(--sol-line);
-}
-.solara-landing .sol-compare-row:first-of-type {
-  border-top: 0;
-  padding-top: 0;
-}
-.solara-landing .sol-compare-row-t {
-  font-weight: 600;
-  color: var(--sol-fg);
-  font-size: 16px;
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-.solara-landing .sol-compare-row-t::before {
-  content: "";
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  flex-shrink: 0;
-}
-.solara-landing .sol-compare-col--bad .sol-compare-row-t::before { background: #c25a48; opacity: 0.7; }
-.solara-landing .sol-compare-col--good .sol-compare-row-t::before {
-  background: var(--sol-accent);
-  box-shadow: 0 0 0 3px var(--sol-accent-tint);
-}
-.solara-landing .sol-compare-row-d {
-  font-size: 14px;
-  color: var(--sol-fg-mute);
-  margin-top: 6px;
-  line-height: 1.55;
-  padding-left: 17px;
-}
-.solara-landing .sol-compare-divider {
-  background: var(--sol-bg-2);
-  display: grid;
-  place-items: center;
-  position: relative;
-}
-.solara-landing .sol-compare-divider::before {
-  content: "";
-  position: absolute;
-  left: 50%;
-  top: 0;
-  bottom: 0;
-  width: 1px;
-  background: linear-gradient(180deg, transparent, var(--sol-accent), transparent);
-  opacity: 0.5;
-}
-.solara-landing .sol-compare-divider-icon {
-  position: relative;
-  z-index: 2;
-  width: 38px;
-  height: 38px;
-  border-radius: 50%;
-  background: var(--sol-bg-2);
-  display: grid;
-  place-items: center;
-  color: var(--sol-accent);
-  border: 1px solid var(--sol-line);
-}
-.solara-landing .sol-compare-divider-icon svg { width: 16px; height: 16px; }
-@media (max-width: 880px) {
-  .solara-landing .sol-compare {
-    grid-template-columns: 1fr;
-  }
-  .solara-landing .sol-compare-col--bad {
-    border-bottom: 1px solid var(--sol-line);
-  }
-  .solara-landing .sol-compare-divider { display: none; }
-}
-
-/* ── System-Diagramm: 4 Layer (Fundament → Skalierung) ──────── */
-.solara-landing .sol-system-section { padding-top: clamp(80px, 11vw, 160px); }
-.solara-landing .sol-system-head {
-  text-align: center;
-  max-width: 760px;
-  margin: 0 auto 56px;
-}
-.solara-landing .sol-system-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 6px 16px;
-  border-radius: 999px;
-  background: var(--sol-accent-tint);
-  border: 1px solid var(--sol-accent-tint-2);
-  color: var(--sol-accent);
-  font-size: 11px;
-  letter-spacing: 0.12em;
-}
-.solara-landing .sol-system-badge-pulse {
-  width: 8px;
-  height: 8px;
-  background: var(--sol-accent);
-  border-radius: 50%;
-  animation: sol-pulse-dot 2s ease-in-out infinite;
-}
-.solara-landing .sol-system-h {
-  font-size: clamp(34px, 4.5vw, 58px);
-  margin: 18px 0 14px;
-}
-.solara-landing .sol-system-sub {
-  color: var(--sol-fg-mute);
-  font-size: clamp(15px, 1.1vw, 18px);
-  margin: 0;
-  line-height: 1.6;
-}
-
-.solara-landing .sol-system-canvas {
-  max-width: 980px;
-  margin: 0 auto;
-  display: flex;
-  flex-direction: column;
-  gap: 22px;
-}
-.solara-landing .sol-system-layer {
-  position: relative;
-  background: #fff;
-  border: 1px solid var(--sol-line);
-  border-radius: 18px;
-  padding: 30px 32px;
-  transition: border-color var(--sol-t-med), box-shadow var(--sol-t-med), transform var(--sol-t-med);
-  opacity: 0;
-  transform: translateY(20px);
-  animation: sol-layer-in 0.7s cubic-bezier(0.16, 1, 0.3, 1) forwards;
-  animation-delay: var(--sol-delay, 0s);
-}
-@keyframes sol-layer-in {
-  to { opacity: 1; transform: translateY(0); }
-}
-.solara-landing .sol-system-layer:hover {
-  border-color: var(--sol-accent-tint-2);
-  box-shadow: 0 20px 50px -30px rgba(180,106,60,.35);
-  transform: translateX(6px);
-}
-.solara-landing .sol-system-layer-head {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  margin-bottom: 22px;
-}
-.solara-landing .sol-system-layer-n {
-  width: 44px;
-  height: 44px;
-  background: linear-gradient(135deg, var(--sol-accent), var(--sol-accent-2));
-  color: var(--sol-accent-ink);
-  border-radius: 12px;
-  display: grid;
-  place-items: center;
-  font-size: 17px;
-  font-weight: 700;
-  flex-shrink: 0;
-  box-shadow: 0 6px 18px -8px rgba(180,106,60,.55);
-}
-.solara-landing .sol-system-layer-name {
-  flex: 1;
-  font-family: var(--sol-font-display);
-  font-size: 20px;
-  font-weight: 700;
-  color: var(--sol-fg);
-  letter-spacing: -0.01em;
-}
-.solara-landing .sol-system-layer-name-link {
-  color: inherit;
-  text-decoration: none;
-  background-image: linear-gradient(currentColor, currentColor);
-  background-size: 0 1px;
-  background-repeat: no-repeat;
-  background-position: 0 100%;
-  transition: background-size .25s ease, color .25s ease;
-  padding-bottom: 2px;
-}
-.solara-landing .sol-system-layer:hover .sol-system-layer-name-link,
-.solara-landing .sol-system-layer-name-link:hover,
-.solara-landing .sol-system-layer-name-link:focus-visible {
-  color: var(--sol-accent);
-  background-size: 100% 1px;
-}
-.solara-landing .sol-system-layer-status {
-  padding: 5px 11px;
-  border: 1px solid var(--sol-line);
-  border-radius: 6px;
-  font-size: 10px;
-  letter-spacing: 0.14em;
-  color: var(--sol-fg-dim);
-}
-.solara-landing .sol-system-layer:hover .sol-system-layer-status {
-  color: var(--sol-accent);
-  border-color: var(--sol-accent-tint-2);
-  background: var(--sol-accent-tint);
-}
-.solara-landing .sol-system-grid {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 14px;
-}
-.solara-landing .sol-system-layer.is-three .sol-system-grid {
-  grid-template-columns: repeat(3, 1fr);
-}
-.solara-landing .sol-system-comp {
-  display: flex;
-  gap: 14px;
-  align-items: flex-start;
-  padding: 16px;
-  background: var(--sol-bg-2);
-  border: 1px solid var(--sol-line);
-  border-radius: 12px;
-  transition: background var(--sol-t-fast), border-color var(--sol-t-fast), transform var(--sol-t-fast);
-}
-.solara-landing .sol-system-comp:hover {
-  background: var(--sol-accent-tint);
-  border-color: var(--sol-accent-tint-2);
-  transform: translateY(-2px);
-}
-.solara-landing .sol-system-comp-icon {
-  width: 38px;
-  height: 38px;
-  border-radius: 10px;
-  background: #fff;
-  border: 1px solid var(--sol-line);
-  display: grid;
-  place-items: center;
-  color: var(--sol-accent);
-  flex-shrink: 0;
-}
-.solara-landing .sol-system-comp-icon svg { width: 18px; height: 18px; }
-.solara-landing .sol-system-comp-body { flex: 1; min-width: 0; }
-.solara-landing .sol-system-comp-t {
-  font-weight: 600;
-  font-size: 15px;
-  color: var(--sol-fg);
-  line-height: 1.3;
-}
-.solara-landing .sol-system-comp-s {
-  margin-top: 4px;
-  font-size: 13px;
-  color: var(--sol-fg-mute);
-  line-height: 1.5;
-}
-.solara-landing .sol-system-layer-connector {
-  position: absolute;
-  left: 50%;
-  bottom: -22px;
-  transform: translateX(-50%);
-  width: 2px;
-  height: 22px;
-  background: linear-gradient(180deg, var(--sol-accent), transparent);
-  border-radius: 1px;
-  pointer-events: none;
-}
-.solara-landing .sol-system-ownership {
-  display: flex;
-  gap: 22px;
-  align-items: flex-start;
-  max-width: 980px;
-  margin: 36px auto 0;
-  padding: 26px 30px;
-  background: linear-gradient(135deg, var(--sol-accent-tint-2), var(--sol-accent-tint));
-  border: 1px solid var(--sol-accent-tint-2);
-  border-radius: 16px;
-}
-.solara-landing .sol-system-ownership-mark {
-  width: 50px;
-  height: 50px;
-  background: var(--sol-accent);
-  color: var(--sol-accent-ink);
-  border-radius: 12px;
-  display: grid;
-  place-items: center;
-  flex-shrink: 0;
-  box-shadow: 0 10px 24px -10px rgba(180,106,60,.5);
-}
-.solara-landing .sol-system-ownership-mark svg { width: 22px; height: 22px; }
-.solara-landing .sol-system-ownership-t {
-  font-family: var(--sol-font-display);
-  font-weight: 700;
-  font-size: 18px;
-  color: var(--sol-fg);
-  margin-bottom: 6px;
-}
-.solara-landing .sol-system-ownership-s {
-  font-size: 14px;
-  color: var(--sol-fg-mute);
-  line-height: 1.6;
-}
-@media (max-width: 720px) {
-  .solara-landing .sol-system-grid,
-  .solara-landing .sol-system-layer.is-three .sol-system-grid {
-    grid-template-columns: 1fr;
-  }
-  .solara-landing .sol-system-layer { padding: 22px; }
-  .solara-landing .sol-system-ownership { padding: 22px; flex-direction: column; gap: 14px; }
-}
-
-/* ── CAPEX vs OPEX · Bilanz-Vergleich mit Timeframe-Picker ──── */
-.solara-landing .sol-capex-head {
-  max-width: 760px;
-  margin: 0 0 40px;
-}
-.solara-landing .sol-capex-h {
-  font-size: clamp(34px, 4.5vw, 64px);
-  margin: 14px 0 14px;
-  max-width: 18ch;
-}
-.solara-landing .sol-capex-sub {
-  margin: 0;
-  color: var(--sol-fg-mute);
-  font-size: clamp(15px, 1.1vw, 18px);
-  max-width: 60ch;
-}
+/* ─── 7) CAPEX-Picker + Summary + Sektions-CTAs ─────────────── */
 .solara-landing .sol-capex-picker {
   display: flex;
   align-items: center;
-  justify-content: center;
-  gap: 18px;
-  margin-bottom: 36px;
+  gap: 14px;
+  margin-bottom: 26px;
   flex-wrap: wrap;
 }
 .solara-landing .sol-capex-picker-label {
-  font-size: 11px;
-  letter-spacing: 0.14em;
-  color: var(--sol-fg-dim);
+  font-size: 10px;
+  letter-spacing: .16em;
+  text-transform: uppercase;
+  color: var(--fg-3);
 }
-.solara-landing .sol-capex-picker-buttons {
-  display: inline-flex;
-  gap: 4px;
-  padding: 4px;
-  background: var(--sol-bg-3);
-  border: 1px solid var(--sol-line);
-  border-radius: 12px;
-}
+.solara-landing .sol-capex-picker-buttons { display: flex; gap: 8px; }
 .solara-landing .sol-capex-picker-btn {
-  appearance: none;
-  border: 1px solid transparent;
-  padding: 10px 18px;
-  border-radius: 9px;
-  background: transparent;
-  font-family: var(--sol-font-body);
-  font-size: 13px;
+  padding: 10px 20px;
+  border: 1px solid var(--line-2);
+  border-radius: 999px;
+  color: var(--fg);
+  font-size: 14px;
   font-weight: 600;
-  color: var(--sol-fg);
   cursor: pointer;
-  transition: background var(--sol-t-fast), color var(--sol-t-fast), box-shadow var(--sol-t-fast);
+  transition: background .15s, color .15s, border-color .15s;
 }
-.solara-landing .sol-capex-picker-btn:hover { background: var(--sol-bg-2); }
+.solara-landing .sol-capex-picker-btn:hover { border-color: var(--fg-3); background: var(--bg-2); }
 .solara-landing .sol-capex-picker-btn.is-active {
-  background: #fff;
-  border-color: var(--sol-accent-tint-2);
-  color: var(--sol-accent);
-  box-shadow: 0 2px 8px -2px rgba(0,0,0,.08);
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #1A0F05;
 }
-
-.solara-landing .sol-capex-compare {
-  display: grid;
-  grid-template-columns: 1fr 56px 1fr;
-  gap: 0;
-  align-items: stretch;
-  margin-bottom: 36px;
-}
-.solara-landing .sol-capex-col {
-  background: #fff;
-  border-radius: 20px;
-  padding: 36px 32px;
-  border: 2px solid transparent;
-  display: flex;
-  flex-direction: column;
-  gap: 18px;
-}
-.solara-landing .sol-capex-col--opex {
-  border-color: rgba(199,112,95,.45);
-  background: linear-gradient(180deg, rgba(199,112,95,.05), #fff);
-}
-.solara-landing .sol-capex-col--capex {
-  border-color: var(--sol-accent-tint-2);
-  background: linear-gradient(180deg, var(--sol-accent-tint), #fff);
-  box-shadow: 0 18px 50px -30px rgba(180,106,60,.4);
-}
-.solara-landing .sol-capex-col-head { margin-bottom: 4px; }
-.solara-landing .sol-capex-col-badge {
-  display: inline-block;
-  padding: 5px 13px;
-  border-radius: 999px;
-  font-size: 11px;
-  letter-spacing: 0.16em;
-  font-weight: 600;
-  margin-bottom: 14px;
-}
-.solara-landing .sol-capex-col-badge--opex {
-  background: rgba(199,112,95,.15);
-  color: #c25a48;
-}
-.solara-landing .sol-capex-col-badge--capex {
-  background: var(--sol-accent-tint-2);
-  color: var(--sol-accent);
-}
-.solara-landing .sol-capex-col-title {
-  font-family: var(--sol-font-display);
-  font-size: clamp(22px, 2.2vw, 28px);
-  font-weight: 700;
-  letter-spacing: -0.02em;
-  margin: 0 0 6px;
-  color: var(--sol-fg);
-}
-.solara-landing .sol-capex-col-sub {
-  color: var(--sol-fg-mute);
-  font-size: 15px;
-  margin: 0;
-}
-.solara-landing .sol-capex-breakdown {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  padding-bottom: 18px;
-  border-bottom: 1px solid var(--sol-line);
-}
-.solara-landing .sol-capex-row {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 14px;
-  padding: 12px 14px;
-  background: var(--sol-bg-2);
-  border: 1px solid var(--sol-line);
-  border-radius: 10px;
-}
-.solara-landing .sol-capex-row--issue {
-  background: rgba(199,112,95,.06);
-  border-color: rgba(199,112,95,.22);
-}
-.solara-landing .sol-capex-row--benefit {
-  background: var(--sol-accent-tint);
-  border-color: var(--sol-accent-tint-2);
-}
-.solara-landing .sol-capex-row-l {
-  font-size: 14px;
-  color: var(--sol-fg-mute);
-  flex: 1;
-}
-.solara-landing .sol-capex-row-v {
-  font-weight: 600;
-  font-size: 14px;
-  color: var(--sol-fg);
-  text-align: right;
-  font-variant-numeric: tabular-nums;
-}
-.solara-landing .sol-capex-total {
-  background: var(--sol-fg);
-  color: #fff;
-  border-radius: 12px;
-  padding: 18px 20px;
-}
-.solara-landing .sol-capex-total-l {
-  font-size: 11px;
-  letter-spacing: 0.14em;
-  color: oklch(0.78 0.014 60);
-  margin-bottom: 6px;
-}
-.solara-landing .sol-capex-total-v {
-  font-size: clamp(28px, 3.4vw, 40px);
-  font-weight: 700;
-  letter-spacing: -0.03em;
-  line-height: 1;
-  font-variant-numeric: tabular-nums;
-}
-.solara-landing .sol-capex-total-v--opex { color: #e6a394; }
-.solara-landing .sol-capex-total-v--capex { color: var(--sol-accent); }
-.solara-landing .sol-capex-result {
-  display: flex;
-  align-items: center;
-  gap: 14px;
-  padding: 16px 18px;
-  border-radius: 12px;
-  background: rgba(199,112,95,.08);
-  border: 1px solid rgba(199,112,95,.25);
-}
-.solara-landing .sol-capex-result--good {
-  background: var(--sol-accent-tint);
-  border-color: var(--sol-accent-tint-2);
-}
-.solara-landing .sol-capex-result-icon {
-  width: 38px;
-  height: 38px;
-  border-radius: 10px;
-  display: grid;
-  place-items: center;
-  font-size: 16px;
-  font-weight: 700;
-  flex-shrink: 0;
-}
-.solara-landing .sol-capex-result-icon--bad {
-  background: rgba(199,112,95,.18);
-  color: #c25a48;
-}
-.solara-landing .sol-capex-result-icon--good {
-  background: var(--sol-accent);
-  color: var(--sol-accent-ink);
-}
-.solara-landing .sol-capex-result-icon--good svg { width: 18px; height: 18px; }
-.solara-landing .sol-capex-result-body strong {
-  display: block;
-  font-weight: 700;
-  font-size: 16px;
-  color: var(--sol-fg);
-  margin-bottom: 2px;
-}
-.solara-landing .sol-capex-result-body span {
-  font-size: 13px;
-  color: var(--sol-fg-mute);
-}
-.solara-landing .sol-capex-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-.solara-landing .sol-capex-list li {
-  display: flex;
-  gap: 10px;
-  font-size: 14px;
-  color: var(--sol-fg);
-  line-height: 1.55;
-}
-.solara-landing .sol-capex-list-x,
-.solara-landing .sol-capex-list-v {
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-  display: grid;
-  place-items: center;
-  font-size: 11px;
-  font-weight: 700;
-  flex-shrink: 0;
-  margin-top: 1px;
-}
-.solara-landing .sol-capex-list-x {
-  background: rgba(199,112,95,.18);
-  color: #c25a48;
-}
-.solara-landing .sol-capex-list-v {
-  background: var(--sol-accent-tint-2);
-  color: var(--sol-accent);
-}
-
-.solara-landing .sol-capex-divider {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 10px;
-}
-.solara-landing .sol-capex-divider-line {
-  width: 1px;
-  flex: 1;
-  background: linear-gradient(180deg, transparent, var(--sol-line-2), transparent);
-}
-.solara-landing .sol-capex-divider-tag {
-  padding: 8px 14px;
-  background: var(--sol-fg);
-  color: var(--sol-accent);
-  border-radius: 999px;
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.18em;
-}
-
 .solara-landing .sol-capex-summary {
-  background: var(--sol-fg);
-  color: oklch(0.92 0.014 60);
+  margin-top: 26px;
+  padding: 24px 28px;
+  border: 1px solid var(--line);
   border-radius: 18px;
-  padding: 32px 36px;
-  margin-bottom: 32px;
+  background: var(--bg-2);
 }
 .solara-landing .sol-capex-summary-h {
-  font-family: var(--sol-font-display);
-  font-size: 22px;
+  font-size: 17px;
   font-weight: 700;
-  letter-spacing: -0.02em;
-  color: var(--sol-accent);
-  margin: 0 0 12px;
+  letter-spacing: -.01em;
+  margin: 0 0 8px;
 }
 .solara-landing .sol-capex-summary p {
   margin: 0;
-  font-size: 15px;
-  line-height: 1.7;
-  max-width: 72ch;
+  color: var(--fg-2);
+  font-size: 14.5px;
+  line-height: 1.6;
+  max-width: 90ch;
 }
-.solara-landing .sol-capex-summary strong {
-  color: #fff;
-  font-weight: 600;
+.solara-landing .sol-capex-summary strong { color: var(--fg); }
+.solara-landing .sol-section-cta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 12px;
+  margin-top: 30px;
 }
-.solara-landing .sol-capex-cta {
-  text-align: center;
-}
-.solara-landing .sol-capex-cta-micro {
-  margin-top: 14px;
-  font-size: 11px;
-  letter-spacing: 0.14em;
-  color: var(--sol-fg-dim);
-}
-@media (max-width: 920px) {
-  .solara-landing .sol-capex-compare {
-    grid-template-columns: 1fr;
-    gap: 22px;
-  }
-  .solara-landing .sol-capex-divider {
-    flex-direction: row;
-    width: 100%;
-  }
-  .solara-landing .sol-capex-divider-line {
-    width: auto;
-    flex: 1;
-    height: 1px;
-    background: linear-gradient(90deg, transparent, var(--sol-line-2), transparent);
-  }
-}
-@media (max-width: 560px) {
-  .solara-landing .sol-capex-col { padding: 26px 22px; }
-  .solara-landing .sol-capex-summary { padding: 24px 22px; }
+.solara-landing .sol-section-cta-micro {
+  font-size: 10.5px;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  color: var(--fg-3);
 }
 
-/* ── Fit-Check (passt / passt nicht) ────────────────────────── */
-.solara-landing .sol-fit-section { padding-top: clamp(80px, 11vw, 160px); }
-.solara-landing .sol-fit-head {
-  text-align: center;
-  max-width: 720px;
-  margin: 0 auto 48px;
-}
-.solara-landing .sol-fit-head .sol-eyebrow { justify-content: center; }
-.solara-landing .sol-fit-h {
-  font-size: clamp(34px, 4.5vw, 58px);
-  margin: 16px 0 12px;
-}
-.solara-landing .sol-fit-sub {
-  color: var(--sol-fg-mute);
-  font-size: clamp(15px, 1.1vw, 18px);
-  margin: 0;
-}
-.solara-landing .sol-fit-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 22px;
-}
-.solara-landing .sol-fit-col {
-  background: #fff;
-  border: 1px solid var(--sol-line);
-  border-radius: 16px;
-  padding: 30px;
-}
-.solara-landing .sol-fit-col--yes { border-top: 3px solid var(--sol-accent); }
-.solara-landing .sol-fit-col--no  { border-top: 3px solid #c25a48; background: var(--sol-bg-warm); }
-.solara-landing .sol-fit-col-head {
+/* Proof-Sektion: Abbinder (Tiefendiagnose + E3-Case-Link) */
+.solara-landing .sol-proof-foot {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  gap: 12px;
-  font-family: var(--sol-font-display);
-  font-weight: 700;
-  font-size: 18px;
-  color: var(--sol-fg);
-  margin-bottom: 22px;
+  justify-content: space-between;
+  gap: 18px;
+  margin-top: 30px;
+  padding-top: 24px;
+  border-top: 1px solid var(--line);
 }
-.solara-landing .sol-fit-col-badge {
-  width: 32px;
-  height: 32px;
-  border-radius: 8px;
+.solara-landing .sol-proof-foot p {
+  margin: 0;
+  color: var(--fg-2);
+  font-size: 14.5px;
+  line-height: 1.6;
+  max-width: 62ch;
+}
+
+/* ─── 8) Risiko-Umkehr-Karten ───────────────────────────────── */
+.solara-landing .sol-risk-grid {
   display: grid;
-  place-items: center;
-  flex-shrink: 0;
-  font-size: 14px;
-  font-weight: 700;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
 }
-.solara-landing .sol-fit-col-badge--yes {
-  background: var(--sol-accent);
-  color: var(--sol-accent-ink);
+@media (max-width: 900px) {
+  .solara-landing .sol-risk-grid { grid-template-columns: 1fr; }
 }
-.solara-landing .sol-fit-col-badge--yes svg { width: 16px; height: 16px; }
-.solara-landing .sol-fit-col-badge--no {
-  background: #c25a48;
-  color: #fff;
+.solara-landing .sol-risk-card {
+  height: 100%;
+  padding: 28px;
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  background: var(--bg-2);
 }
-.solara-landing .sol-fit-list {
+.solara-landing .sol-risk-card .hu-eyebrow { color: var(--accent); }
+.solara-landing .sol-risk-card-t {
+  font-family: 'Satoshi', 'Figtree', sans-serif;
+  font-weight: 800;
+  font-size: 20px;
+  letter-spacing: -.02em;
+  line-height: 1.2;
+  margin: 10px 0;
+}
+.solara-landing .sol-risk-card-d {
+  margin: 0;
+  color: var(--fg-2);
+  font-size: 14.5px;
+  line-height: 1.6;
+}
+
+/* ─── 9) FAQ (Design-Akkordeon auf bestehendem Markup/JS) ───── */
+.solara-landing .sol-faq-inner {
+  display: grid;
+  grid-template-columns: 1fr 2fr;
+  gap: 56px;
+  align-items: start;
+}
+@media (max-width: 880px) {
+  .solara-landing .sol-faq-inner { grid-template-columns: 1fr; gap: 28px; }
+}
+.solara-landing .sol-faq-h {
+  font-size: clamp(34px, 4vw, 58px);
+  letter-spacing: -.03em;
+  line-height: 1;
+  font-weight: 800;
+  margin: 12px 0 14px;
+}
+.solara-landing .sol-faq-sub {
+  color: var(--fg-2);
+  font-size: 15.5px;
+  line-height: 1.6;
+  margin: 0;
+  max-width: 38ch;
+}
+.solara-landing .sol-faq-list {
   list-style: none;
   padding: 0;
   margin: 0;
+  border-top: 1px solid var(--line);
 }
-.solara-landing .sol-fit-list li {
-  padding: 14px 0;
-  border-top: 1px solid var(--sol-line);
-}
-.solara-landing .sol-fit-list li:first-child {
-  border-top: 0;
-  padding-top: 0;
-}
-.solara-landing .sol-fit-list-t {
-  font-weight: 600;
-  color: var(--sol-fg);
-  font-size: 15px;
-}
-.solara-landing .sol-fit-list-d {
-  margin-top: 4px;
-  color: var(--sol-fg-mute);
-  font-size: 13px;
-  line-height: 1.55;
-}
-.solara-landing .sol-fit-cta {
-  text-align: center;
-  margin-top: 40px;
-}
-.solara-landing .sol-fit-cta-micro {
-  margin-top: 14px;
-  font-size: 11px;
-  letter-spacing: 0.14em;
-  color: var(--sol-fg-dim);
-}
-@media (max-width: 880px) {
-  .solara-landing .sol-fit-grid { grid-template-columns: 1fr; }
-}
-
-/* ── Reduced-Motion · neue Sektionen ─────────────────────────── */
-@media (prefers-reduced-motion: reduce) {
-  .solara-landing .sol-system-layer {
-    animation: none !important;
-    opacity: 1;
-    transform: none;
-  }
-  .solara-landing .sol-system-badge-pulse { animation: none !important; }
-}
-
-/* ══════════════════════════════════════════════════════════════
-   HERO · CPL-Kaskaden-Dashboard (Blueprint-Style)
-   Visualisiert die E3-Referenz-Reduktion 150 € → 22 € über
-   6 Monate. Technische Bildsprache (Grid, Mono, Achsenlabels).
-   ══════════════════════════════════════════════════════════════ */
-.solara-landing .sol-hero-dashboard {
-  position: relative;
-  margin: 0;
-  padding: 18px 18px 16px;
-  border: 1px solid var(--sol-line);
-  border-radius: 14px;
-  background:
-    linear-gradient(180deg, rgba(255,255,255,.78), rgba(255,255,255,.55)),
-    repeating-linear-gradient(0deg, rgba(0,0,0,.025) 0 1px, transparent 1px 28px),
-    repeating-linear-gradient(90deg, rgba(0,0,0,.025) 0 1px, transparent 1px 28px);
-  box-shadow:
-    0 1px 0 rgba(255,255,255,.7) inset,
-    0 10px 26px rgba(0,0,0,.05);
-  color: var(--sol-accent);
-  overflow: hidden;
-}
-.solara-landing .sol-hero-dashboard::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  border-radius: inherit;
-  background:
-    radial-gradient(120% 80% at 100% 0%, rgba(180,106,60,.08), transparent 60%);
-}
-.solara-landing .sol-hero-dashboard-cap {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: baseline;
-  gap: 10px 18px;
-  margin-bottom: 10px;
-}
-.solara-landing .sol-hero-dashboard-tag {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 3px 10px;
-  border-radius: 999px;
-  background: rgba(180,106,60,.10);
-  color: var(--sol-accent);
-  font-size: 10px;
-  letter-spacing: 0.10em;
-  text-transform: uppercase;
-}
-.solara-landing .sol-hero-dashboard-tag-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: currentColor;
-  box-shadow: 0 0 0 4px rgba(180,106,60,.18);
-  animation: sol-cta-tag-pulse 2.2s ease-in-out infinite;
-}
-.solara-landing .sol-hero-dashboard-title {
-  font-size: clamp(18px, 1.8vw, 22px);
-  font-weight: 600;
-  letter-spacing: -0.01em;
-  color: var(--sol-fg);
-  line-height: 1.1;
-}
-.solara-landing .sol-hero-dashboard-meta {
-  margin-left: auto;
-  color: var(--sol-fg-dim);
-  font-size: 10px;
-  letter-spacing: 0.10em;
-  text-transform: uppercase;
-}
-.solara-landing .sol-hero-dashboard-frame {
-  position: relative;
-  background: rgba(255,255,255,.55);
-  border-radius: 10px;
-  padding: 4px 4px 0;
-}
-.solara-landing .sol-hero-dashboard-svg {
-  display: block;
+.solara-landing .sol-faq-item { border-bottom: 1px solid var(--line); }
+.solara-landing .sol-faq-q {
   width: 100%;
-  height: auto;
-  color: var(--sol-accent);
-}
-.solara-landing .sol-hero-dashboard-line {
-  stroke-dasharray: 720;
-  stroke-dashoffset: 720;
-  animation: sol-cpl-draw 1.6s cubic-bezier(.5,.05,.25,1) 0.2s forwards;
-}
-.solara-landing .sol-hero-dashboard-area {
-  opacity: 0;
-  animation: sol-cpl-fade 1.4s ease-out 1.2s forwards;
-}
-.solara-landing .sol-hero-dashboard-pt {
-  opacity: 0;
-  animation: sol-cpl-pt-in 0.4s cubic-bezier(.2,.7,.25,1) forwards;
-  animation-delay: calc(0.5s + var(--sol-pt-delay, 0s));
-  transform-origin: center;
-}
-.solara-landing .sol-hero-dashboard-pt.is-anchor circle:nth-child(2) {
-  animation: sol-cpl-pulse 2.4s ease-out infinite;
-  transform-box: fill-box;
-  transform-origin: center;
-}
-.solara-landing .sol-hero-dashboard-readout {
-  position: absolute;
-  top: 12px;
-  right: 14px;
-  display: inline-flex;
-  flex-direction: column;
-  align-items: flex-end;
-  padding: 6px 10px 5px;
-  border-radius: 8px;
-  background: rgba(180,106,60,.10);
-  color: var(--sol-accent);
-}
-.solara-landing .sol-hero-dashboard-readout-l {
-  font-size: 9px;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  opacity: 0.75;
-}
-.solara-landing .sol-hero-dashboard-readout-v {
-  font-size: 15px;
-  font-weight: 700;
-  letter-spacing: -0.01em;
-  line-height: 1;
-  margin-top: 2px;
-}
-.solara-landing .sol-hero-dashboard-legend {
   display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  gap: 6px 16px;
-  margin-top: 10px;
-  font-size: 10px;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--sol-fg-dim);
+  align-items: center;
+  gap: 18px;
+  padding: 22px 0;
+  text-align: left;
+  font-size: clamp(15.5px, 1.3vw, 18px);
+  font-weight: 600;
+  color: var(--fg);
+  cursor: pointer;
+  transition: color .2s;
 }
-.solara-landing .sol-hero-dashboard-legend > span:first-child { color: var(--sol-fg-mute); }
-.solara-landing .sol-hero-dashboard-legend-mark {
-  display: inline-block;
-  width: 14px;
-  height: 2px;
-  margin-right: 6px;
-  vertical-align: middle;
-  background: var(--sol-accent);
-  border-radius: 1px;
-}
-
-@keyframes sol-cpl-draw {
-  to { stroke-dashoffset: 0; }
-}
-@keyframes sol-cpl-fade {
-  to { opacity: 1; }
-}
-@keyframes sol-cpl-pt-in {
-  from { opacity: 0; transform: scale(0.4); }
-  to   { opacity: 1; transform: scale(1); }
-}
-@keyframes sol-cpl-pulse {
-  0%   { stroke-opacity: 0.45; r: 9; }
-  50%  { stroke-opacity: 0.10; r: 14; }
-  100% { stroke-opacity: 0.45; r: 9; }
-}
-
-@media (max-width: 560px) {
-  .solara-landing .sol-hero-dashboard { padding: 14px 12px; }
-  .solara-landing .sol-hero-dashboard-meta { margin-left: 0; }
-  .solara-landing .sol-hero-dashboard-readout { top: 8px; right: 8px; padding: 4px 8px; }
-  .solara-landing .sol-hero-dashboard-readout-v { font-size: 13px; }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .solara-landing .sol-hero-dashboard-line {
-    stroke-dasharray: 0 !important;
-    stroke-dashoffset: 0 !important;
-    animation: none !important;
-  }
-  .solara-landing .sol-hero-dashboard-area,
-  .solara-landing .sol-hero-dashboard-pt { opacity: 1 !important; animation: none !important; }
-  .solara-landing .sol-hero-dashboard-tag-dot,
-  .solara-landing .sol-hero-dashboard-pt.is-anchor circle:nth-child(2) { animation: none !important; }
-}
-
-/* ══════════════════════════════════════════════════════════════
-   HERO · Risk-Reversal-Bullets unter dem System-Intake-CTA
-   ══════════════════════════════════════════════════════════════ */
-.solara-landing .sol-cta-bullets {
-  list-style: none;
-  margin: 14px 0 12px;
-  padding: 10px 0 4px;
-  border-top: 1px dashed var(--sol-line);
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 6px;
+.solara-landing .sol-faq-q:hover { color: var(--accent); }
+.solara-landing .sol-faq-q-n {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
   font-size: 11px;
-  letter-spacing: 0.04em;
-  color: var(--sol-fg-mute);
+  letter-spacing: .1em;
+  color: var(--fg-4);
+  flex-shrink: 0;
 }
-.solara-landing .sol-cta-bullets li {
+.solara-landing .sol-faq-q-t { flex: 1; }
+.solara-landing .sol-faq-q-mark {
+  position: relative;
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--line-2);
+  border-radius: 50%;
+  flex-shrink: 0;
+  transition: background .2s, border-color .2s;
+}
+.solara-landing .sol-faq-q-mark span {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 10px;
+  height: 1.6px;
+  background: var(--fg-2);
+  transform: translate(-50%, -50%);
+  transition: transform .25s, background .2s;
+}
+.solara-landing .sol-faq-q-mark span:last-child { transform: translate(-50%, -50%) rotate(90deg); }
+.solara-landing .sol-faq-item.is-open .sol-faq-q-mark {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+.solara-landing .sol-faq-item.is-open .sol-faq-q-mark span { background: #1A0F05; }
+.solara-landing .sol-faq-item.is-open .sol-faq-q-mark span:last-child {
+  transform: translate(-50%, -50%) rotate(0deg);
+}
+.solara-landing .sol-faq-a-wrap {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows .35s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.solara-landing .sol-faq-item.is-open .sol-faq-a-wrap { grid-template-rows: 1fr; }
+.solara-landing .sol-faq-a {
+  overflow: hidden;
+  color: var(--fg-2);
+  font-size: 14.5px;
+  line-height: 1.65;
+  max-width: 72ch;
+}
+.solara-landing .sol-faq-item.is-open .sol-faq-a { padding-bottom: 22px; }
+
+/* ─── 10) Founding / Final-CTA ──────────────────────────────── */
+.solara-landing .hu-final-cta { max-width: 880px; margin: 0 auto; }
+.solara-landing .sol-founding-facts {
+  list-style: none;
   display: flex;
-  align-items: flex-start;
-  gap: 8px;
-  line-height: 1.4;
+  flex-direction: column;
+  gap: 9px;
+  padding: 0;
+  margin: 0 auto 28px;
+  max-width: 560px;
+  text-align: left;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 12px;
+  letter-spacing: .05em;
+  color: var(--fg-2);
 }
-.solara-landing .sol-cta-bullets-tick {
-  flex: 0 0 14px;
+.solara-landing .sol-founding-facts li::before {
+  content: "·";
+  color: var(--accent);
+  margin-right: 10px;
+  font-weight: 700;
+}
+.solara-landing .hu-final-cta__signature { margin-top: 20px; font-size: 14px; color: var(--fg-3); }
+.solara-landing .hu-final-cta__signature strong { color: var(--fg); }
+
+/* ─── 11) Sticky Mobile-CTA ─────────────────────────────────── */
+.solara-landing .sol-sticky-cta {
+  position: fixed;
+  left: 50%;
+  bottom: 18px;
+  z-index: 60;
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  width: 14px;
-  height: 14px;
-  margin-top: 1px;
-  border-radius: 50%;
-  background: rgba(180,106,60,.12);
-  color: var(--sol-accent);
-  font-size: 9px;
-  font-weight: 700;
+  gap: 10px;
+  padding: 14px 24px;
+  border-radius: 999px;
+  background: var(--accent);
+  color: #1A0F05;
+  font-weight: 600;
+  font-size: 15px;
+  box-shadow: 0 1px 0 rgba(255, 255, 255, .18) inset, 0 16px 40px -12px rgba(0, 0, 0, .65);
+  opacity: 0;
+  transform: translate(-50%, 16px);
+  pointer-events: none;
+  transition: opacity .25s, transform .25s;
+}
+.solara-landing .sol-sticky-cta.is-visible {
+  opacity: 1;
+  transform: translate(-50%, 0);
+  pointer-events: auto;
+}
+.solara-landing .sol-sticky-cta-arrow { display: inline-flex; width: 16px; height: 16px; }
+.solara-landing .sol-sticky-cta-arrow svg { width: 16px; height: 16px; }
+@media (min-width: 821px) {
+  .solara-landing .sol-sticky-cta { display: none; }
+}
+
+/* ─── 12) Reduced Motion ────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .solara-landing .sol-sun-rays,
+  .solara-landing .sol-bar,
+  .solara-landing .sol-bar-label,
+  .solara-landing .sol-quiz-opt,
+  .solara-landing .sol-quiz-progress-shimmer { animation: none; }
+  .solara-landing .sol-quiz-progress-fill { transition: none; }
 }

--- a/blocksy-child/assets/js/solar-leadgenerierung-solara.js
+++ b/blocksy-child/assets/js/solar-leadgenerierung-solara.js
@@ -1,6 +1,6 @@
 /* solar-leadgenerierung-solara.js
    SOLARA Landing — B2B Marktcheck im Hero.
-   3-stufige Progressive-Disclosure-Sequenz (Sales-Team → Portal-Streuverlust → Business-Daten).
+   3-stufige Progressive-Disclosure-Sequenz (Vertrieb → Akquisekosten → Befund-Daten).
    Submit → /wp-json/nexus/v1/audit-request (intake_variant=energy_systems).
    Success-Screen mit Cal.com-Direktbuchung + händischer SLA-Antwort.
    Vanilla JS. Keine Dependencies. Touch- & Keyboard-accessible. */
@@ -13,39 +13,39 @@
 
   // ── Progressive Disclosure: 3-stufige B2B-Sequenz ─────────────
   // Step 1 — Klickbasierter Einstieg ohne Datenrisiko.
-  // Step 2 — Problemverankerung mit Portal-Namen (Sunk-Cost-Trigger).
+  // Step 2 — Problemverankerung über Akquisekosten (Sunk-Cost-Trigger).
   // Step 3 — Erst danach freigeschaltete Business-Datenfelder.
   var QUIZ_STEPS = [
     {
       key: 'sales_team_size',
-      label: 'Vertriebsteam',
-      title: 'Wie viele fest angestellte Vertriebsmitarbeiter bearbeiten aktuell Ihre Anfragen?',
-      hint: 'Der Hebel eines eigenen Anfrage-Systems wirkt nur, wenn jemand die qualifizierten Anfragen auch konsequent abschließt.',
+      label: 'Vertrieb',
+      title: 'Wer verkauft bei Ihnen?',
+      hint: 'Das System richtet sich an Betriebe mit eigenem Vertrieb — die Antwort entscheidet über den Fit.',
       kind: 'pick',
       options: [
-        { v: 'none',           t: 'Noch kein eigenes Vertriebsteam / Einzelkämpfer', s: 'Geschäftsführung verkauft aktuell selbst — oder gar nicht.', i: '⊘' },
-        { v: 'one',            t: '1 Person',                                      s: 'Eine zentrale Anlaufstelle, klare Verantwortung.',          i: '①' },
-        { v: 'two_to_five',    t: '2 bis 5 Personen',                              s: 'Vertriebsteam vorhanden, Pipeline-Routing geregelt.',       i: '⑤' },
-        { v: 'more_than_five', t: 'Mehr als 5 Personen',                           s: 'Strukturierter Vertrieb mit eigener Pipeline-Logik.',       i: '∞' }
+        { v: 'none',           t: 'Die Geschäftsführung verkauft selbst', s: 'Noch kein eigenes Vertriebsteam — Abschluss ist Chefsache.' },
+        { v: 'one',            t: '1 Person im Vertrieb',                 s: 'Eine zentrale Anlaufstelle, klare Verantwortung.' },
+        { v: 'two_to_five',    t: '2–5 Personen im Vertrieb',             s: 'Vertriebsteam vorhanden, Pipeline-Routing geregelt.' },
+        { v: 'more_than_five', t: 'Mehr als 5 Personen im Vertrieb',      s: 'Strukturierter Vertrieb mit eigener Pipeline-Logik.' }
       ]
     },
     {
       key: 'portal_margin_loss',
-      label: 'Portal-Belastung',
-      title: 'Wie stark belasten geteilte oder unqualifizierte Portal-Leads (z. B. Aroundhome, DAA, Wattfox) aktuell Ihre Vertriebsmarge?',
-      hint: 'Portal-Leads kosten Vertriebszeit, Budget und Abschlusskraft — auch wenn der Stundenpreis im CPL nicht direkt sichtbar wird.',
+      label: 'Akquisekosten',
+      title: 'Was kostet Sie Akquise heute?',
+      hint: 'Portal-Leads, Google Ads, Agentur — alles zusammengenommen, grob geschätzt. Es geht um den Druck auf Ihre Marge.',
       kind: 'pick',
       options: [
-        { v: 'low',    t: 'Gering',     s: 'Portal-Leads sind wirtschaftlich noch vertretbar.',                  i: '◔' },
-        { v: 'medium', t: 'Deutlich',   s: 'CPL und Anfragequalität drücken die Marge in Grenzprojekten.',       i: '◐' },
-        { v: 'high',   t: 'Erheblich',  s: 'Vertriebszeit und Budget gehen verloren in Anfragen, die nicht kaufen.', i: '●' }
+        { v: 'low',    t: 'Gering',    s: 'Portal-Leads und Werbekosten sind wirtschaftlich noch vertretbar.' },
+        { v: 'medium', t: 'Deutlich',  s: 'CPL und Anfragequalität drücken die Marge in Grenzprojekten.' },
+        { v: 'high',   t: 'Erheblich', s: 'Budget und Vertriebszeit verbrennen in Anfragen, die nicht kaufen.' }
       ]
     },
     {
       key: 'contact',
       label: 'Marktcheck',
-      title: 'Daten-Integrität & Kontakt',
-      hint: 'Erst nach den beiden Qualifikationsantworten öffnet sich der geschäftliche Datenpfad. Sie erhalten eine persönliche Fit-Einschätzung nach händischer Prüfung.',
+      title: 'Wohin darf der Befund?',
+      hint: 'Fünf Angaben — mehr braucht der Marktcheck nicht. Die Firmen-PLZ dient der Regions-Verfügbarkeitsprüfung.',
       kind: 'form'
     }
   ];
@@ -169,8 +169,7 @@
       if (a.email && /^[^\s@]+@(gmail|gmx|web|t-online|outlook|hotmail|yahoo|icloud|aol|live|mail|googlemail)\.(com|de|net|at|ch)$/i.test(a.email)) {
         errs.email = 'Bitte nutzen Sie Ihre geschäftliche E-Mail-Adresse (Firmen-Domain) — so kann ich Betrieb und Region eindeutig zuordnen. Keine eigene Domain? Schreiben Sie direkt an hasim@hasimuener.de.';
       }
-      // Phone is optional — only validate format if provided.
-      if (a.phone && a.phone.trim().length > 0 && a.phone.trim().length < 5) errs.phone = 'Bitte eine vollständige Telefonnummer angeben.';
+      if (!a.postal_code || !/^[0-9]{5}$/.test(String(a.postal_code).trim())) errs.postal_code = 'Bitte eine fünfstellige Firmen-PLZ angeben.';
       if (!a.consent_privacy) errs.consent_privacy = 'Bitte den Datenschutzhinweis bestätigen.';
       return errs;
     }
@@ -179,7 +178,7 @@
       if (state.submitting) return;
       var errs = validateContact();
       if (Object.keys(errs).length) {
-        state.touched = Object.assign({}, state.touched || {}, { name: true, company: true, position: true, email: true, consent_privacy: true });
+        state.touched = Object.assign({}, state.touched || {}, { name: true, company: true, position: true, email: true, postal_code: true, consent_privacy: true });
         render();
         // Focus and scroll to the first invalid field so the user knows what to fix.
         var firstKey = Object.keys(errs)[0];
@@ -214,6 +213,7 @@
         position:            state.answers.position || '',
         email:                state.answers.email || '',
         phone:                state.answers.phone || '',
+        postal_code:          (state.answers.postal_code || '').trim(),
         page_url:             CFG.pageUrl || window.location.href,
         consent_privacy:      'accepted',
         company_website:      state.answers.company_website || ''
@@ -320,9 +320,11 @@
       var email = (answers.email || '').trim();
       var company = (answers.company || '').trim();
       var position = (answers.position || '').trim();
+      var plz = (answers.postal_code || '').trim();
       var noteParts = ['Aus Marktcheck'];
       if (company) noteParts.push('Firma: ' + company);
       if (position) noteParts.push('Position: ' + position);
+      if (plz) noteParts.push('PLZ: ' + plz);
 
       var params = [];
       if (name) params.push('name=' + encodeURIComponent(name));
@@ -444,6 +446,7 @@
           placeholder: opts.ph || '',
           autocomplete: opts.ac || 'off',
           inputmode: opts.im || null,
+          maxlength: opts.maxlength || null,
           name: opts.k,
           onInput: function (e) { setAnswer(opts.k, e.target.value); },
           onBlur: function () {
@@ -469,19 +472,19 @@
       });
 
       var rationale = el('div', { className: 'sol-quiz-rationale', role: 'note' }, [
-        el('p', { className: 'sol-quiz-rationale-h' }, 'Daten-Integrität · Drittes Modul des Marktchecks'),
+        el('p', { className: 'sol-quiz-rationale-h' }, 'Daten-Integrität · Letzter Schritt des Marktchecks'),
         el('p', { className: 'sol-quiz-rationale-b' },
-          'Sie haben Ihre Vertriebsstruktur und Portal-Margenverluste skizziert — jetzt brauche ich die Firmen-Eckdaten, um Domain, Region und Fit persönlich-händisch zu prüfen und den Befund an den richtigen Entscheider zu senden.')
+          'Sie haben Vertrieb und Akquisekosten skizziert — jetzt brauche ich die Firmen-Eckdaten, um Domain, Region und Fit persönlich-händisch zu prüfen und den Befund an den richtigen Entscheider zu senden.')
       ]);
       form.appendChild(rationale);
 
       form.appendChild(renderField({ k: 'company', t: 'Firma', type: 'text', ph: 'Mustermann Solar GmbH', req: true, ac: 'organization', full: true,
         validator: function (v) { return (!v || v.trim().length < 2) ? 'Bitte Firma angeben.' : null; }
       }));
-      form.appendChild(renderField({ k: 'name', t: 'Name des Ansprechpartners', type: 'text', ph: 'Max Mustermann', req: true, ac: 'name',
+      form.appendChild(renderField({ k: 'name', t: 'Ansprechpartner', type: 'text', ph: 'Max Mustermann', req: true, ac: 'name',
         validator: function (v) { return (!v || v.trim().length < 2) ? 'Bitte Namen angeben.' : null; }
       }));
-      form.appendChild(renderField({ k: 'position', t: 'Position im Unternehmen', kind: 'select', req: true, ac: 'organization-title',
+      form.appendChild(renderField({ k: 'position', t: 'Position', kind: 'select', req: true, ac: 'organization-title',
         options: [
           { v: '',                              t: '— Bitte wählen —',              disabled: true },
           { v: 'Geschäftsführung / Inhaber',    t: 'Geschäftsführung / Inhaber' },
@@ -491,17 +494,17 @@
         ],
         validator: function (v) { return !v ? 'Bitte Position auswählen.' : null; }
       }));
-      form.appendChild(renderField({ k: 'email', t: 'Geschäftliche E-Mail-Adresse', type: 'email', ph: 'max@solar-betrieb.de', req: true, ac: 'email', full: true,
+      form.appendChild(renderField({ k: 'email', t: 'Geschäftliche E-Mail', type: 'email', ph: 'max@solar-betrieb.de', req: true, ac: 'email',
         validator: function (v) {
           if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(String(v || ''))) return 'Gültige E-Mail nötig.';
           if (/^[^\s@]+@(gmail|gmx|web|t-online|outlook|hotmail|yahoo|icloud|aol|live|mail|googlemail)\.(com|de|net|at|ch)$/i.test(String(v || ''))) return 'Bitte die E-Mail-Adresse Ihrer Firmen-Domain verwenden — sie ordnet Betrieb und Region eindeutig zu.';
           return null;
         }
       }));
-      form.appendChild(renderField({ k: 'phone', t: 'Telefon (optional, für Rückfragen)', type: 'tel', ph: '+49 ___ ____', req: false, ac: 'tel', im: 'tel', full: true,
+      form.appendChild(renderField({ k: 'postal_code', t: 'Firmen-PLZ', type: 'text', ph: '30159', req: true, ac: 'postal-code', im: 'numeric',
+        maxlength: '5',
         validator: function (v) {
-          if (!v || v.trim().length === 0) return null;
-          return v.trim().length < 5 ? 'Bitte vollständige Telefonnummer angeben.' : null;
+          return /^[0-9]{5}$/.test(String(v || '').trim()) ? null : 'Bitte eine fünfstellige PLZ angeben — sie steuert die Regions-Verfügbarkeitsprüfung.';
         }
       }));
 
@@ -558,7 +561,7 @@
           trackFunnelStage: 'lead_capture_submit'
         }
       }, [
-        el('span', null, state.submitting ? 'Wird gesendet …' : 'Marktcheck anfordern'),
+        el('span', null, state.submitting ? 'Wird gesendet …' : 'Befund in 48 h anfordern'),
         el('span', { className: 'sol-quiz-submit-arrow', 'aria-hidden': 'true', html: ARROW_SVG })
       ]);
       form.appendChild(submitBtn);
@@ -678,7 +681,7 @@
       var head = el('div', { className: 'sol-cta-head' }, [
         el('span', { className: 'sol-cta-tag sol-mono' }, [
           el('span', { className: 'sol-cta-tag-dot', 'aria-hidden': 'true' }),
-          'Marktcheck · Fit geprüft · nächster Schritt'
+          'Marktcheck · Fit geprüft · 48-h-Befund'
         ]),
         el('span', { className: 'sol-cta-head-right sol-mono' }, 'Fit-Check')
       ]);
@@ -751,22 +754,56 @@
   }
 
   // ── Page-wide setup ──────────────────────────────────────────
-  function mountSunRays() {
-    var hosts = document.querySelectorAll(ROOT_SELECTOR + ' [data-sol-rays]');
-    if (!hosts.length) return;
-    hosts.forEach(function (host) {
-      if (host.dataset.solRaysMounted === '1') return;
-      var frag = document.createDocumentFragment();
-      for (var i = 0; i < 24; i++) {
-        var ray = document.createElement('span');
-        ray.className = 'sol-hero-sun-ray';
-        ray.style.transform = 'rotate(' + (i * 15) + 'deg)';
-        ray.setAttribute('aria-hidden', 'true');
-        frag.appendChild(ray);
+
+  /* Count-up für die Hero-Stats. Liest den serverseitig gerenderten
+     Zieltext (z. B. "1.750+", "22 €", "12 %") direkt aus dem DOM,
+     zählt per rAF hoch und stellt am Ende exakt den Originaltext
+     wieder her — Canon-Werte bleiben damit die Quelle der Wahrheit. */
+  function setupCountUp() {
+    var nodes = document.querySelectorAll(ROOT_SELECTOR + ' [data-sol-countup]');
+    if (!nodes.length) return;
+    var reduced = false;
+    try { reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches; } catch (e) {}
+    if (reduced || typeof window.requestAnimationFrame !== 'function') return;
+
+    function animate(node) {
+      var original = node.textContent;
+      var match = /^([^0-9]*)([0-9][0-9.,]*)(.*)$/.exec(original.trim());
+      if (!match) return;
+      var target = parseInt(match[2].replace(/[.,]/g, ''), 10);
+      if (!isFinite(target) || target <= 0) return;
+      var prefix = match[1];
+      var suffix = match[3];
+      var t0 = null;
+      var duration = 1100;
+      function tick(now) {
+        if (t0 === null) t0 = now;
+        var p = Math.min(1, (now - t0) / duration);
+        var eased = 1 - Math.pow(1 - p, 3);
+        if (p < 1) {
+          node.textContent = prefix + Math.round(target * eased).toLocaleString('de-DE') + suffix;
+          window.requestAnimationFrame(tick);
+        } else {
+          node.textContent = original;
+        }
       }
-      host.appendChild(frag);
-      host.dataset.solRaysMounted = '1';
-    });
+      window.requestAnimationFrame(tick);
+    }
+
+    try {
+      if ('IntersectionObserver' in window) {
+        var io = new IntersectionObserver(function (entries) {
+          entries.forEach(function (entry) {
+            if (!entry.isIntersecting) return;
+            io.unobserve(entry.target);
+            animate(entry.target);
+          });
+        }, { threshold: 0.4 });
+        nodes.forEach(function (node) { io.observe(node); });
+      } else {
+        nodes.forEach(animate);
+      }
+    } catch (e) { /* Stats bleiben statisch — kein Schaden. */ }
   }
 
   function setupFaq() {
@@ -968,7 +1005,7 @@
   }
 
   ready(function () {
-    mountSunRays();
+    setupCountUp();
     setupFaq();
     setupStickyCta();
     setupScrollAnchor();

--- a/blocksy-child/inc/enqueue.php
+++ b/blocksy-child/inc/enqueue.php
@@ -256,11 +256,13 @@ function hu_enqueue_assets() {
 	}
 
 	// ── F1a) Solar-/Wärmepumpen-Leadgenerierung (SOLARA Redesign) ──
-	// Eigene CSS/JS-Stack; legacy energy-systems / review-funnel werden hier
-	// bewusst NICHT geladen, weil das Template ein eigenes Visual-System hat
-	// und einen 60-Sek-Marktcheck im Hero rendert (REST → CRM).
+	// Nutzt das geteilte .hu-hp-Brand-Kit (homepage-redesign.css) plus ein
+	// schlankes Page-Delta-Stylesheet; legacy energy-systems / review-funnel
+	// werden hier bewusst NICHT geladen — das Template rendert einen
+	// 3-Schritte-Marktcheck im Hero (REST → CRM).
 	if ( is_page( 'solar-waermepumpen-leadgenerierung' ) || is_page_template( 'page-solar-waermepumpen-leadgenerierung.php' ) ) {
-		hu_enqueue_css( 'nexus-solar-leadgen-solara-css', 'solar-leadgenerierung-solara.css', [ 'nexus-design-system' ] );
+		hu_enqueue_css( 'nexus-home-redesign-css', 'homepage-redesign.css', [ 'nexus-design-system' ] );
+		hu_enqueue_css( 'nexus-solar-leadgen-solara-css', 'solar-leadgenerierung-solara.css', [ 'nexus-home-redesign-css' ] );
 		hu_enqueue_js( 'nexus-solar-leadgen-solara-js', 'solar-leadgenerierung-solara.js', [ 'nexus-core-js' ] );
 
 		$marktcheck_cfg = [

--- a/blocksy-child/page-solar-waermepumpen-leadgenerierung.php
+++ b/blocksy-child/page-solar-waermepumpen-leadgenerierung.php
@@ -1,8 +1,9 @@
 <?php
 /**
  * Template Name: Solar & Wärmepumpen Leadgenerierung (SOLARA)
- * Description: Premium · cinematic · minimalistisch. Hybrid-Theme (warm-cream + Copper).
- *              Primärer Lead-Pfad: B2B-Marktcheck im Hero (REST → CRM).
+ * Description: v2 · Ink/Creme-Wechsel im hasimuener.de-System (.hu-hp-Kit),
+ *              Kupfer als einziger Akzent. Primärer Lead-Pfad: B2B-Marktcheck
+ *              im Hero (REST → CRM), CPL-Telemetrie als Proof daneben.
  *              Zielgruppe: Solar-/Wärmepumpen-Betriebe mit hohen Projektwerten,
  *              klarem Zielgebiet und eigener Vertriebsverantwortung.
  *
@@ -35,24 +36,31 @@ $e3_metrics          = isset( $e3_canon['metrics'] ) && is_array( $e3_canon['met
 $e3_case_label       = isset( $e3_canon['case_label'] ) ? (string) $e3_canon['case_label'] : 'E3 New Energy';
 $e3_lead_count       = $e3_metrics['lead_count']['display'] ?? '1.750+';
 $e3_sales_conversion = $e3_metrics['sales_conversion']['display'] ?? '12 %';
+$e3_conv_before      = $e3_metrics['sales_conversion_before']['display'] ?? '1 – 5 %';
 $e3_conv_uplift      = $e3_metrics['sales_conversion_uplift']['display'] ?? '1 – 5 % → 12 %';
-$e3_cpl_reduction    = $e3_metrics['cpl_reduction']['display'] ?? '> 85 %';
+$e3_cpl_reduction    = $e3_metrics['cpl_reduction']['display'] ?? 'über 85 %';
 $e3_cpl_before       = $e3_metrics['cpl_before']['display'] ?? '150 €';
 $e3_cpl_after        = $e3_metrics['cpl_after']['display'] ?? '22 €';
+$e3_cpl_before_val   = (int) ( $e3_metrics['cpl_before']['value'] ?? 150 );
+$e3_cpl_after_val    = (int) ( $e3_metrics['cpl_after']['value'] ?? 22 );
 $e3_timeframe        = $e3_metrics['timeframe']['display'] ?? '6 Monate';
 $e3_timeframe_dative = $e3_metrics['timeframe']['display_dative'] ?? '6 Monaten';
 
-// ── Inhaltsmodelle ─────────────────────────────────────────────
-$hero_metrics = [
-	[ 'n' => $e3_cpl_after,  'l' => 'CPL nach 6 Monaten · ' . $e3_case_label ],
-	[ 'n' => $e3_conv_uplift, 'l' => 'Abschlussquote · Portal-Leads vs. eigenes System' ],
-	[ 'n' => '100 %',         'l' => 'Asset-Eigentum · Code · Tracking · Daten' ],
+// ── Founding-Canon ─────────────────────────────────────────────
+$founding = function_exists( 'hu_founding_canon' ) ? hu_founding_canon() : [
+	'label'           => 'Founding Cohort 2026',
+	'slots_total'     => 3,
+	'slots_remaining' => 3,
+	'end_date'        => '2026-09-30',
 ];
+$founding_label   = isset( $founding['label'] ) ? (string) $founding['label'] : 'Founding Cohort 2026';
+$founding_open    = isset( $founding['slots_remaining'] ) ? (int) $founding['slots_remaining'] : 3;
+$founding_seats   = isset( $founding['slots_total'] ) ? (int) $founding['slots_total'] : 3;
+$founding_end_iso = isset( $founding['end_date'] ) ? (string) $founding['end_date'] : '2026-09-30';
+$founding_end_ts  = strtotime( $founding_end_iso );
+$founding_end_de  = $founding_end_ts ? wp_date( 'd.m.Y', $founding_end_ts ) : '30.09.2026';
 
-$founding_strip = function_exists( 'hu_founding_canon' ) ? hu_founding_canon() : [];
-$founding_open  = isset( $founding_strip['slots_remaining'] ) ? (int) $founding_strip['slots_remaining'] : 3;
-$founding_seats = isset( $founding_strip['slots_total'] ) ? (int) $founding_strip['slots_total'] : 3;
-
+// ── Inhaltsmodelle ─────────────────────────────────────────────
 $trust_items = [
 	'B2B · DACH · eigener Vertrieb',
 	'Server in Frankfurt · DSGVO',
@@ -60,90 +68,29 @@ $trust_items = [
 	'Hardcoded WordPress · kein Page-Builder',
 	'1:1 Senior · keine Junior-Kette',
 	'Marktcheck mit Fit-Entscheid',
-	sprintf( 'Founding Cohort 2026 · %d/%d Plätze', $founding_open, $founding_seats ),
+	sprintf( '%s · %d/%d Plätze', $founding_label, $founding_open, $founding_seats ),
 ];
 
-$problem_cards = [
+// 01 / Status quo — drei Kostenkarten (Creme)
+$cost_cards = [
 	[
-		'n' => '01',
-		'l' => 'Lead-Einkauf',
-		't' => 'Portal-Leads kosten 80–150 €. Die Hälfte geht nicht ans Telefon.',
-		's' => 'Aroundhome, Check24, DAA: Mieter ohne Dach, Preisvergleicher ohne Budget, Anfragen, die bei drei Wettbewerbern parallel landen. Ihr Vertrieb verbrennt Stunden mit Leuten, die nie kaufen werden.',
+		'big'  => '80–150 €',
+		'sub'  => 'pro Portal-Lead — geteilt',
+		'body' => 'Aroundhome, DAA, Wattfox: Mieter ohne Dach, Preisvergleicher ohne Budget — Anfragen, die parallel bei drei Wettbewerbern landen. Die Hälfte geht nicht ans Telefon.',
 	],
 	[
-		'n' => '02',
-		'l' => 'Blindflug',
-		't' => 'Kein Überblick, welcher Kanal sich wirklich lohnt.',
-		's' => 'Google Ads, Portal-Leads, Empfehlungen — niemand kann sauber sagen, woher die guten Abschlüsse kommen. Ohne diese Klarheit investieren Sie blind. Und skalieren falsch.',
+		'big'  => 'Blindflug',
+		'sub'  => 'Klicks ≠ Anfragen ≠ Termine',
+		'body' => 'Google Ads, Portale, Empfehlungen — niemand kann sauber sagen, woher die guten Abschlüsse kommen. Ohne diese Klarheit investieren Sie blind. Und skalieren falsch.',
 	],
 	[
-		'n' => '03',
-		'l' => 'Marktwende',
-		't' => 'Seit 2024 kommen Anfragen nicht mehr von allein.',
-		's' => 'Der PV-Boom ist vorbei. Der Markt normalisiert sich. Wer jetzt keine eigene Anfrage-Infrastruktur hat, ist abhängig von Portalen — und deren Preisen.',
-	],
-];
-
-$method_cards = [
-	[
-		'n'  => 'I',
-		'p'  => 'Phase 01',
-		't'  => 'Diagnose & Fundament',
-		's'  => 'Anfrage-Quellen, Tracking, Funnel, Vertriebsanschluss — vier Module, schriftlicher Befund, drei priorisierte Hebel. Verrechenbar auf Umsetzung.',
-		'b'  => [ 'Module: Quellen · Daten · Funnel · Sales', 'Schriftlicher Befund · keine Folien', 'Auf Umsetzung 1:1 verrechenbar' ],
-	],
-	[
-		'n'  => 'II',
-		'p'  => 'Phase 02',
-		't'  => 'Eigenes Anfrage-System',
-		's'  => 'WordPress hardcoded — kein Page-Builder, kein Plugin-Stack. <a href="' . esc_url( $tracking_url ) . '">Server-Side-Tracking</a>: Messdaten laufen über Ihren eigenen Server statt nur über den Browser — belastbare Zahlen trotz Ad-Blockern. Smarte Vorqualifizierung. <a href="' . esc_url( $cro_url ) . '">Conversion-Pfad</a> ohne Mietsysteme.',
-		'b'  => [ 'Money-Page · Proof- & Angebotsseiten', 'Frankfurt-Server · CAPI · DSGVO', 'Lead-Scoring vor dem Erstkontakt' ],
-	],
-	[
-		'n'  => 'III',
-		'p'  => 'Phase 03',
-		't'  => 'Skalieren & Übergeben',
-		's'  => 'Mit sauberem <a href="' . esc_url( $cwv_url ) . '">technischen Fundament</a> rechnen sich Google Ads, Meta Ads und <a href="' . esc_url( $seo_url ) . '">SEO</a> endlich. Wöchentliches Reporting. Bei Vertragsende: dokumentierte Übergabe — Code, Tracking, Daten bleiben bei Ihnen.',
-		'b'  => [ 'Google Ads · Meta Ads · SEO-Anteil', 'Wöchentliches Reporting', 'Monatlich kündbar · 100 % Asset-Übergabe' ],
+		'big'  => 'Seit 2024',
+		'sub'  => 'kommen Anfragen nicht mehr von allein',
+		'body' => 'Der PV-Boom ist vorbei, der Markt normalisiert sich. Ohne eigene Nachfrage-Infrastruktur bleiben Sie abhängig von Portalen — und deren Preisen.',
 	],
 ];
 
-$results_qualifiers = [
-	[ 'k' => 'Anfrage-Quellen',    'v' => 'Beziffert' ],
-	[ 'k' => 'Tracking & CAPI',    'v' => 'Auditiert' ],
-	[ 'k' => 'Funnel-Hebel',       'v' => 'Drei priorisiert' ],
-	[ 'k' => 'Wirtschaftlichkeit', 'v' => 'Einordnung' ],
-	[ 'k' => 'Nächster Schritt',   'v' => 'Konkret' ],
-];
-
-$guarantee_points = [
-	[
-		't' => 'Marktcheck schafft Entscheidungsgrundlage',
-		's' => 'Strukturierter, händisch geprüfter Marktcheck statt automatisierter Tool-Bericht. Befund Ihrer Domain und Region innerhalb von 48 Stunden per E-Mail — mit Fit-Einschätzung, drei priorisierten Hebeln und klarer Empfehlung für oder gegen den nächsten Schritt.',
-	],
-	[
-		't' => 'Drei Hebel — auch bei Abrat',
-		's' => 'Wenn die anschließende Diagnose zum Ergebnis kommt, dass Sie das volle System nicht brauchen, bekommen Sie trotzdem drei priorisierte Hebel mit konkretem nächstem Schritt.',
-	],
-	[
-		't' => 'Diagnose wird verrechnet',
-		's' => 'Bei Umsetzung wird die Diagnose 1:1 angerechnet. Sie zahlen sie nur dann, wenn Sie sich gegen die Umsetzung entscheiden. Keine Mindestlaufzeit, volle Asset-Übergabe.',
-	],
-];
-
-// ── Sticky In-Page Section Nav (CRO: orientation + jump to relevant block) ─────
-$section_nav = [
-	[ 'h' => '#problem',     'l' => 'Status quo' ],
-	[ 'h' => '#vergleich',   'l' => 'Vergleich' ],
-	[ 'h' => '#system-bild', 'l' => 'System' ],
-	[ 'h' => '#capex',       'l' => 'CAPEX vs OPEX' ],
-	[ 'h' => '#ergebnisse',  'l' => 'Referenz' ],
-	[ 'h' => '#fit',         'l' => 'Passt es?' ],
-	[ 'h' => '#deeper',      'l' => 'Vertiefung' ],
-	[ 'h' => '#faq',         'l' => 'FAQ' ],
-];
-
-// ── Markt-Standard vs Eigener Weg (Compare-Section) ───────────────────────────
+// 02 / Markt vs. eigener Weg (Compare)
 $compare_bad = [
 	[ 't' => 'Portal-Leads',      's' => 'Drei Wettbewerber bekommen dieselbe Anfrage. Sie bieten gegen den Preis.' ],
 	[ 't' => 'Klickberichte',     's' => 'Reportings über Impressionen — nicht über Projektwert.' ],
@@ -157,58 +104,34 @@ $compare_good = [
 	[ 't' => 'Dokumentiertes System',    's' => 'Sie verstehen, warum es funktioniert. Code, Tracking, Daten bleiben bei Ihnen.' ],
 ];
 
-// ── System-Diagramm: 4 Layer · was Kunden konkret bekommen ─────────────────────
-// `url` (optional) verlinkt den Layer-Header auf passende technische Trust-Seiten.
-$system_layers = [
+// 03 / Das System — Asset-Panel (links) + drei Schritte (rechts)
+$process_rows = [
+	[ 'e' => 'Fundament',        't' => 'WordPress hardcoded · Frankfurt-Server · DSGVO', 'url' => $cwv_url ],
+	[ 'e' => 'Daten & Tracking', 't' => 'Server-Side · GA4 · CAPI · saubere Attribution', 'url' => $tracking_url ],
+	[ 'e' => 'Conversion-Pfad',  't' => 'Vorqualifizierung · Lead-Scoring vor dem Anruf', 'url' => $cro_url ],
+];
+$method_cards = [
 	[
-		'n'      => '01',
-		'name'   => 'Fundament',
-		'url'    => $cwv_url,
-		'status' => 'DSGVO · Frankfurt',
-		'cols'   => 2,
-		'items'  => [
-			[ 'i' => 'M3 12l9-9 9 9M5 10v10h14V10', 't' => 'WordPress hardcoded',  's' => 'Kein Page-Builder, kein Plugin-Stack.' ],
-			[ 'i' => 'M3 5h18v12H3zM3 21h18',       't' => 'Frankfurt-Server',     's' => 'DSGVO-konform · eigenes Hosting.' ],
-		],
+		'n'   => '01',
+		't'   => 'Diagnose & Fundament',
+		's'   => 'Anfrage-Quellen, Tracking, Funnel, Vertriebsanschluss — vier Bausteine, ein schriftlicher Befund, drei priorisierte Hebel. Auf Umsetzung 1:1 verrechenbar.',
+		'out' => 'Output / Befund · keine Folien · verrechenbar',
 	],
 	[
-		'n'      => '02',
-		'name'   => 'Daten & Tracking',
-		'url'    => $tracking_url,
-		'status' => 'Server-Side · CAPI',
-		'cols'   => 2,
-		'items'  => [
-			[ 'i' => 'M4 19V5m0 14h16m-12-7v7m4-12v12m4-9v9', 't' => 'Server-Side Tracking', 's' => 'GA4 · CAPI · eigener Container.' ],
-			[ 'i' => 'M10 14l4-4m-7-3a5 5 0 017-7l3 3m1 11a5 5 0 01-7 7l-3-3', 't' => 'Saubere Attribution', 's' => 'Welcher Kanal bringt zahlende Aufträge?' ],
-		],
+		'n'   => '02',
+		't'   => 'Eigenes Anfrage-System',
+		's'   => 'Money-Page, Proof- und Angebotsseiten. <a href="' . esc_url( $tracking_url ) . '">Server-Side-Tracking</a> auf eigenem Server — belastbare Zahlen trotz Ad-Blockern. <a href="' . esc_url( $cro_url ) . '">Vorqualifizierung</a> vor dem Formular statt 5-Felder-Hürdenlauf.',
+		'out' => 'Output / System · Frankfurt · CAPI · Lead-Scoring',
 	],
 	[
-		'n'      => '03',
-		'name'   => 'Conversion-Pfad',
-		'url'    => $cro_url,
-		'status' => 'Vorqualifizierung · Score',
-		'cols'   => 3,
-		'items'  => [
-			[ 'i' => 'M12 2l3 7h7l-5.5 4.5L18 21l-6-4-6 4 1.5-7.5L2 9h7z', 't' => 'Money Page',           's' => 'Solar/WP-spezifisch · Proof.' ],
-			[ 'i' => 'M13 2L4 14h7v8l9-12h-7z',                              't' => 'B2B-Marktcheck',     's' => 'Region · Vertriebsstruktur · Projektwert.' ],
-			[ 'i' => 'M12 2l3.09 6.26L22 9.27l-5 4.87L18.18 22 12 18.27 5.82 22 7 14.14l-5-4.87 6.91-1.01z', 't' => 'Lead-Scoring', 's' => 'Grün, gelb, rot — vor dem Anruf.' ],
-		],
-	],
-	[
-		'n'      => '04',
-		'name'   => 'Skalierung',
-		'url'    => $paid_url,
-		'status' => 'Multi-Channel · messbar',
-		'cols'   => 3,
-		'items'  => [
-			[ 'i' => 'M11 4a7 7 0 100 14 7 7 0 000-14zM21 21l-5.2-5.2', 't' => 'Google Ads', 's' => 'Lokal · hoher Intent.' ],
-			[ 'i' => 'M7 2h10a2 2 0 012 2v16a2 2 0 01-2 2H7a2 2 0 01-2-2V4a2 2 0 012-2zm5 17v.01', 't' => 'Meta Ads', 's' => 'Facebook · Instagram · Retargeting.' ],
-			[ 'i' => 'M12 2a10 10 0 100 20 10 10 0 000-20zM2 12h20M12 2a15.3 15.3 0 010 20m0-20a15.3 15.3 0 000 20', 't' => 'SEO-Anteil', 's' => 'Basis-Optimierung · Indexierung.' ],
-		],
+		'n'   => '03',
+		't'   => 'Skalieren & Übergeben',
+		's'   => 'Auf sauberem <a href="' . esc_url( $cwv_url ) . '">technischen Fundament</a> rechnen sich <a href="' . esc_url( $paid_url ) . '">Google Ads und Meta Ads</a> endlich — plus <a href="' . esc_url( $seo_url ) . '">SEO-Anteil</a>. Wöchentliches Reporting. Bei Vertragsende: dokumentierte Übergabe.',
+		'out' => 'Output / Skalierung · monatlich kündbar · 100 % Übergabe',
 	],
 ];
 
-// ── CAPEX vs OPEX · Zahlen aus dem messaging-canon ─────────────────────────────
+// 04 / CAPEX vs OPEX · Zahlen aus dem messaging-canon ──────────
 $capex_timeframes = [
 	12 => [
 		'portal_monthly' => '~ 1.080 €',
@@ -236,22 +159,54 @@ $capex_timeframes = [
 	],
 ];
 $capex_default = 24;
+$capex_now     = $capex_timeframes[ $capex_default ];
 
-// ── Fit-Check (passt / passt nicht) ────────────────────────────────────────────
+// 06 / Fit-Check (passt / passt nicht) ─────────────────────────
 $fit_yes = [
-	[ 't' => 'Solar, Wärmepumpe oder Speicher',             's' => 'Für Betriebe, bei denen Projektwert, Marge und Vertriebsfähigkeit stimmen.' ],
-	[ 't' => 'Eigener Vertrieb',                            's' => 'Ihr Vertriebsteam verkauft selbst — oder die Geschäftsführung übernimmt den Abschluss.' ],
-	[ 't' => 'Klares Zielgebiet',                           's' => 'Region oder Bundesland definiert — kein „bundesweit, alles".' ],
-	[ 't' => 'Hohe Projektwerte',                           's' => 'B2C ab ca. 15 k €, B2B ab ca. 50 k € pro Projekt.' ],
-	[ 't' => '12–24-Monate-Horizont',                       's' => 'Bereit, ein eigenes Anfrage-Asset aufzubauen statt nur Anfragen einzukaufen.' ],
-	[ 't' => 'Marke und Sichtbarkeit sind gewollt',          's' => 'Der eigene Anfrageweg funktioniert nur, wenn Ihr Betrieb sichtbar und unterscheidbar werden soll.' ],
+	[ 't' => 'Solar, Wärmepumpe oder Speicher',     's' => 'Projektwert, Marge und Vertriebsfähigkeit stimmen.' ],
+	[ 't' => 'Eigener Vertrieb',                    's' => 'Ihr Team verkauft selbst — oder die Geschäftsführung übernimmt den Abschluss.' ],
+	[ 't' => 'Klares Zielgebiet',                   's' => 'Region oder Bundesland definiert — kein „bundesweit, alles".' ],
+	[ 't' => 'Hohe Projektwerte',                   's' => 'B2C ab ca. 15 k €, B2B ab ca. 50 k € pro Projekt.' ],
+	[ 't' => '12–24-Monate-Horizont',               's' => 'Bereit, ein Anfrage-Asset aufzubauen statt nur Anfragen einzukaufen.' ],
+	[ 't' => 'Marke und Sichtbarkeit sind gewollt', 's' => 'Der eigene Anfrageweg lebt davon, dass Ihr Betrieb sichtbar und unterscheidbar wird.' ],
 ];
 $fit_no = [
-	[ 't' => 'Reines Vermittlungsgeschäft',                's' => 'Wer Leads weiterverkauft, braucht kein eigenes System.' ],
-	[ 't' => '„Nächste Woche brauchen wir Leads."',        's' => 'Tragfähige Pipelines wachsen über Monate, nicht Tage.' ],
-	[ 't' => 'Kein funktionierender Vertriebsprozess',     's' => 'Anfragen sterben, wenn niemand konsequent qualifiziert, zurückruft und nachfasst.' ],
-	[ 't' => 'Keine Marke gewollt',                        's' => 'Eigener Anfrageweg lebt davon, dass Sie sichtbar werden.' ],
+	[ 't' => 'Reines Vermittlungsgeschäft',                 's' => 'Wer Leads weiterverkauft, braucht kein eigenes System.' ],
+	[ 't' => '„Nächste Woche brauchen wir Leads."',         's' => 'Tragfähige Pipelines wachsen über Monate, nicht Tage.' ],
+	[ 't' => 'Kein funktionierender Vertriebsprozess',      's' => 'Anfragen sterben, wenn niemand konsequent qualifiziert, zurückruft und nachfasst.' ],
+	[ 't' => 'Keine Marke gewollt',                         's' => 'Eigener Anfrageweg lebt davon, dass Sie sichtbar werden.' ],
 	[ 't' => 'Kein sauberer Daten- und Anfrageweg gewollt', 's' => 'Ohne Tracking, Vorqualifizierung und klare Zuständigkeit bleibt auch ein eigenes System blind.' ],
+];
+
+// 07 / Risiko-Umkehr ───────────────────────────────────────────
+$guarantee_points = [
+	[
+		'e' => 'Befund',
+		't' => 'Marktcheck schafft Entscheidungsgrundlage',
+		's' => 'Händisch geprüfter Befund Ihrer Domain und Region innerhalb von 48 Stunden per E-Mail — mit Fit-Einschätzung und klarer Empfehlung für oder gegen den nächsten Schritt.',
+	],
+	[
+		'e' => 'Abrat inklusive',
+		't' => 'Drei priorisierte Hebel — auch bei Nein',
+		's' => 'Kommt die Diagnose zum Ergebnis, dass Sie das volle System nicht brauchen, bekommen Sie trotzdem drei Hebel mit konkretem nächstem Schritt.',
+	],
+	[
+		'e' => 'Verrechnung',
+		't' => 'Diagnose wird 1:1 angerechnet',
+		's' => 'Bei Umsetzung zahlen Sie die Diagnose nicht doppelt. Keine Mindestlaufzeit, volle Asset-Übergabe.',
+	],
+];
+
+// ── Sticky In-Page Section Nav (CRO: Orientierung + Jump) ─────
+$section_nav = [
+	[ 'h' => '#problem',    'l' => 'Status quo' ],
+	[ 'h' => '#vergleich',  'l' => 'Vergleich' ],
+	[ 'h' => '#system',     'l' => 'System' ],
+	[ 'h' => '#capex',      'l' => 'Rechnung' ],
+	[ 'h' => '#ergebnisse', 'l' => 'Referenz' ],
+	[ 'h' => '#fit',        'l' => 'Passt es?' ],
+	[ 'h' => '#deeper',     'l' => 'Vertiefung' ],
+	[ 'h' => '#faq',        'l' => 'FAQ' ],
 ];
 
 // ── Vertiefung: SEO-Sub-Pages-Cluster (Topical Authority) ──────
@@ -302,7 +257,7 @@ $faq_items = [
 	],
 	[
 		'question' => 'Welche Daten brauchen Sie für die Diagnose?',
-		'answer'   => 'Für den Marktcheck reichen zwei Klick-Antworten plus geschäftliche Eckdaten (Firma, Position, geschäftliche E-Mail, Firmen-PLZ). Für die Tiefendiagnose: Lesezugriff auf Google Analytics, Google Ads und Meta Ads Manager, Einblick in den CRM-Datenbestand der letzten 90 Tage und eine 15-Minuten-Bestandsaufnahme zu Vertriebsprozess und Lead-Quellen. Wenn Tracking-Daten fehlen, ist das oft schon das erste Diagnose-Ergebnis.',
+		'answer'   => 'Für den Marktcheck reichen zwei Klick-Antworten plus geschäftliche Eckdaten (Firma, Ansprechpartner, Position, geschäftliche E-Mail, Firmen-PLZ). Für die Tiefendiagnose: Lesezugriff auf Google Analytics, Google Ads und Meta Ads Manager, Einblick in den CRM-Datenbestand der letzten 90 Tage und eine 15-Minuten-Bestandsaufnahme zu Vertriebsprozess und Lead-Quellen. Wenn Tracking-Daten fehlen, ist das oft schon das erste Diagnose-Ergebnis.',
 	],
 	[
 		'question' => 'Warum nicht einfach mehr Google Ads schalten?',
@@ -428,131 +383,148 @@ get_header();
 ?>
 
 <main id="main" class="site-main">
-	<div class="solara-landing" data-track-section="energy_service_landing">
+	<div class="solara-landing hu-hp" data-track-section="energy_service_landing">
 
 		<!-- ════════════════════════════════════════════════════════════
-		     HERO mit Marktcheck-Quiz
+		     HERO — Ink, Kupfer-Sonne, CPL-Telemetrie + Marktcheck-Card
 		     ════════════════════════════════════════════════════════════ -->
-		<section class="sol-hero" id="hero" data-track-section="hero">
-			<div class="sol-hero-sky" aria-hidden="true"></div>
-			<div class="sol-hero-sun" aria-hidden="true">
-				<div class="sol-hero-sun-disc"></div>
-				<div class="sol-hero-sun-halo"></div>
-				<div class="sol-hero-sun-rays" data-sol-rays></div>
-			</div>
-			<div class="sol-hero-horizon" aria-hidden="true"></div>
+		<section class="hu-hero sol-hero" id="hero" data-track-section="hero">
+			<div class="hu-hero__grid-bg" aria-hidden="true"></div>
 
-			<div class="sol-wrap sol-hero-inner">
+			<?php
+			// Kupfer-Sonne: 32 Strahlen, alternierende Länge/Stärke,
+			// langsam rotierend (CSS), rein dekorativ.
+			?>
+			<svg class="sol-sun" viewBox="0 0 600 600" aria-hidden="true" focusable="false">
+				<defs>
+					<radialGradient id="sol-sun-core" cx="50%" cy="50%" r="50%">
+						<stop offset="0%" stop-color="#E08A3C" stop-opacity="0.22" />
+						<stop offset="60%" stop-color="#E08A3C" stop-opacity="0.07" />
+						<stop offset="100%" stop-color="#E08A3C" stop-opacity="0" />
+					</radialGradient>
+				</defs>
+				<circle cx="300" cy="300" r="150" fill="url(#sol-sun-core)" />
+				<g class="sol-sun-rays">
+					<?php
+					for ( $ray = 0; $ray < 32; $ray++ ) :
+						$angle = $ray / 32 * 2 * M_PI;
+						$r1    = 150;
+						$r2    = 0 === $ray % 2 ? 225 : 188;
+						?>
+						<line
+							x1="<?php echo esc_attr( (string) round( 300 + cos( $angle ) * $r1, 1 ) ); ?>"
+							y1="<?php echo esc_attr( (string) round( 300 + sin( $angle ) * $r1, 1 ) ); ?>"
+							x2="<?php echo esc_attr( (string) round( 300 + cos( $angle ) * $r2, 1 ) ); ?>"
+							y2="<?php echo esc_attr( (string) round( 300 + sin( $angle ) * $r2, 1 ) ); ?>"
+							stroke="#E08A3C" stroke-width="<?php echo esc_attr( 0 === $ray % 2 ? '1.5' : '0.9' ); ?>"
+							stroke-linecap="round" opacity="0.4" />
+					<?php endfor; ?>
+				</g>
+				<circle cx="300" cy="300" r="150" fill="none" stroke="#E08A3C" stroke-width="1" opacity="0.3" />
+				<circle cx="300" cy="300" r="122" fill="none" stroke="#E08A3C" stroke-width="0.7" opacity="0.18" stroke-dasharray="1 6" />
+			</svg>
+
+			<div class="hu-container hu-hero__container sol-hero-inner">
 				<div class="sol-hero-left">
-					<div class="sol-eyebrow">Für Solar- &amp; Wärmepumpen-Anbieter mit eigenem Vertrieb · DACH</div>
-					<h1 class="sol-display sol-hero-h1">
-						Eigene Solar-Anfragen statt geteilte Portal-Leads — exklusiv für Ihren Vertrieb.
+					<span class="hu-tag">
+						<span class="hu-dot hu-dot--live" aria-hidden="true"></span>
+						<span class="hu-mono">Für Solar- &amp; Wärmepumpen-Betriebe · Eigener Vertrieb · DACH</span>
+					</span>
+					<h1 class="hu-display hu-hero__title sol-hero-h1">
+						Hören Sie auf,<br />Anfragen<br />zu&nbsp;<span class="hu-hero__title-2">mieten.</span>
 					</h1>
-					<p class="sol-hero-claim">
-						Aroundhome, DAA und Wattfox verkaufen jede Anfrage an drei Wettbewerber. Sie zahlen für den Preiskampf.
-					</p>
-					<p class="sol-hero-sub">
-						Ein geschlossenes Anfrage-System auf Ihrer Domain — Sie besitzen den Kanal, den Datensatz und jede Anfrage. Der Marktcheck zeigt, ob Region, Vertrieb und Anfragequalität den nächsten Schritt tragen.
+					<p class="hu-hero__sub">
+						Aroundhome, DAA und Wattfox verkaufen jede Anfrage an drei Wettbewerber — Sie bezahlen den Preiskampf.
+						Ein eigenes Anfrage-System für Solar, Wärmepumpe und Speicher macht <strong>Region, Projektwert und Fit</strong>
+						sichtbar, bevor Ihr Vertrieb Zeit in falsche Gespräche steckt. Sie besitzen den Kanal,
+						den Datensatz und jede Anfrage.
 					</p>
 
 					<?php
-					// ── CPL-Kaskade · Blueprint-Dashboard (E3 New Energy Case) ──
-					// 6-Monats-Achse · 150 € → 22 € (animierte SVG-Visualisierung).
-					$cpl_cascade = [
-						[ 'm' => 1, 'v' => 150 ],
-						[ 'm' => 2, 'v' => 95 ],
-						[ 'm' => 3, 'v' => 65 ],
-						[ 'm' => 4, 'v' => 42 ],
-						[ 'm' => 5, 'v' => 28 ],
-						[ 'm' => 6, 'v' => 22 ],
-					];
-					$cpl_max  = 160;
-					$cpl_chart_w = 480;
-					$cpl_chart_h = 200;
-					$cpl_pad_l   = 44;
-					$cpl_pad_r   = 28;
-					$cpl_pad_t   = 24;
-					$cpl_pad_b   = 36;
-					$cpl_inner_w = $cpl_chart_w - $cpl_pad_l - $cpl_pad_r;
-					$cpl_inner_h = $cpl_chart_h - $cpl_pad_t - $cpl_pad_b;
-					$cpl_points  = [];
-					foreach ( $cpl_cascade as $i => $p ) {
-						$x = $cpl_pad_l + ( $cpl_inner_w * $i / ( count( $cpl_cascade ) - 1 ) );
-						$y = $cpl_pad_t + ( $cpl_inner_h * ( 1 - $p['v'] / $cpl_max ) );
-						$cpl_points[] = [ 'x' => round( $x, 1 ), 'y' => round( $y, 1 ), 'm' => $p['m'], 'v' => $p['v'] ];
-					}
-					$cpl_path = '';
-					foreach ( $cpl_points as $i => $pt ) {
-						$cpl_path .= ( 0 === $i ? 'M' : ' L' ) . $pt['x'] . ' ' . $pt['y'];
-					}
-					$cpl_area = $cpl_path . ' L' . end( $cpl_points )['x'] . ' ' . ( $cpl_pad_t + $cpl_inner_h ) . ' L' . $cpl_points[0]['x'] . ' ' . ( $cpl_pad_t + $cpl_inner_h ) . ' Z';
+					// CPL-Telemetrie: 6 Kupfer-Balken, Endpunkte aus dem E3-Canon
+					// (150 € → 22 €), Zwischenwerte kosmetische Kaskade.
+					$cpl_bars  = [ $e3_cpl_before_val, 96, 61, 42, 30, $e3_cpl_after_val ];
+					$cpl_w     = 520;
+					$cpl_h     = 210;
+					$cpl_pad_l = 16;
+					$cpl_pad_t = 22;
+					$cpl_pad_b = 30;
+					$cpl_max   = 160;
+					$cpl_inner = $cpl_h - $cpl_pad_t - $cpl_pad_b;
+					$cpl_bw    = ( $cpl_w - $cpl_pad_l - 10 ) / count( $cpl_bars );
 					?>
-					<figure class="sol-hero-dashboard" aria-labelledby="sol-cpl-dashboard-title" data-track-section="hero_dashboard">
-						<figcaption class="sol-hero-dashboard-cap">
-							<span class="sol-mono sol-hero-dashboard-tag">
-								<span class="sol-hero-dashboard-tag-dot" aria-hidden="true"></span>
-								Live-Telemetrie · E3 New Energy
-							</span>
-							<span id="sol-cpl-dashboard-title" class="sol-display sol-hero-dashboard-title">CPL-Kaskade · 6 Monate</span>
-							<span class="sol-hero-dashboard-meta sol-mono">Akquisitionskosten pro qualifizierter Anfrage</span>
+					<figure class="hu-diagram sol-cpl" aria-labelledby="sol-cpl-title" data-track-section="hero_dashboard">
+						<div class="hu-lead-sketch__head">
+							<span class="hu-eyebrow">Live-Telemetrie · <?php echo esc_html( $e3_case_label ); ?></span>
+							<span class="hu-lead-sketch__status" id="sol-cpl-title">Kosten pro qualifizierter Anfrage · <?php echo esc_html( $e3_timeframe ); ?></span>
+						</div>
+						<svg viewBox="0 0 <?php echo (int) $cpl_w; ?> <?php echo (int) $cpl_h; ?>" role="img"
+							aria-label="Kosten pro Anfrage fallen von <?php echo esc_attr( (string) $e3_cpl_before_val ); ?> Euro auf <?php echo esc_attr( (string) $e3_cpl_after_val ); ?> Euro in sechs Monaten">
+							<?php
+							foreach ( [ 0, 40, 80, 120, 160 ] as $grid_v ) :
+								$grid_y = $cpl_pad_t + ( 1 - $grid_v / $cpl_max ) * $cpl_inner;
+								?>
+								<line x1="<?php echo (int) ( $cpl_pad_l + 16 ); ?>" x2="<?php echo (int) $cpl_w; ?>"
+									y1="<?php echo esc_attr( (string) round( $grid_y, 1 ) ); ?>" y2="<?php echo esc_attr( (string) round( $grid_y, 1 ) ); ?>"
+									stroke="rgba(255,255,255,0.07)" stroke-width="1" />
+								<text x="<?php echo (int) ( $cpl_pad_l + 10 ); ?>" y="<?php echo esc_attr( (string) round( $grid_y + 3, 1 ) ); ?>"
+									text-anchor="end" font-size="9" fill="#5C5A52"
+									font-family="'JetBrains Mono', monospace"><?php echo (int) $grid_v; ?></text>
+							<?php endforeach; ?>
+							<?php
+							foreach ( $cpl_bars as $bar_i => $bar_v ) :
+								$bar_x    = $cpl_pad_l + 24 + $bar_i * $cpl_bw;
+								$bar_h    = $bar_v / $cpl_max * $cpl_inner;
+								$bar_y    = $cpl_h - $cpl_pad_b - $bar_h;
+								$bar_last = count( $cpl_bars ) - 1 === $bar_i;
+								?>
+								<rect class="sol-bar" style="animation-delay:<?php echo (int) ( 250 + $bar_i * 110 ); ?>ms"
+									x="<?php echo esc_attr( (string) round( $bar_x, 1 ) ); ?>" y="<?php echo esc_attr( (string) round( $bar_y, 1 ) ); ?>"
+									width="<?php echo esc_attr( (string) round( $cpl_bw * 0.5, 1 ) ); ?>" height="<?php echo esc_attr( (string) round( $bar_h, 1 ) ); ?>"
+									rx="2" fill="<?php echo esc_attr( $bar_last ? '#E08A3C' : 'rgba(242,235,221,0.13)' ); ?>" />
+								<text class="sol-bar-label" style="animation-delay:<?php echo (int) ( 520 + $bar_i * 110 ); ?>ms"
+									x="<?php echo esc_attr( (string) round( $bar_x + $cpl_bw * 0.25, 1 ) ); ?>" y="<?php echo esc_attr( (string) round( $bar_y - 7, 1 ) ); ?>"
+									text-anchor="middle" font-size="11.5" font-weight="800"
+									font-family="'Satoshi','Figtree',sans-serif"
+									fill="<?php echo esc_attr( $bar_last ? '#E08A3C' : '#8A8478' ); ?>"><?php echo (int) $bar_v; ?> €</text>
+								<text x="<?php echo esc_attr( (string) round( $bar_x + $cpl_bw * 0.25, 1 ) ); ?>" y="<?php echo (int) ( $cpl_h - $cpl_pad_b + 17 ); ?>"
+									text-anchor="middle" font-size="9" letter-spacing="1.5"
+									font-family="'JetBrains Mono', monospace" fill="#5C5A52">M<?php echo (int) ( $bar_i + 1 ); ?></text>
+							<?php endforeach; ?>
+						</svg>
+						<figcaption class="hu-lead-sketch__footer">
+							<span>Reduktion <?php echo esc_html( $e3_cpl_reduction ); ?></span>
+							<span>DSGVO · Server in Frankfurt</span>
 						</figcaption>
-						<div class="sol-hero-dashboard-frame">
-							<svg class="sol-hero-dashboard-svg" viewBox="0 0 <?php echo (int) $cpl_chart_w; ?> <?php echo (int) $cpl_chart_h; ?>" role="img" aria-label="CPL fällt in 6 Monaten von 150 € auf 22 € — Visualisierung der Kosten-Reduktion">
-								<defs>
-									<pattern id="sol-cpl-grid" width="40" height="20" patternUnits="userSpaceOnUse">
-										<path d="M40 0H0V20" fill="none" stroke="currentColor" stroke-width="0.5" stroke-opacity="0.18"/>
-									</pattern>
-									<linearGradient id="sol-cpl-fill" x1="0" x2="0" y1="0" y2="1">
-										<stop offset="0%" stop-color="currentColor" stop-opacity="0.35"/>
-										<stop offset="100%" stop-color="currentColor" stop-opacity="0"/>
-									</linearGradient>
-								</defs>
-								<rect x="<?php echo (int) $cpl_pad_l; ?>" y="<?php echo (int) $cpl_pad_t; ?>" width="<?php echo (int) $cpl_inner_w; ?>" height="<?php echo (int) $cpl_inner_h; ?>" fill="url(#sol-cpl-grid)" />
-								<?php for ( $g = 0; $g <= 4; $g++ ) : $gy = $cpl_pad_t + ( $cpl_inner_h * $g / 4 ); $gv = (int) round( $cpl_max * ( 1 - $g / 4 ) ); ?>
-									<line x1="<?php echo (int) $cpl_pad_l; ?>" x2="<?php echo (int) ( $cpl_chart_w - $cpl_pad_r ); ?>" y1="<?php echo (float) $gy; ?>" y2="<?php echo (float) $gy; ?>" stroke="currentColor" stroke-opacity="0.22" stroke-dasharray="2 4" stroke-width="0.6"/>
-									<text x="<?php echo (int) ( $cpl_pad_l - 8 ); ?>" y="<?php echo (float) ( $gy + 3 ); ?>" text-anchor="end" font-size="9" fill="currentColor" fill-opacity="0.65" font-family="ui-monospace, SFMono-Regular, Menlo, monospace"><?php echo (int) $gv; ?> €</text>
-								<?php endfor; ?>
-								<path class="sol-hero-dashboard-area" d="<?php echo esc_attr( $cpl_area ); ?>" fill="url(#sol-cpl-fill)"/>
-								<path class="sol-hero-dashboard-line" d="<?php echo esc_attr( $cpl_path ); ?>" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
-								<?php foreach ( $cpl_points as $i => $pt ) : $is_anchor = ( 0 === $i || count( $cpl_points ) - 1 === $i ); ?>
-										<g class="sol-hero-dashboard-pt<?php echo esc_attr( $is_anchor ? ' is-anchor' : '' ); ?>" style="--sol-pt-delay:<?php echo esc_attr( (string) (float) ( $i * 0.12 ) ); ?>s;">
-											<circle cx="<?php echo esc_attr( (string) (float) $pt['x'] ); ?>" cy="<?php echo esc_attr( (string) (float) $pt['y'] ); ?>" r="<?php echo esc_attr( (string) ( $is_anchor ? 4.5 : 2.5 ) ); ?>" fill="currentColor"/>
-										<?php if ( $is_anchor ) : ?>
-											<circle cx="<?php echo (float) $pt['x']; ?>" cy="<?php echo (float) $pt['y']; ?>" r="9" fill="none" stroke="currentColor" stroke-opacity="0.45" stroke-width="0.8"/>
-											<text x="<?php echo (float) ( $pt['x'] + ( 0 === $i ? 10 : -10 ) ); ?>" y="<?php echo (float) ( $pt['y'] - 10 ); ?>" text-anchor="<?php echo 0 === $i ? 'start' : 'end'; ?>" font-size="11" font-weight="600" fill="currentColor" font-family="ui-monospace, SFMono-Regular, Menlo, monospace"><?php echo (int) $pt['v']; ?> €</text>
-										<?php endif; ?>
-									</g>
-								<?php endforeach; ?>
-								<?php foreach ( $cpl_points as $i => $pt ) : if ( 0 !== $i && count( $cpl_points ) - 1 !== $i && 0 !== $i % 2 ) continue; ?>
-									<text x="<?php echo (float) $pt['x']; ?>" y="<?php echo (int) ( $cpl_chart_h - 12 ); ?>" text-anchor="middle" font-size="9" fill="currentColor" fill-opacity="0.65" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">M<?php echo (int) $pt['m']; ?></text>
-								<?php endforeach; ?>
-								<line x1="<?php echo (int) $cpl_pad_l; ?>" x2="<?php echo (int) ( $cpl_chart_w - $cpl_pad_r ); ?>" y1="<?php echo (int) ( $cpl_pad_t + $cpl_inner_h ); ?>" y2="<?php echo (int) ( $cpl_pad_t + $cpl_inner_h ); ?>" stroke="currentColor" stroke-opacity="0.45" stroke-width="0.8"/>
-							</svg>
-							<div class="sol-hero-dashboard-readout sol-mono" aria-hidden="true">
-								<span class="sol-hero-dashboard-readout-l">Reduktion</span>
-								<span class="sol-hero-dashboard-readout-v">−85,3 %</span>
-							</div>
-						</div>
-						<div class="sol-hero-dashboard-legend sol-mono">
-							<span><span class="sol-hero-dashboard-legend-mark"></span>CPL · Eigene Anfrage-Infrastruktur</span>
-							<span>Quelle: E3 New Energy · 6-Monats-Zeitachse · DSGVO-konform</span>
-						</div>
 					</figure>
 
-					<div class="sol-hero-metrics">
-						<?php foreach ( $hero_metrics as $m ) : ?>
-							<div class="sol-metric">
-								<div class="sol-metric-n sol-display"><?php echo esc_html( $m['n'] ); ?></div>
-								<div class="sol-metric-l sol-mono"><?php echo esc_html( $m['l'] ); ?></div>
-							</div>
-						<?php endforeach; ?>
+					<div class="hu-hero__stats">
+						<div>
+							<div class="hu-stat-num" style="color:var(--accent);" data-sol-countup><?php echo esc_html( $e3_cpl_after ); ?></div>
+							<div class="hu-stat-label">CPL nach <?php echo esc_html( $e3_timeframe_dative ); ?> · <?php echo esc_html( $e3_case_label ); ?></div>
+						</div>
+						<div class="hu-stat-divider"></div>
+						<div>
+							<div class="hu-stat-num" data-sol-countup><?php echo esc_html( $e3_lead_count ); ?></div>
+							<div class="hu-stat-label">Qualifizierte Anfragen</div>
+						</div>
+						<div class="hu-stat-divider"></div>
+						<div>
+							<div class="hu-stat-num" data-sol-countup><?php echo esc_html( $e3_sales_conversion ); ?></div>
+							<div class="hu-stat-label">Abschlussquote · Anfrage → Vertrag</div>
+						</div>
 					</div>
 
-					<p class="sol-mono" style="margin-top:14px;color:var(--sol-fg-dim);font-size:11px;letter-spacing:.06em;">
+					<ul class="hu-hero__bullets">
+						<li><span class="hu-bullet-dot" aria-hidden="true"></span>Befund in 48 h · kein Pflicht-Call</li>
+						<li><span class="hu-bullet-dot" aria-hidden="true"></span>Keine Zahlungsdaten, kein Abo</li>
+						<li><span class="hu-bullet-dot" aria-hidden="true"></span>Für Solar, Wärmepumpe und Speicher</li>
+					</ul>
+
+					<p class="sol-hero-callink hu-mono">
 						Bereits qualifizierter Fall?
 						<a
 							href="<?php echo esc_url( $cal_url ); ?>"
-							style="color:var(--sol-accent);text-decoration:underline;text-underline-offset:3px;margin-left:6px;"
 							data-track-action="cta_solar_to_calcom"
 							data-track-category="lead_gen"
 							data-track-section="hero_secondary"
@@ -562,11 +534,6 @@ get_header();
 
 				<aside class="sol-hero-right" aria-labelledby="sol-quiz-title">
 					<div class="sol-cta-card" id="marktcheck">
-						<div class="sol-cta-particles" aria-hidden="true">
-							<span class="sol-cta-particle"></span>
-							<span class="sol-cta-particle"></span>
-							<span class="sol-cta-particle"></span>
-						</div>
 						<!--
 						  Marktcheck Mount-Point. JS rendert hier die
 						  3-stufige Progressive-Disclosure-Sequenz.
@@ -577,7 +544,7 @@ get_header();
 								<style>.solara-landing .sol-cta-fineprint{display:none!important;}</style>
 								<p class="sol-cta-hint">
 									Aktivieren Sie JavaScript für den Marktcheck oder schreiben Sie direkt an
-									<a href="mailto:hasim@hasimuener.de" style="color:var(--sol-accent);">hasim@hasimuener.de</a>.
+									<a href="mailto:hasim@hasimuener.de" style="color:var(--accent);">hasim@hasimuener.de</a>.
 								</p>
 								<a
 									class="sol-cta-submit"
@@ -595,7 +562,7 @@ get_header();
 							<div class="sol-cta-head">
 								<span class="sol-cta-tag sol-mono">
 									<span class="sol-cta-tag-dot" aria-hidden="true"></span>
-									Marktcheck · Fit geprüft · nächster Schritt
+									Marktcheck · Fit geprüft · 48-h-Befund
 								</span>
 								<span class="sol-cta-head-right sol-mono">Fit-Check</span>
 							</div>
@@ -603,15 +570,17 @@ get_header();
 								Marktcheck für Ihren Vertrieb starten.
 							</h2>
 							<p class="sol-cta-hint">
-								Dreistufiger Marktcheck. Strukturierte Aufnahme Ihres Vertriebs- und Lead-Profils — mit Fit-Befund, drei priorisierten Hebeln und nächstem Schritt. Kein Newsletter, kein Pitch-Deck.
+								Drei Schritte, vier Angaben. Sie erhalten einen händisch geprüften Fit-Befund
+								für Ihre Region — mit drei priorisierten Hebeln und klarem nächsten Schritt.
+								Kein Newsletter, kein Pitch-Deck.
 							</p>
 							<ul class="sol-cta-bullets sol-mono" aria-label="Was Sie nach dem Marktcheck erhalten">
 								<li><span class="sol-cta-bullets-tick" aria-hidden="true">✓</span>Kostenlos &amp; unverbindlich — keine Zahlungsdaten, kein Abo</li>
-								<li><span class="sol-cta-bullets-tick" aria-hidden="true">✓</span>Inklusive Regions-Verfügbarkeitsprüfung</li>
+								<li><span class="sol-cta-bullets-tick" aria-hidden="true">✓</span>Regions-Verfügbarkeitsprüfung über Ihre Firmen-PLZ</li>
 								<li><span class="sol-cta-bullets-tick" aria-hidden="true">✓</span>Manuelle Erst-Analyse statt automatisierter Tool-Bericht</li>
-								<li><span class="sol-cta-bullets-tick" aria-hidden="true">✓</span>Persönliche Rückmeldung mit Fit-Entscheid</li>
+								<li><span class="sol-cta-bullets-tick" aria-hidden="true">✓</span>Befund in 48 h per E-Mail · kein Pflicht-Call</li>
 							</ul>
-							<p class="sol-cta-fineprint" style="text-align:left;margin:0 0 14px;">Wird geladen …</p>
+							<p class="sol-cta-fineprint">Wird geladen …</p>
 						</div>
 					</div>
 				</aside>
@@ -622,7 +591,7 @@ get_header();
 		     TRUST STRIP
 		     ════════════════════════════════════════════════════════════ -->
 		<section class="sol-trust" aria-label="Vertrauenssignale" data-track-section="trust_strip">
-			<div class="sol-wrap">
+			<div class="hu-container">
 				<div class="sol-trust-row">
 					<?php foreach ( $trust_items as $t ) : ?>
 						<span class="sol-trust-item sol-mono">
@@ -640,7 +609,7 @@ get_header();
 		     ohne den globalen Header zu ersetzen (SEO/Brand bleibt).
 		     ════════════════════════════════════════════════════════════ -->
 		<nav class="sol-section-nav" aria-label="Sektionen dieser Seite" data-track-section="section_nav">
-			<div class="sol-wrap">
+			<div class="hu-container">
 				<div class="sol-section-nav-inner">
 					<span class="sol-section-nav-label sol-mono" aria-hidden="true">Auf dieser Seite</span>
 					<ul class="sol-section-nav-list">
@@ -662,20 +631,23 @@ get_header();
 		</nav>
 
 		<!-- ════════════════════════════════════════════════════════════
-		     PROBLEM
+		     01 / STATUS QUO (Creme)
 		     ════════════════════════════════════════════════════════════ -->
-		<section class="sol-section" id="problem" data-track-section="problem">
-			<div class="sol-wrap">
-				<div class="sol-eyebrow">Der Status Quo</div>
-				<h2 class="sol-display sol-problem-h">
-					Sie zahlen für <em>Anfragen, die nicht Ihnen gehören</em> — und Vertriebsstunden, die niemand kauft.
-				</h2>
-				<div class="sol-problem-grid">
-					<?php foreach ( $problem_cards as $c ) : ?>
-						<article class="sol-problem-card">
-							<div class="sol-problem-card-n"><?php echo esc_html( $c['n'] ); ?> · <?php echo esc_html( $c['l'] ); ?></div>
-							<div class="sol-problem-card-t"><?php echo esc_html( $c['t'] ); ?></div>
-							<p class="sol-problem-card-s"><?php echo esc_html( $c['s'] ); ?></p>
+		<section class="hu-section hu-section--cream" id="problem" data-track-section="problem">
+			<div class="hu-container">
+				<div class="hu-section-head">
+					<span class="hu-eyebrow">01 / Status quo</span>
+					<div>
+						<h2>Sie zahlen für Anfragen, die nicht Ihnen gehören.</h2>
+						<p class="hu-lead">Und für Vertriebsstunden, die niemand kauft. Drei Gründe, warum der Lead-Einkauf Sie teurer kommt, als er aussieht.</p>
+					</div>
+				</div>
+				<div class="hu-cost-grid">
+					<?php foreach ( $cost_cards as $c ) : ?>
+						<article class="hu-cost-card">
+							<div class="hu-cost-card__big"><?php echo esc_html( $c['big'] ); ?></div>
+							<div class="hu-cost-card__sub"><?php echo esc_html( $c['sub'] ); ?></div>
+							<p class="hu-cost-card__body"><?php echo esc_html( $c['body'] ); ?></p>
 						</article>
 					<?php endforeach; ?>
 				</div>
@@ -683,50 +655,42 @@ get_header();
 		</section>
 
 		<!-- ════════════════════════════════════════════════════════════
-		     COMPARE — Markt-Standard vs Eigener Weg
-		     Konturiert die strategische Alternative zum Status quo.
+		     02 / MARKT VS. EIGENER WEG (Ink)
 		     ════════════════════════════════════════════════════════════ -->
-		<section class="sol-section sol-compare-section" id="vergleich" data-track-section="compare">
-			<div class="sol-wrap">
-				<div class="sol-eyebrow">Markt vs Eigener Weg</div>
-				<h2 class="sol-display sol-compare-h">
-					Sie kaufen keine Leads mehr. Sie bauen <em>den Weg</em>, auf dem sie entstehen.
-				</h2>
-				<p class="sol-compare-sub">
-					Der Ausweg ist nicht ein besseres Portal. Es ist ein Anfrageweg, der Ihnen gehört — und sich messen lässt.
-				</p>
-
-				<div class="sol-compare">
-					<div class="sol-compare-col sol-compare-col--bad">
-						<div class="sol-compare-tag sol-mono" aria-hidden="true">Aktuell · kostet</div>
-						<div class="sol-compare-head">
-							<span class="sol-compare-icon sol-compare-icon--bad" aria-hidden="true">✕</span>
-							<span>Markt-Standard</span>
+		<section class="hu-section" id="vergleich" data-track-section="compare">
+			<div class="hu-container">
+				<div class="hu-section-head">
+					<span class="hu-eyebrow">02 / Markt vs. eigener Weg</span>
+					<div>
+						<h2>Mieten oder besitzen.</h2>
+						<p class="hu-lead">Der Ausweg ist nicht ein besseres Portal. Es ist ein Anfrageweg, der Ihnen gehört — und sich messen lässt.</p>
+					</div>
+				</div>
+				<div class="hu-compare">
+					<div class="hu-compare__col hu-compare__col--bad">
+						<div class="hu-compare__head">
+							<span class="hu-compare__icon" aria-hidden="true">✕</span>
+							<span>Portal-Miete</span>
 						</div>
 						<?php foreach ( $compare_bad as $row ) : ?>
-							<div class="sol-compare-row">
-								<div class="sol-compare-row-t"><?php echo esc_html( $row['t'] ); ?></div>
-								<div class="sol-compare-row-d"><?php echo esc_html( $row['s'] ); ?></div>
+							<div class="hu-compare__row">
+								<div class="hu-compare__row-t"><?php echo esc_html( $row['t'] ); ?></div>
+								<div class="hu-compare__row-d"><?php echo esc_html( $row['s'] ); ?></div>
 							</div>
 						<?php endforeach; ?>
 					</div>
-
-					<div class="sol-compare-divider" aria-hidden="true">
-						<span class="sol-compare-divider-icon"><?php echo $arrow_svg; // raw-ok phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></span>
+					<div class="hu-compare__divider" aria-hidden="true">
+						<span class="hu-compare__divider-icon">→</span>
 					</div>
-
-					<div class="sol-compare-col sol-compare-col--good">
-						<div class="sol-compare-tag sol-mono sol-compare-tag--good" aria-hidden="true">Empfohlen · bleibt</div>
-						<div class="sol-compare-head">
-							<span class="sol-compare-icon sol-compare-icon--good" aria-hidden="true">
-								<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12l5 5L20 7"/></svg>
-							</span>
-							<span>Eigener Weg</span>
+					<div class="hu-compare__col hu-compare__col--good">
+						<div class="hu-compare__head">
+							<span class="hu-compare__icon hu-compare__icon--good" aria-hidden="true">✓</span>
+							<span>Eigener Anfrageweg</span>
 						</div>
 						<?php foreach ( $compare_good as $row ) : ?>
-							<div class="sol-compare-row">
-								<div class="sol-compare-row-t"><?php echo esc_html( $row['t'] ); ?></div>
-								<div class="sol-compare-row-d"><?php echo esc_html( $row['s'] ); ?></div>
+							<div class="hu-compare__row">
+								<div class="hu-compare__row-t"><?php echo esc_html( $row['t'] ); ?></div>
+								<div class="hu-compare__row-d"><?php echo esc_html( $row['s'] ); ?></div>
 							</div>
 						<?php endforeach; ?>
 					</div>
@@ -735,115 +699,71 @@ get_header();
 		</section>
 
 		<!-- ════════════════════════════════════════════════════════════
-		     SYSTEM-DIAGRAMM — 4 Layer · was Kunden konkret bekommen
-		     "Ihr eigenes System — was Sie genau bekommen"
+		     03 / DAS SYSTEM — Asset-Panel + drei Schritte (Creme)
 		     ════════════════════════════════════════════════════════════ -->
-		<section class="sol-section sol-section--tinted sol-system-section" id="system-bild" data-track-section="system_diagram">
-			<div class="sol-wrap">
-				<div class="sol-system-head">
-					<span class="sol-system-badge sol-mono">
-						<span class="sol-system-badge-pulse" aria-hidden="true"></span>
-						Ihr eigenes System
-					</span>
-					<h2 class="sol-display sol-system-h">
-						Was Sie <em>genau</em> bekommen.
-					</h2>
-					<p class="sol-system-sub">
-						Kein Blackbox-Setup. Jede Komponente ist dokumentiert, gehört Ihnen und wird 1:1 übergeben — inklusive Zugang zu allen Accounts.
-					</p>
+		<section class="hu-section hu-section--cream" id="system" data-track-section="method">
+			<div class="hu-container">
+				<div class="hu-section-head">
+					<span class="hu-eyebrow">03 / Das System</span>
+					<div>
+						<h2>Diagnose. Aufbau. Eigentum.</h2>
+						<p class="hu-lead">Drei Schritte, ein Ergebnis: exklusive Anfragen. Jede Komponente ist dokumentiert, gehört Ihnen und wird 1:1 übergeben — inklusive Zugang zu allen Accounts.</p>
+					</div>
 				</div>
-
-				<div class="sol-system-canvas">
-					<?php foreach ( $system_layers as $layer_index => $layer ) : ?>
-						<article class="sol-system-layer<?php echo 3 === $layer['cols'] ? ' is-three' : ''; ?>" style="--sol-delay:<?php echo (float) ( $layer_index * 0.12 ); ?>s;">
-							<header class="sol-system-layer-head">
-								<div class="sol-system-layer-n sol-display"><?php echo esc_html( $layer['n'] ); ?></div>
-								<div class="sol-system-layer-name">
-									<?php if ( ! empty( $layer['url'] ) ) : ?>
-										<a href="<?php echo esc_url( $layer['url'] ); ?>" class="sol-system-layer-name-link" data-track-action="cluster_link_<?php echo esc_attr( sanitize_title( $layer['name'] ) ); ?>" data-track-category="internal_link" data-track-section="system_diagram"><?php echo esc_html( $layer['name'] ); ?></a>
+				<div class="hu-process-grid">
+					<div class="hu-process-asset">
+						<?php foreach ( $process_rows as $row ) : ?>
+							<div class="hu-process-asset__row">
+								<span class="hu-eyebrow"><?php echo esc_html( $row['e'] ); ?></span>
+								<div class="hu-process-asset__row-title">
+									<?php if ( ! empty( $row['url'] ) ) : ?>
+										<a href="<?php echo esc_url( $row['url'] ); ?>"
+											data-track-action="cluster_link_<?php echo esc_attr( sanitize_title( $row['e'] ) ); ?>"
+											data-track-category="internal_link"
+											data-track-section="method"><?php echo esc_html( $row['t'] ); ?></a>
 									<?php else : ?>
-										<?php echo esc_html( $layer['name'] ); ?>
+										<?php echo esc_html( $row['t'] ); ?>
 									<?php endif; ?>
 								</div>
-								<div class="sol-system-layer-status sol-mono"><?php echo esc_html( $layer['status'] ); ?></div>
-							</header>
-							<div class="sol-system-grid">
-								<?php foreach ( $layer['items'] as $item ) : ?>
-									<div class="sol-system-comp">
-										<span class="sol-system-comp-icon" aria-hidden="true">
-											<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" focusable="false"><path d="<?php echo esc_attr( $item['i'] ); ?>"/></svg>
-										</span>
-										<div class="sol-system-comp-body">
-											<div class="sol-system-comp-t"><?php echo esc_html( $item['t'] ); ?></div>
-											<div class="sol-system-comp-s"><?php echo esc_html( $item['s'] ); ?></div>
-										</div>
-									</div>
-								<?php endforeach; ?>
 							</div>
-							<?php if ( $layer_index < count( $system_layers ) - 1 ) : ?>
-								<div class="sol-system-layer-connector" aria-hidden="true"></div>
-							<?php endif; ?>
-						</article>
-					<?php endforeach; ?>
-				</div>
-
-				<div class="sol-system-ownership" role="note">
-					<div class="sol-system-ownership-mark" aria-hidden="true">
-						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" focusable="false"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+						<?php endforeach; ?>
+						<div class="hu-process-asset__metrics">
+							<div class="hu-process-asset__metric">
+								<div class="hu-process-asset__metric-num">100 %</div>
+								<div class="hu-process-asset__metric-lbl">Asset-Eigentum</div>
+							</div>
+							<div class="hu-process-asset__metric">
+								<div class="hu-process-asset__metric-num">1:1</div>
+								<div class="hu-process-asset__metric-lbl">Übergabe · Accounts</div>
+							</div>
+						</div>
 					</div>
-					<div class="sol-system-ownership-body">
-						<div class="sol-system-ownership-t">100 % Asset-Eigentum</div>
-						<div class="sol-system-ownership-s">Code, Tracking-Accounts, Server-Zugang, Datenhoheit — alles dokumentiert übergeben. Das System bleibt bei Ihnen, auch wenn die Zusammenarbeit endet.</div>
+					<div class="hu-steps">
+						<?php foreach ( $method_cards as $card ) : ?>
+							<div class="hu-step">
+								<div class="hu-step__num"><?php echo esc_html( $card['n'] ); ?></div>
+								<div class="hu-step__title"><?php echo esc_html( $card['t'] ); ?></div>
+								<p class="hu-step__body"><?php echo wp_kses_post( $card['s'] ); ?></p>
+								<div class="hu-step__out"><?php echo esc_html( $card['out'] ); ?></div>
+							</div>
+						<?php endforeach; ?>
 					</div>
 				</div>
 			</div>
 		</section>
 
 		<!-- ════════════════════════════════════════════════════════════
-		     METHOD / SYSTEM
-		     ════════════════════════════════════════════════════════════ -->
-		<section class="sol-section sol-method" id="system" data-track-section="method">
-			<div class="sol-wrap">
-				<div class="sol-method-head">
-					<div class="sol-eyebrow">Das System</div>
-					<h2 class="sol-display sol-method-h">
-						Diagnose. Aufbau. Eigentum.<br />Drei Phasen — <em>ein Ergebnis</em>: exklusive Anfragen.
-					</h2>
-				</div>
-				<div class="sol-method-grid">
-					<?php foreach ( $method_cards as $card ) : ?>
-						<article class="sol-method-card">
-							<div class="sol-method-card-top">
-								<div class="sol-method-card-n sol-display"><?php echo esc_html( $card['n'] ); ?></div>
-								<div class="sol-method-card-pill"><?php echo esc_html( $card['p'] ); ?></div>
-							</div>
-							<h3 class="sol-method-card-t"><?php echo esc_html( $card['t'] ); ?></h3>
-							<p class="sol-method-card-s"><?php echo wp_kses_post( $card['s'] ); ?></p>
-							<ul class="sol-method-card-list">
-								<?php foreach ( $card['b'] as $b ) : ?>
-									<li><span class="sol-method-tick">+</span><?php echo esc_html( $b ); ?></li>
-								<?php endforeach; ?>
-							</ul>
-						</article>
-					<?php endforeach; ?>
-				</div>
-			</div>
-		</section>
-
-		<!-- ════════════════════════════════════════════════════════════
-		     CAPEX vs OPEX — Bilanzielle Entscheidung
+		     04 / DIE RECHNUNG — CAPEX vs OPEX (Ink)
 		     Interaktiver Zeitraum-Picker (12 · 24 · 36 Monate).
 		     ════════════════════════════════════════════════════════════ -->
-		<section class="sol-section sol-capex-section" id="capex" data-track-section="capex_opex">
-			<div class="sol-wrap">
-				<div class="sol-capex-head">
-					<div class="sol-eyebrow">CAPEX statt OPEX</div>
-					<h2 class="sol-display sol-capex-h">
-						Mieten oder besitzen. Eine <em>Bilanz-Entscheidung</em>.
-					</h2>
-					<p class="sol-capex-sub">
-						Beide Wege kosten Geld. Nur einer hinterlässt am Ende ein Asset, das Ihnen gehört.
-					</p>
+		<section class="hu-section" id="capex" data-track-section="capex_opex">
+			<div class="hu-container">
+				<div class="hu-section-head">
+					<span class="hu-eyebrow">04 / Die Rechnung</span>
+					<div>
+						<h2>Eine Bilanz-Entscheidung.</h2>
+						<p class="hu-lead">Beide Wege kosten Geld. Nur einer hinterlässt ein Asset, das Ihnen gehört — CAPEX statt OPEX.</p>
+					</div>
 				</div>
 
 				<div class="sol-capex-picker" role="tablist" aria-label="Zeitraum auswählen">
@@ -863,101 +783,30 @@ get_header();
 					</div>
 				</div>
 
-				<div class="sol-capex-compare" data-sol-capex>
-					<!-- OPEX · Portal-Leads -->
-					<article class="sol-capex-col sol-capex-col--opex">
-						<header class="sol-capex-col-head">
-							<span class="sol-capex-col-badge sol-capex-col-badge--opex sol-mono">OPEX</span>
-							<h3 class="sol-capex-col-title">Portal-Leads mieten</h3>
-							<p class="sol-capex-col-sub">Monatlich zahlen, nichts besitzen.</p>
-						</header>
-						<div class="sol-capex-breakdown">
-							<div class="sol-capex-row">
-								<span class="sol-capex-row-l">Lead-Kosten (Ø 80 €/Stk)</span>
-								<span class="sol-capex-row-v" data-sol-capex-out="portal_monthly"><?php echo esc_html( $capex_timeframes[ $capex_default ]['portal_monthly'] ); ?> / Monat</span>
-							</div>
-							<div class="sol-capex-row">
-								<span class="sol-capex-row-l">Erwartete Leads</span>
-								<span class="sol-capex-row-v" data-sol-capex-out="portal_leads"><?php echo esc_html( $capex_timeframes[ $capex_default ]['portal_leads'] ); ?> Stück</span>
-							</div>
-							<div class="sol-capex-row sol-capex-row--issue">
-								<span class="sol-capex-row-l">Qualität</span>
-								<span class="sol-capex-row-v">~ 50 % gehen nicht ans Telefon</span>
-							</div>
-							<div class="sol-capex-row sol-capex-row--issue">
-								<span class="sol-capex-row-l">Exklusivität</span>
-								<span class="sol-capex-row-v">drei Wettbewerber parallel</span>
-							</div>
-						</div>
-						<div class="sol-capex-total">
-							<div class="sol-capex-total-l sol-mono">Gesamt (<span data-sol-capex-out="tf"><?php echo esc_html( (string) $capex_default ); ?></span> Monate)</div>
-							<div class="sol-capex-total-v sol-capex-total-v--opex sol-display" data-sol-capex-out="portal_total"><?php echo esc_html( $capex_timeframes[ $capex_default ]['portal_total'] ); ?></div>
-						</div>
-						<div class="sol-capex-result">
-							<div class="sol-capex-result-icon sol-capex-result-icon--bad" aria-hidden="true">✕</div>
-							<div class="sol-capex-result-body">
-								<strong>0 € Asset am Ende</strong>
-								<span>Budget aus = Anfragen aus.</span>
-							</div>
-						</div>
-						<ul class="sol-capex-list">
-							<li><span class="sol-capex-list-x" aria-hidden="true">✕</span>Portal behält die Daten</li>
-							<li><span class="sol-capex-list-x" aria-hidden="true">✕</span>Keine Kontrolle über Qualität</li>
-							<li><span class="sol-capex-list-x" aria-hidden="true">✕</span>Preiserhöhungen jederzeit möglich</li>
-							<li><span class="sol-capex-list-x" aria-hidden="true">✕</span>Vertrieb verbrennt Zeit mit Nicht-Käufern</li>
+				<div class="hu-models" data-sol-capex>
+					<article class="hu-model hu-model--a">
+						<div class="hu-model__label">Modell A · OPEX</div>
+						<div class="hu-model__title">Portal-Leads mieten</div>
+						<ul class="hu-model__list">
+							<li><span class="hu-model__bullet" aria-hidden="true">✕</span><span>Lead-Kosten Ø 80 €/Stück — <span data-sol-capex-out="portal_monthly"><?php echo esc_html( $capex_now['portal_monthly'] ); ?> / Monat</span></span></li>
+							<li><span class="hu-model__bullet" aria-hidden="true">✕</span><span><span data-sol-capex-out="portal_leads"><?php echo esc_html( $capex_now['portal_leads'] ); ?> Stück</span> erwartet — rund 50 % gehen nicht ans Telefon</span></li>
+							<li><span class="hu-model__bullet" aria-hidden="true">✕</span><span>Drei Wettbewerber parallel auf jeder Anfrage</span></li>
+							<li><span class="hu-model__bullet" aria-hidden="true">✕</span><span>Portal behält die Daten · Preiserhöhung jederzeit</span></li>
 						</ul>
+						<div class="hu-model__foot">Gesamt über <span data-sol-capex-out="tf"><?php echo esc_html( (string) $capex_default ); ?></span> Monate: <span data-sol-capex-out="portal_total"><?php echo esc_html( $capex_now['portal_total'] ); ?></span></div>
+						<span class="hu-model__pill">0 € Asset am Ende — Budget aus, Anfragen aus</span>
 					</article>
-
-					<div class="sol-capex-divider" aria-hidden="true">
-						<span class="sol-capex-divider-line"></span>
-						<span class="sol-capex-divider-tag sol-mono">VS</span>
-						<span class="sol-capex-divider-line"></span>
-					</div>
-
-					<!-- CAPEX · Eigenes System -->
-					<article class="sol-capex-col sol-capex-col--capex">
-						<header class="sol-capex-col-head">
-							<span class="sol-capex-col-badge sol-capex-col-badge--capex sol-mono">CAPEX</span>
-							<h3 class="sol-capex-col-title">Eigenes System besitzen</h3>
-							<p class="sol-capex-col-sub">Einmalig investieren, langfristig skalieren.</p>
-						</header>
-						<div class="sol-capex-breakdown">
-							<div class="sol-capex-row">
-								<span class="sol-capex-row-l">Setup (einmalig)</span>
-								<span class="sol-capex-row-v" data-sol-capex-out="own_setup"><?php echo esc_html( $capex_timeframes[ $capex_default ]['own_setup'] ); ?></span>
-							</div>
-							<div class="sol-capex-row">
-								<span class="sol-capex-row-l">Hosting + Wartung</span>
-								<span class="sol-capex-row-v" data-sol-capex-out="own_monthly"><?php echo esc_html( $capex_timeframes[ $capex_default ]['own_monthly'] ); ?> / Monat</span>
-							</div>
-							<div class="sol-capex-row sol-capex-row--benefit">
-								<span class="sol-capex-row-l">Datenhoheit</span>
-								<span class="sol-capex-row-v">100 % bei Ihnen</span>
-							</div>
-							<div class="sol-capex-row sol-capex-row--benefit">
-								<span class="sol-capex-row-l">Vorqualifizierung</span>
-								<span class="sol-capex-row-v">Region · Projektwert · Fit-Score</span>
-							</div>
-						</div>
-						<div class="sol-capex-total">
-							<div class="sol-capex-total-l sol-mono">Gesamt (<span data-sol-capex-out="tf2"><?php echo esc_html( (string) $capex_default ); ?></span> Monate)</div>
-							<div class="sol-capex-total-v sol-capex-total-v--capex sol-display" data-sol-capex-out="own_total"><?php echo esc_html( $capex_timeframes[ $capex_default ]['own_total'] ); ?></div>
-						</div>
-						<div class="sol-capex-result sol-capex-result--good">
-							<div class="sol-capex-result-icon sol-capex-result-icon--good" aria-hidden="true">
-								<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" focusable="false"><path d="M5 12l5 5L20 7"/></svg>
-							</div>
-							<div class="sol-capex-result-body">
-								<strong>Aktiviertes Asset</strong>
-								<span>Code, Tracking, Daten bleiben bei Ihnen.</span>
-							</div>
-						</div>
-						<ul class="sol-capex-list">
-							<li><span class="sol-capex-list-v" aria-hidden="true">✓</span>Exklusive Anfragen — nur für Sie</li>
-							<li><span class="sol-capex-list-v" aria-hidden="true">✓</span>Volle Transparenz über Herkunft</li>
-							<li><span class="sol-capex-list-v" aria-hidden="true">✓</span>Skaliert ohne Kostenexplosion</li>
-							<li><span class="sol-capex-list-v" aria-hidden="true">✓</span>System bleibt — auch ohne laufende Kosten</li>
+					<article class="hu-model hu-model--b">
+						<div class="hu-model__label">Modell B · CAPEX</div>
+						<div class="hu-model__title">Eigenes System besitzen</div>
+						<ul class="hu-model__list">
+							<li><span class="hu-model__bullet" aria-hidden="true">✓</span><span>Setup einmalig <span data-sol-capex-out="own_setup"><?php echo esc_html( $capex_now['own_setup'] ); ?></span> · Hosting <span data-sol-capex-out="own_monthly"><?php echo esc_html( $capex_now['own_monthly'] ); ?> / Monat</span></span></li>
+							<li><span class="hu-model__bullet" aria-hidden="true">✓</span><span>Exklusive Anfragen — nur für Ihren Vertrieb</span></li>
+							<li><span class="hu-model__bullet" aria-hidden="true">✓</span><span>Vorqualifizierung: Region · Projektwert · Fit-Score</span></li>
+							<li><span class="hu-model__bullet" aria-hidden="true">✓</span><span>Datenhoheit 100 % bei Ihnen · skaliert ohne Kostenexplosion</span></li>
 						</ul>
+						<div class="hu-model__foot">Gesamt über <span data-sol-capex-out="tf2"><?php echo esc_html( (string) $capex_default ); ?></span> Monate: <span data-sol-capex-out="own_total"><?php echo esc_html( $capex_now['own_total'] ); ?></span></div>
+						<span class="hu-model__pill">Aktiviertes Asset — bleibt, auch ohne laufende Kosten</span>
 					</article>
 				</div>
 
@@ -966,226 +815,171 @@ get_header();
 					<p>
 						Ein eigenes Anfrage-System ist eine <strong>aktivierbare Investition</strong> (CAPEX), kein wiederkehrender Kostenfaktor (OPEX). Portal-Leads sind Betriebsausgaben ohne Restwert.
 						Nach <span data-sol-capex-out="tf3"><?php echo esc_html( (string) $capex_default ); ?></span> Monaten haben Sie entweder
-						<strong><span data-sol-capex-out="portal_total2"><?php echo esc_html( $capex_timeframes[ $capex_default ]['portal_total'] ); ?></span> ausgegeben und besitzen nichts</strong> —
-						oder Sie haben <strong><span data-sol-capex-out="own_total2"><?php echo esc_html( $capex_timeframes[ $capex_default ]['own_total'] ); ?></span> investiert und ein skalierbares Asset</strong>
+						<strong><span data-sol-capex-out="portal_total2"><?php echo esc_html( $capex_now['portal_total'] ); ?></span> ausgegeben und besitzen nichts</strong> —
+						oder Sie haben <strong><span data-sol-capex-out="own_total2"><?php echo esc_html( $capex_now['own_total'] ); ?></span> investiert und ein skalierbares Asset</strong>
 						(Setup einmalig + <span data-sol-capex-out="tf4"><?php echo esc_html( (string) $capex_default ); ?></span> × Hosting/Wartung).
 					</p>
 				</aside>
 
-				<div class="sol-capex-cta">
-					<a class="sol-btn sol-btn-primary" href="#marktcheck"
+				<div class="sol-section-cta">
+					<a class="hu-btn hu-btn-primary" href="#marktcheck"
 						data-track-action="cta_solar_capex_to_intake"
 						data-track-category="lead_gen"
 						data-track-section="capex_opex"
 						data-track-funnel-stage="intake_open"
 					>
 						<span>Marktcheck starten</span>
-						<span class="sol-btn-arrow"><?php echo $arrow_svg; // raw-ok phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></span>
+						<?php echo $arrow_svg; // raw-ok phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 					</a>
-					<div class="sol-capex-cta-micro sol-mono">Regions-Verfügbarkeitsprüfung · Manuelle Erst-Analyse · Fit-Entscheid mit drei Hebeln</div>
+					<div class="sol-section-cta-micro sol-mono">Regions-Verfügbarkeitsprüfung · Manuelle Erst-Analyse · Fit-Entscheid mit drei Hebeln</div>
 				</div>
 			</div>
 		</section>
 
 		<!-- ════════════════════════════════════════════════════════════
-		     RESULTS — E3-Proof + Methodik-Snapshot
+		     05 / E3 NEW ENERGY — Vorher/Nachher + Stats (Ink)
 		     ════════════════════════════════════════════════════════════ -->
-		<section class="sol-section" id="ergebnisse" data-track-section="results">
-			<div class="sol-wrap sol-results-inner">
-				<div class="sol-results-text">
-					<div class="sol-eyebrow">Schritt 2 · Tiefendiagnose (verrechenbar)</div>
-					<h2 class="sol-display sol-results-h">
-						Klarheit, keine <em>Folien</em>.
-					</h2>
-					<p class="sol-results-sub">
-						Nach dem Marktcheck (Fit-Befund innerhalb von 48 Stunden) folgt optional die verrechenbare Tiefendiagnose: vier Module · schriftlicher Befund in 7 Werktagen · drei priorisierte Hebel · eine Wirtschaftlichkeits-Einordnung — belastbare Entscheidungsgrundlage statt Pitch-Deck.
+		<section class="hu-section" id="ergebnisse" data-track-section="results">
+			<div class="hu-container">
+				<div class="hu-proof-headline">
+					<span class="hu-eyebrow">05 / <?php echo esc_html( $e3_case_label ); ?></span>
+					<h2>Vorher. Nachher. Beziffert.</h2>
+					<p><?php echo esc_html( $e3_timeframe ); ?> eigener Anfrageweg — Methodik-Snapshot statt Referenz-Logo-Wand.</p>
+				</div>
+				<div class="hu-proof-cards">
+					<div class="hu-proof-card">
+						<div class="hu-proof-card__lbl">Vorher · Portal-Miete</div>
+						<div class="hu-proof-card__title">Geteilte Leads, steigende Preise</div>
+						<ul class="hu-proof-list">
+							<li><span class="x" aria-hidden="true">✕</span><?php echo esc_html( $e3_cpl_before ); ?> Kosten pro Anfrage zu Beginn</li>
+							<li><span class="x" aria-hidden="true">✕</span>Abschlussquote <?php echo esc_html( $e3_conv_before ); ?> auf Portal-Leads</li>
+							<li><span class="x" aria-hidden="true">✕</span>Keine Sicht auf Region, Dach, Projektwert</li>
+						</ul>
+					</div>
+					<div class="hu-proof-arrow" aria-hidden="true">→</div>
+					<div class="hu-proof-card hu-proof-card--after">
+						<div class="hu-proof-card__lbl">Nachher · Eigener Anfrageweg</div>
+						<div class="hu-proof-card__title">Exklusive, vorqualifizierte Anfragen</div>
+						<ul class="hu-proof-list">
+							<li><span class="v" aria-hidden="true">✓</span><?php echo esc_html( $e3_cpl_after ); ?> Kosten pro Anfrage nach <?php echo esc_html( $e3_timeframe_dative ); ?></li>
+							<li><span class="v" aria-hidden="true">✓</span><?php echo esc_html( $e3_sales_conversion ); ?> Abschlussquote — Anfrage zu Vertrag</li>
+							<li><span class="v" aria-hidden="true">✓</span>Fit-Signal vor dem ersten Anruf</li>
+						</ul>
+					</div>
+				</div>
+				<div class="hu-proof-stats">
+					<div class="hu-proof-stat">
+						<div class="hu-proof-stat__num"><?php echo esc_html( $e3_lead_count ); ?></div>
+						<div class="hu-proof-stat__lbl">Qualifizierte Anfragen</div>
+					</div>
+					<div class="hu-proof-stat">
+						<div class="hu-proof-stat__num"><?php echo esc_html( $e3_conv_uplift ); ?></div>
+						<div class="hu-proof-stat__lbl">Abschlussquote · vorher → nachher</div>
+					</div>
+					<div class="hu-proof-stat">
+						<div class="hu-proof-stat__num" style="color:var(--accent);"><?php echo esc_html( $e3_cpl_reduction ); ?></div>
+						<div class="hu-proof-stat__lbl">Weniger Kosten pro Anfrage</div>
+					</div>
+					<div class="hu-proof-stat">
+						<div class="hu-proof-stat__num"><?php echo esc_html( $e3_timeframe ); ?></div>
+						<div class="hu-proof-stat__lbl">Live-Telemetrie · DSGVO</div>
+					</div>
+				</div>
+				<div class="sol-proof-foot">
+					<p>
+						Schritt 2 nach dem Marktcheck: die verrechenbare <strong>Tiefendiagnose</strong> —
+						vier Bausteine, schriftlicher Befund in 7 Werktagen, drei priorisierte Hebel,
+						eine Wirtschaftlichkeits-Einordnung. Klarheit, keine Folien.
 					</p>
-					<ul class="sol-results-list">
-						<?php foreach ( $results_qualifiers as $row ) : ?>
-							<li>
-								<span><?php echo esc_html( $row['k'] ); ?></span>
-								<span class="sol-mono sol-results-list-v"><?php echo esc_html( $row['v'] ); ?></span>
-							</li>
-						<?php endforeach; ?>
-					</ul>
-
 					<a
-						class="sol-btn sol-btn-ghost"
+						class="hu-btn hu-btn-ghost"
 						href="<?php echo esc_url( $e3_url ); ?>"
 						data-track-action="cta_solar_to_e3_case"
 						data-track-category="proof"
 						data-track-section="results"
-						style="margin-top:32px;"
 					>
 						Vollständige Methodik im <?php echo esc_html( $e3_case_label ); ?>-Case
-						<span class="sol-btn-arrow"><?php echo $arrow_svg; // raw-ok phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></span>
+						<?php echo $arrow_svg; // raw-ok phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 					</a>
-				</div>
-
-				<div class="sol-results-mock" aria-label="<?php echo esc_attr( $e3_case_label ); ?> — Methodik-Snapshot">
-					<div class="sol-results-mock-head">
-						<div class="sol-results-mock-dots" aria-hidden="true">
-							<span></span><span></span><span></span>
-						</div>
-						<div class="sol-mono sol-results-mock-title"><?php echo esc_html( $e3_case_label ); ?> · Methodik-Snapshot</div>
-						<div class="sol-mono sol-results-mock-live">
-							<span class="sol-live-dot" aria-hidden="true"></span>
-							<?php echo esc_html( $e3_timeframe ); ?>
-						</div>
-					</div>
-					<div class="sol-results-mock-body">
-						<div class="sol-results-mock-row">
-							<div class="sol-results-mock-stat">
-								<div class="sol-mono">Anfragen</div>
-								<div class="sol-display sol-results-mock-big"><?php echo esc_html( $e3_lead_count ); ?></div>
-								<div class="sol-results-mock-delta">qualifiziert · in <?php echo esc_html( $e3_timeframe_dative ); ?></div>
-							</div>
-							<div class="sol-results-mock-stat">
-								<div class="sol-mono">Abschlussquote</div>
-								<div class="sol-display sol-results-mock-big"><?php echo esc_html( $e3_sales_conversion ); ?></div>
-								<div class="sol-results-mock-delta">Anfrage → Vertrag</div>
-							</div>
-							<div class="sol-results-mock-stat">
-								<div class="sol-mono">CPL</div>
-								<div class="sol-display sol-results-mock-big"><?php echo esc_html( $e3_cpl_after ); ?></div>
-								<div class="sol-results-mock-delta">von <?php echo esc_html( $e3_cpl_before ); ?> · <?php echo esc_html( $e3_cpl_reduction ); ?></div>
-							</div>
-						</div>
-						<div class="sol-results-mock-chart" aria-hidden="true">
-							<svg viewBox="0 0 400 120" preserveAspectRatio="none" width="100%" height="120">
-								<defs>
-									<linearGradient id="sol-rg" x1="0" x2="0" y1="0" y2="1">
-										<stop offset="0%" stop-color="currentColor" stop-opacity=".25" />
-										<stop offset="100%" stop-color="currentColor" stop-opacity="0" />
-									</linearGradient>
-								</defs>
-								<g style="color: var(--sol-accent);">
-									<path d="M0 96 L40 90 L80 80 L120 72 L160 66 L200 56 L240 46 L280 38 L320 30 L360 22 L400 16 L400 120 L0 120 Z" fill="url(#sol-rg)" />
-									<path d="M0 96 L40 90 L80 80 L120 72 L160 66 L200 56 L240 46 L280 38 L320 30 L360 22 L400 16" fill="none" stroke="currentColor" stroke-width="1.5" />
-									<circle cx="40"  cy="90" r="3" fill="currentColor" />
-									<circle cx="120" cy="72" r="3" fill="currentColor" />
-									<circle cx="200" cy="56" r="3" fill="currentColor" />
-									<circle cx="280" cy="38" r="3" fill="currentColor" />
-									<circle cx="360" cy="22" r="3" fill="currentColor" />
-								</g>
-							</svg>
-							<div class="sol-results-mock-axis sol-mono">
-								<span>Mon 1</span><span>Mon 2</span><span>Mon 3</span><span>Mon 4</span><span>Mon 5</span><span>Mon 6</span>
-							</div>
-						</div>
-						<div class="sol-results-mock-list">
-							<div class="sol-results-mock-item">
-								<span class="sol-results-mock-tag is-new">Neu</span>
-								<span>Anfrage-Quellen quantifiziert</span>
-								<span class="sol-results-mock-prod sol-mono">Modul 01</span>
-								<span class="sol-results-mock-time">7 d</span>
-							</div>
-							<div class="sol-results-mock-item">
-								<span class="sol-results-mock-tag is-call">Befund</span>
-								<span>Drei priorisierte Hebel</span>
-								<span class="sol-results-mock-prod sol-mono">Output</span>
-								<span class="sol-results-mock-time">7 d</span>
-							</div>
-							<div class="sol-results-mock-item">
-								<span class="sol-results-mock-tag is-booked">Übergabe</span>
-								<span>30-Min-Call · optional</span>
-								<span class="sol-results-mock-prod sol-mono">Wahlfrei</span>
-								<span class="sol-results-mock-time">+ 1 Wo</span>
-							</div>
-						</div>
-					</div>
 				</div>
 			</div>
 		</section>
 
 		<!-- ════════════════════════════════════════════════════════════
-		     FIT — passt / passt nicht (ehrliche Vorauswahl)
+		     06 / WANN ES PASST — ehrliche Vorauswahl (Creme)
 		     ════════════════════════════════════════════════════════════ -->
-		<section class="sol-section sol-section--tinted sol-fit-section" id="fit" data-track-section="fit_check">
-			<div class="sol-wrap">
-				<div class="sol-fit-head">
-					<div class="sol-eyebrow">Wann es sich lohnt</div>
-					<h2 class="sol-display sol-fit-h">
-						Ehrliche Vorauswahl, <em>bevor wir reden</em>.
-					</h2>
-					<p class="sol-fit-sub">
-						Lieber jetzt klären, ob es passt — als später ein Setup zu bauen, das ins Leere läuft.
-					</p>
+		<section class="hu-section hu-section--cream" id="fit" data-track-section="fit_check">
+			<div class="hu-container">
+				<div class="hu-section-head">
+					<span class="hu-eyebrow">06 / Wann es passt</span>
+					<div>
+						<h2>Lieber jetzt klären, ob es passt.</h2>
+						<p class="hu-lead">Als später ein Setup zu bauen, das ins Leere läuft. Ehrliche Vorauswahl, bevor wir reden.</p>
+					</div>
 				</div>
-
-				<div class="sol-fit-grid">
-					<article class="sol-fit-col sol-fit-col--yes">
-						<header class="sol-fit-col-head">
-							<span class="sol-fit-col-badge sol-fit-col-badge--yes" aria-hidden="true">
-								<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" focusable="false"><path d="M5 12l5 5L20 7"/></svg>
-							</span>
+				<div class="hu-fit-grid">
+					<article class="hu-fit-col hu-fit-col--yes">
+						<div class="hu-fit-col__head">
+							<span class="hu-fit-col__badge hu-fit-col__badge--yes" aria-hidden="true">✓</span>
 							<span>Passt, wenn …</span>
-						</header>
-						<ul class="sol-fit-list">
+						</div>
+						<ul class="hu-fit-list">
 							<?php foreach ( $fit_yes as $row ) : ?>
 								<li>
-									<div class="sol-fit-list-t"><?php echo esc_html( $row['t'] ); ?></div>
-									<div class="sol-fit-list-d"><?php echo esc_html( $row['s'] ); ?></div>
+									<div class="hu-fit-list__t"><?php echo esc_html( $row['t'] ); ?></div>
+									<div class="hu-fit-list__d"><?php echo esc_html( $row['s'] ); ?></div>
 								</li>
 							<?php endforeach; ?>
 						</ul>
 					</article>
-					<article class="sol-fit-col sol-fit-col--no">
-						<header class="sol-fit-col-head">
-							<span class="sol-fit-col-badge sol-fit-col-badge--no" aria-hidden="true">✕</span>
+					<article class="hu-fit-col hu-fit-col--no">
+						<div class="hu-fit-col__head">
+							<span class="hu-fit-col__badge hu-fit-col__badge--no" aria-hidden="true">✕</span>
 							<span>Passt nicht, wenn …</span>
-						</header>
-						<ul class="sol-fit-list">
+						</div>
+						<ul class="hu-fit-list">
 							<?php foreach ( $fit_no as $row ) : ?>
 								<li>
-									<div class="sol-fit-list-t"><?php echo esc_html( $row['t'] ); ?></div>
-									<div class="sol-fit-list-d"><?php echo esc_html( $row['s'] ); ?></div>
+									<div class="hu-fit-list__t"><?php echo esc_html( $row['t'] ); ?></div>
+									<div class="hu-fit-list__d"><?php echo esc_html( $row['s'] ); ?></div>
 								</li>
 							<?php endforeach; ?>
 						</ul>
 					</article>
 				</div>
-
-				<div class="sol-fit-cta">
-					<a class="sol-btn sol-btn-primary" href="#marktcheck"
+				<div class="sol-section-cta">
+					<a class="hu-btn hu-btn-primary" href="#marktcheck"
 						data-track-action="cta_solar_fit_to_intake"
 						data-track-category="lead_gen"
 						data-track-section="fit_check"
 						data-track-funnel-stage="intake_open"
 					>
 						<span>Marktcheck beantragen</span>
-						<span class="sol-btn-arrow"><?php echo $arrow_svg; // raw-ok phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></span>
+						<?php echo $arrow_svg; // raw-ok phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 					</a>
-					<div class="sol-fit-cta-micro sol-mono">Regions-Verfügbarkeitsprüfung · Manuelle Erst-Analyse · Fit-Entscheid mit drei Hebeln</div>
+					<div class="sol-section-cta-micro sol-mono">Regions-Verfügbarkeitsprüfung · Manuelle Erst-Analyse · Fit-Entscheid mit drei Hebeln</div>
 				</div>
 			</div>
 		</section>
 
 		<!-- ════════════════════════════════════════════════════════════
-		     GUARANTEE
+		     07 / RISIKO-UMKEHR (Ink)
 		     ════════════════════════════════════════════════════════════ -->
-		<section class="sol-section sol-guarantee" id="garantie" data-track-section="guarantee">
-			<div class="sol-wrap sol-guarantee-inner">
-				<div class="sol-guarantee-glow" aria-hidden="true"></div>
-				<div class="sol-eyebrow" style="justify-content:center;">Risiko-Umkehr</div>
-				<h2 class="sol-display sol-guarantee-h">
-					Drei Hebel — auch wenn wir <em>nicht zusammenarbeiten</em>.
-				</h2>
-				<p class="sol-guarantee-sub">
-					Der Marktcheck ist kein Verkaufsritual. Er ist eine ehrliche Ersteinschätzung. Wenn sich daraus keine Zusammenarbeit ergibt, bekommen Sie trotzdem drei priorisierte Hebel mit konkretem nächstem Schritt — auch dann, wenn das heißt, dass Sie nicht mit mir weitermachen.
-				</p>
-				<div class="sol-guarantee-points">
+		<section class="hu-section" id="garantie" data-track-section="guarantee">
+			<div class="hu-container">
+				<div class="hu-section-head">
+					<span class="hu-eyebrow">07 / Risiko-Umkehr</span>
+					<div>
+						<h2>Diagnose vor Pitch.</h2>
+						<p class="hu-lead">Der Marktcheck ist kein Verkaufsritual — er ist eine ehrliche Ersteinschätzung. Auch dann, wenn sie heißt: nicht mit mir.</p>
+					</div>
+				</div>
+				<div class="sol-risk-grid">
 					<?php foreach ( $guarantee_points as $p ) : ?>
-						<div class="sol-guarantee-point">
-							<div class="sol-guarantee-point-mark" aria-hidden="true">
-								<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" focusable="false">
-									<path d="M5 12l5 5L20 7" />
-								</svg>
-							</div>
-							<div>
-								<div class="sol-guarantee-point-t"><?php echo esc_html( $p['t'] ); ?></div>
-								<div class="sol-guarantee-point-s"><?php echo esc_html( $p['s'] ); ?></div>
-							</div>
+						<div class="sol-risk-card">
+							<span class="hu-eyebrow"><?php echo esc_html( $p['e'] ); ?></span>
+							<div class="sol-risk-card-t"><?php echo esc_html( $p['t'] ); ?></div>
+							<p class="sol-risk-card-d"><?php echo esc_html( $p['s'] ); ?></p>
 						</div>
 					<?php endforeach; ?>
 				</div>
@@ -1193,31 +987,31 @@ get_header();
 		</section>
 
 		<!-- ════════════════════════════════════════════════════════════
-		     Vertiefung — Themen-Hub für SEO-Sub-Pages
+		     08 / VERTIEFUNG — Themen-Hub für SEO-Sub-Pages (Ink)
 		     ════════════════════════════════════════════════════════════ -->
-		<section class="sol-section sol-deeper" id="deeper" data-track-section="deeper">
-			<div class="sol-wrap sol-deeper-inner">
-				<div class="sol-eyebrow">Vertiefung</div>
-				<h2 class="sol-display sol-deeper-h">
-					Weiterführende Themen — wenn Sie tiefer einsteigen wollen
-				</h2>
-				<p class="sol-deeper-sub">
-					Acht thematische Vertiefungs-Seiten zu Strategie, Lead-Qualität, Funnel-Architektur und Markteinordnung. Jede Seite kann unabhängig gelesen werden, alle führen zurück zum Marktcheck.
-				</p>
-				<div class="sol-deeper-clusters">
+		<section class="hu-section" id="deeper" data-track-section="deeper">
+			<div class="hu-container">
+				<div class="hu-section-head">
+					<span class="hu-eyebrow">08 / Vertiefung</span>
+					<div>
+						<h2>Wenn Sie tiefer einsteigen wollen.</h2>
+						<p class="hu-lead">Acht Vertiefungs-Seiten zu Strategie, Lead-Qualität, Funnel-Architektur und Markteinordnung — jede kann unabhängig gelesen werden, alle führen zurück zum Marktcheck.</p>
+					</div>
+				</div>
+				<div class="hu-deeper-clusters">
 					<?php foreach ( $deeper_clusters as $cluster ) : ?>
-						<div class="sol-deeper-cluster">
-							<h3 class="sol-deeper-cluster-h"><?php echo esc_html( $cluster['group'] ); ?></h3>
-							<ul class="sol-deeper-list">
+						<div class="hu-deeper-cluster">
+							<h3 class="hu-deeper-cluster__h"><?php echo esc_html( $cluster['group'] ); ?></h3>
+							<ul class="hu-deeper-list">
 								<?php foreach ( $cluster['items'] as $item ) : ?>
-									<li class="sol-deeper-item">
-										<a class="sol-deeper-link"
+									<li class="hu-deeper-item">
+										<a class="hu-deeper-link"
 										   href="<?php echo esc_url( $item['url'] ); ?>"
 										   data-track-action="deeper_cluster_link"
 										   data-track-category="solar_money_page"
 										   data-track-section="deeper">
-											<span class="sol-deeper-link-t"><?php echo esc_html( $item['t'] ); ?></span>
-											<span class="sol-deeper-link-s"><?php echo esc_html( $item['s'] ); ?></span>
+											<span class="hu-deeper-link__t"><?php echo esc_html( $item['t'] ); ?></span>
+											<span class="hu-deeper-link__s"><?php echo esc_html( $item['s'] ); ?></span>
 										</a>
 									</li>
 								<?php endforeach; ?>
@@ -1229,15 +1023,13 @@ get_header();
 		</section>
 
 		<!-- ════════════════════════════════════════════════════════════
-		     FAQ
+		     09 / FAQ (Ink)
 		     ════════════════════════════════════════════════════════════ -->
-		<section class="sol-section sol-faq" id="faq" data-track-section="faq">
-			<div class="sol-wrap sol-faq-inner">
+		<section class="hu-section" id="faq" data-track-section="faq">
+			<div class="hu-container sol-faq-inner">
 				<div class="sol-faq-left">
-					<div class="sol-eyebrow">Häufige Fragen</div>
-					<h2 class="sol-display sol-faq-h">
-						Bevor Sie <em>fragen</em>.
-					</h2>
+					<span class="hu-eyebrow">09 / FAQ</span>
+					<h2 class="sol-faq-h">Bevor Sie fragen.</h2>
 					<p class="sol-faq-sub">
 						Was hier nicht beantwortet wird, klären wir im Marktcheck — strukturiert, schriftlich, ohne Verkaufsgespräch.
 					</p>
@@ -1267,56 +1059,30 @@ get_header();
 		</section>
 
 		<!-- ════════════════════════════════════════════════════════════
-		     FOUNDING COHORT 2026 — Aufnahme-Protokoll
+		     FOUNDING COHORT 2026 + FINAL CTA — zurück zum Marktcheck
 		     ════════════════════════════════════════════════════════════ -->
-		<?php
-		$founding = function_exists( 'hu_founding_canon' ) ? hu_founding_canon() : [
-			'label'           => 'Founding Cohort 2026',
-			'slots_total'     => 3,
-			'slots_remaining' => 3,
-			'end_date'        => '2026-09-30',
-		];
-		$founding_end_iso = isset( $founding['end_date'] ) ? (string) $founding['end_date'] : '2026-09-30';
-		$founding_end_ts  = strtotime( $founding_end_iso );
-		$founding_end_de  = $founding_end_ts ? wp_date( 'd.m.Y', $founding_end_ts ) : '30.09.2026';
-		?>
-		<section class="sol-section" id="founding" data-track-section="founding_cohort">
-			<div class="sol-wrap" style="max-width:760px">
-				<div class="sol-eyebrow"><?php echo esc_html( $founding['label'] ); ?> · frühe Umsetzungspartner</div>
-				<h2 class="sol-display" style="margin-bottom:18px">
-					Aufnahme-Protokoll für <em><?php echo (int) $founding['slots_total']; ?> Solar- oder SHK-Betriebe</em>.
-				</h2>
-				<p style="color:var(--sol-fg-dim);font-size:18px;line-height:1.6;margin:0 0 28px">
-					Damit jede Region in Diagnose, Daten-Pipeline und Vertriebsanschluss persönlich abgebildet werden kann, nehme ich 2026 maximal <?php echo (int) $founding['slots_total']; ?> Betriebe als Founding-Partner auf. Founding-Partner heißt hier: früher Umsetzungspartner der 2026er Kohorte — kein Mitgründer, kein Anteilseigner und keine gesellschaftsrechtliche Partnerschaft. Stichtag für die Bewerbung ist der <?php echo esc_html( $founding_end_de ); ?>. Der Marktcheck entscheidet, ob die Architektur zu Ihrer Region passt — keine Verkaufslogik, keine Lock-in-Klausel.
-				</p>
-				<ul class="sol-mono" style="display:grid;gap:12px;padding:0;margin:0 0 28px;list-style:none;color:var(--sol-fg);font-size:13px;letter-spacing:.04em">
-					<li><span style="color:var(--sol-accent);margin-right:10px">·</span>Plätze 2026: <?php echo (int) $founding['slots_remaining']; ?> von <?php echo (int) $founding['slots_total']; ?> noch offen</li>
-					<li><span style="color:var(--sol-accent);margin-right:10px">·</span>Rolle: früher Umsetzungspartner, keine Mitgründer- oder Beteiligungsrolle</li>
-					<li><span style="color:var(--sol-accent);margin-right:10px">·</span>Bewerbungsfrist: <?php echo esc_html( $founding_end_de ); ?></li>
-					<li><span style="color:var(--sol-accent);margin-right:10px">·</span>Entscheidung: nach Marktcheck · händisch · innerhalb von 48 Stunden</li>
-					<li><span style="color:var(--sol-accent);margin-right:10px">·</span>Bedingung: eigener Vertrieb · klares Zielgebiet · 12–24-Monate-Horizont</li>
-				</ul>
-			</div>
-		</section>
-
-		<!-- ════════════════════════════════════════════════════════════
-		     FINAL CTA — zurück zum Marktcheck im Hero
-		     ════════════════════════════════════════════════════════════ -->
-		<section class="sol-section sol-final" data-track-section="final_cta">
-			<div class="sol-wrap">
-				<div class="sol-final-inner">
-					<div class="sol-final-sun" aria-hidden="true">
-						<div class="sol-final-sun-disc"></div>
-					</div>
-					<div class="sol-eyebrow" style="justify-content:center;">Letzter Schritt</div>
-					<h2 class="sol-display sol-final-h">
-						Anfragen <em>besitzen</em>,<br />nicht mieten.
-					</h2>
-					<p class="sol-final-sub">
-						Manueller Marktcheck · Region, Vertrieb und Anfragequalität · Fit-Befund per E-Mail innerhalb von 48 Stunden.
+		<section class="hu-section" id="founding" data-track-section="founding_cohort">
+			<div class="hu-container">
+				<div class="hu-final-cta">
+					<span class="hu-tag">
+						<span class="hu-dot hu-dot--live" aria-hidden="true"></span>
+						<span class="hu-mono"><?php echo esc_html( $founding_label ); ?> · <?php echo (int) $founding_open; ?> von <?php echo (int) $founding_seats; ?> Plätzen offen</span>
+					</span>
+					<h2>Anfragen besitzen,<br />nicht mieten.</h2>
+					<p>
+						2026 nehme ich maximal <?php echo (int) $founding_seats; ?> Solar- oder SHK-Betriebe als Founding-Partner auf —
+						damit jede Region in Diagnose, Daten-Pipeline und Vertriebsanschluss persönlich abgebildet werden kann.
+						Founding-Partner heißt: früher Umsetzungspartner, kein Mitgründer, kein Anteilseigner und keine
+						gesellschaftsrechtliche Partnerschaft. Der Marktcheck entscheidet, ob die Architektur zu Ihrer Region passt.
 					</p>
+					<ul class="sol-founding-facts">
+						<li>Plätze 2026: <?php echo (int) $founding_open; ?> von <?php echo (int) $founding_seats; ?> noch offen</li>
+						<li>Bewerbungsfrist: <?php echo esc_html( $founding_end_de ); ?></li>
+						<li>Entscheidung: nach Marktcheck · händisch · innerhalb von 48 Stunden</li>
+						<li>Bedingung: eigener Vertrieb · klares Zielgebiet · 12–24-Monate-Horizont</li>
+					</ul>
 					<a
-						class="sol-btn sol-btn-primary sol-final-btn"
+						class="hu-btn hu-btn-primary"
 						href="#marktcheck"
 						data-track-action="cta_solar_final_to_intake"
 						data-track-category="lead_gen"
@@ -1324,9 +1090,11 @@ get_header();
 						data-track-funnel-stage="intake_open"
 					>
 						<span>Marktcheck starten</span>
-						<span class="sol-btn-arrow"><?php echo $arrow_svg; // raw-ok phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></span>
+						<?php echo $arrow_svg; // raw-ok phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 					</a>
-					<div class="sol-final-micro">Regions-Verfügbarkeitsprüfung · Manuelle Erst-Analyse · Fit-Entscheid mit drei Hebeln</div>
+					<div class="hu-final-cta__signature">
+						Befund in 48 h · <strong>kein Pflicht-Call</strong> · keine Zahlungsdaten · Regions-Verfügbarkeitsprüfung inklusive
+					</div>
 				</div>
 			</div>
 		</section>


### PR DESCRIPTION
## Zusammenfassung

Letzte große Optimierungsrunde für `/solar-waermepumpen-leadgenerierung/` — Design **und** Copy, auf Basis des Claude-Design-Handoffs „Solar-Leadgenerierung v2". Das Design wurde bewusst **nicht blind übernommen**: Der v2-Hero ersetzt den alten, CRO-kritische Bestandsstücke (Formular above the fold, echte Vertiefungs-Links, FAQ-Schema, CAPEX-Rechner) bleiben erhalten.

### Design
- Komplette Seite auf das geteilte `.hu-hp`-Brand-System umgestellt (Ink `#0B0F12` im Wechsel mit Creme `#F4EDDD`, Kupfer `#E08A3C`) — konsistent mit Homepage und E3-Case.
- `homepage-redesign.css` wird wiederverwendet; das Page-CSS ist nur noch ein schlankes Delta-Stylesheet. **Netto −2.314 Zeilen.**
- Neuer Hero: Headline „Hören Sie auf, Anfragen zu mieten." (Kupfer-Akzent), rotierende Kupfer-Sonne (32-Strahlen-SVG), animiertes CPL-Balken-Chart (150 € → 22 € aus `hu_e3_canon`), Count-up-Stats, Trust-Bullets.
- Sektionen auf Kit-Komponenten migriert: Kostenkarten (Creme), Compare „Portal-Miete vs. eigener Anfrageweg", Phasen mit Asset-Panel, CAPEX/OPEX-Modellkarten (12/24/36-Toggle erhalten), E3-Proof Vorher/Nachher + Stats, Fit-Grid, Risiko-Umkehr „Diagnose vor Pitch.", Vertiefung, FAQ.
- `#system-bild`-Sektion aufgelöst (Inhalt kondensiert ins Phasen-Asset-Panel); Founding-Cohort + Final-CTA zu einem `hu-final-cta`-Block gemerged.

### Marktcheck (UX/CRO)
- Frage-Copy verkürzt: „Wer verkauft bei Ihnen?" / „Was kostet Sie Akquise heute?" / „Wohin darf der Befund?"
- **Firmen-PLZ-Feld neu** (`postal_code`, fünfstellig validiert, `inputmode=numeric`) — speist die Regions-Verfügbarkeitsprüfung; das Backend speicherte `_nexus_review_energy_postal_code` bereits, keine Server-Änderung nötig.
- Telefon-Feld entfernt (Straffung Schritt 3), PLZ in Cal.com-Notes übernommen.
- **Unverändert:** REST-Kontrakt (`intake_variant: energy_systems`, `audit_type: b2b_system_intake`), Backend-Enums, Lead-Attribution, GA4-Events, Success-/Nurture-Logik, Honeypot, Consent, Freemail-Validierung, SSR-/noscript-Fallback.

### Copy/Canon
- Kundenseitige „Module" durchgängig zu „Bausteinen" (Messaging-Canon); „−85,3 %" durch Canon-Formulierung „über 85 %" ersetzt; Founding-Partner-Rechtsklarstellung erhalten.

### Verifikation
- ✅ `php -l` (alle Theme-Dateien) · PHPStan (keine Fehler) · `lint:architecture`
- ✅ `scripts/smoke-lead-path-contract.sh` (kritisches Gate für den Formular-Umbau)
- ✅ `lint-e3-canon.sh` · `lint-canon-drift.sh` · `check-german-copy.sh`
- ✅ lightningcss + terser parsen/minifizieren die neuen Assets (voller `build:theme` scheiterte nur an fehlendem `rsync` im Container)
- ✅ Alle Anker (`#marktcheck` site-weiter Kontrakt, Section-Nav-Ziele) vorhanden; FAQ-Schema weiterhin 11 Entities

https://claude.ai/code/session_01MnyLnyySdUkjpCQHWgqj7V

---
_Generated by [Claude Code](https://claude.ai/code/session_01MnyLnyySdUkjpCQHWgqj7V)_