### PR TITLE
Expose agent skills to Claude Code via .claude/skills symlinks

### DIFF
--- a/.claude/skills/b2b-design-system
+++ b/.claude/skills/b2b-design-system
@@ -1,0 +1,1 @@
+../../agents/skills/b2b-design-system

--- a/.claude/skills/blog-seo-ux-optimizer
+++ b/.claude/skills/blog-seo-ux-optimizer
@@ -1,0 +1,1 @@
+../../agents/skills/blog-seo-ux-optimizer

--- a/.claude/skills/growth-audit-optimizer
+++ b/.claude/skills/growth-audit-optimizer
@@ -1,0 +1,1 @@
+../../agents/skills/growth-audit-optimizer

--- a/.claude/skills/homepage-proof-monitoring
+++ b/.claude/skills/homepage-proof-monitoring
@@ -1,0 +1,1 @@
+../../agents/skills/homepage-proof-monitoring

--- a/.claude/skills/internal-linking-audit
+++ b/.claude/skills/internal-linking-audit
@@ -1,0 +1,1 @@
+../../agents/skills/internal-linking-audit

--- a/.claude/skills/landing-page-builder
+++ b/.claude/skills/landing-page-builder
@@ -1,0 +1,1 @@
+../../agents/skills/landing-page-builder

--- a/.claude/skills/modern-web-guidance
+++ b/.claude/skills/modern-web-guidance
@@ -1,0 +1,1 @@
+../../agents/skills/modern-web-guidance

--- a/.claude/skills/navigation-migration
+++ b/.claude/skills/navigation-migration
@@ -1,0 +1,1 @@
+../../agents/skills/navigation-migration

--- a/.claude/skills/offer-funnel-intelligence
+++ b/.claude/skills/offer-funnel-intelligence
@@ -1,0 +1,1 @@
+../../agents/skills/offer-funnel-intelligence

--- a/.claude/skills/page-speed-audit
+++ b/.claude/skills/page-speed-audit
@@ -1,0 +1,1 @@
+../../agents/skills/page-speed-audit

--- a/.claude/skills/pillar-cornerstone-writer
+++ b/.claude/skills/pillar-cornerstone-writer
@@ -1,0 +1,1 @@
+../../agents/skills/pillar-cornerstone-writer

--- a/.claude/skills/pre-deploy-smoke
+++ b/.claude/skills/pre-deploy-smoke
@@ -1,0 +1,1 @@
+../../agents/skills/pre-deploy-smoke

--- a/.claude/skills/registry-release-qa
+++ b/.claude/skills/registry-release-qa
@@ -1,0 +1,1 @@
+../../agents/skills/registry-release-qa

--- a/.claude/skills/seo-agent
+++ b/.claude/skills/seo-agent
@@ -1,0 +1,1 @@
+../../agents/skills/seo-agent

--- a/.claude/skills/seo-cockpit-hardening
+++ b/.claude/skills/seo-cockpit-hardening
@@ -1,0 +1,1 @@
+../../agents/skills/seo-cockpit-hardening

--- a/.claude/skills/seo-live-qa
+++ b/.claude/skills/seo-live-qa
@@ -1,0 +1,1 @@
+../../agents/skills/seo-live-qa

--- a/.claude/skills/wordpress-cro-content-design-audit
+++ b/.claude/skills/wordpress-cro-content-design-audit
@@ -1,0 +1,1 @@
+../../agents/skills/wordpress-cro-content-design-audit

--- a/.claude/skills/wordpress-growth-architecture
+++ b/.claude/skills/wordpress-growth-architecture
@@ -1,0 +1,1 @@
+../../agents/skills/wordpress-growth-architecture

--- a/.claude/skills/wordpress-performance-marketing
+++ b/.claude/skills/wordpress-performance-marketing
@@ -1,0 +1,1 @@
+../../agents/skills/wordpress-performance-marketing

--- a/agents/skills/README.md
+++ b/agents/skills/README.md
@@ -2,6 +2,8 @@
 
 This directory contains the repo-specific agent skills. Use `agents/skills/CONTEXT.md` as the routing table before opening individual skills.
 
+All skills are also exposed to Claude Code via symlinks in `.claude/skills/`, so Claude Code auto-discovers them as invocable skills. `agents/skills/` stays the single source of truth; edit skills here, never in `.claude/skills/`.
+
 ## High-priority routing
 
 - `offer-funnel-intelligence` — offer logic, funnel strategy, marketcheck, proof, qualification, sales-fit, WGOS boundary


### PR DESCRIPTION
Symlink each skill in agents/skills/ into .claude/skills/ so Claude Code auto-discovers them as invocable skills. agents/skills/ remains the single source of truth.

https://claude.ai/code/session_01Gfqy4znrGEv6qMCHyQCWif