### PR TITLE
Weltklasse-Copy-Pass für die Top-5 Money-Pages: Meta-Fixes, Canon-Konsistenz, Floskel-Abbau

### DIFF
--- a/blocksy-child/assets/js/solar-leadgenerierung-solara.js
+++ b/blocksy-child/assets/js/solar-leadgenerierung-solara.js
@@ -566,7 +566,7 @@
       ]);
       form.appendChild(submitBtn);
 
-      form.appendChild(el('p', { className: 'sol-quiz-fineprint' }, 'Kostenlos & unverbindlich · Regions-Verfügbarkeitsprüfung · Manuelle Erst-Analyse · DSGVO'));
+      form.appendChild(el('p', { className: 'sol-quiz-fineprint' }, 'Keine Zahlungsdaten, kein Abo · Regions-Verfügbarkeitsprüfung · Manuelle Erst-Analyse · DSGVO'));
 
       return form;
     }

--- a/blocksy-child/front-page.php
+++ b/blocksy-child/front-page.php
@@ -69,7 +69,7 @@ $home_routing_gateways = [
 			$e3_cpl_after
 		),
 		'url'     => $e3_case_url,
-		'label'   => 'Verifizierte E3-Case-Study analysieren',
+		'label'   => 'E3-Case mit allen Zahlen lesen',
 		'persona' => 'Für skeptische Zahlen-Prüfer',
 		'action'  => 'gateway_e3',
 	],
@@ -153,7 +153,7 @@ get_header();
 						E3-Case ansehen
 					</a>
 				</div>
-				<p class="hu-hero__cta-note hu-hero__cta-note--trust">Der Marktcheck ist kostenlos &amp; unverbindlich — 60 Sekunden Eingabe, persönlich geprüfte Rückmeldung. Kein Pitch-Deck, kein Newsletter.</p>
+				<p class="hu-hero__cta-note hu-hero__cta-note--trust">Der Marktcheck kostet Sie 60 Sekunden — keine Zahlungsdaten, kein Newsletter, kein Pitch-Deck. Die Rückmeldung kommt persönlich geprüft innerhalb von 48 Stunden.</p>
 				<p class="hu-hero__cta-note">Keine neue Website auf Verdacht. Erst Diagnose, dann Entscheidung.</p>
 
 				<div class="hu-hero__stats">
@@ -493,7 +493,7 @@ get_header();
 			<div class="hu-system-flow hu-reveal">
 				<div class="hu-sf-col hu-sf-col--bad">
 					<div class="hu-sf-col-head">
-						<div class="hu-sf-col-label">AKTUELL</div>
+						<div class="hu-sf-col-label">TYPISCHES SETUP</div>
 						<div class="hu-sf-col-title">Portal-Chaos</div>
 					</div>
 					<div class="hu-sf-row">
@@ -518,7 +518,7 @@ get_header();
 						</div>
 					</div>
 					<div class="hu-sf-cost">
-						<div class="hu-sf-cost-label">KOSTEN / MONAT</div>
+						<div class="hu-sf-cost-label">BEISPIELRECHNUNG / MONAT</div>
 						<div class="hu-sf-cost-num">~ 4.800 €</div>
 					</div>
 				</div>
@@ -629,7 +629,7 @@ get_header();
 						<li><span class="hu-about-bullet-dot"></span>Medienwissenschaftliche Architektur — Sprache, Signal, System vor Code</li>
 						<li><span class="hu-about-bullet-dot"></span>Fokus Solar &amp; Wärmepumpen — verifizierte Daten-Integrität seit dem E3-Case</li>
 						<li><span class="hu-about-bullet-dot"></span>Asset-Ownership statt Drittanbieter-Lock-in</li>
-						<li><span class="hu-about-bullet-dot"></span>Founder seit 2026 · Hannover, remote</li>
+						<li><span class="hu-about-bullet-dot"></span>Gegründet 2026 · Hannover, vor Ort und remote</li>
 						<li><span class="hu-about-bullet-dot"></span>Maximal 3 Founding-Partner pro Jahr</li>
 					</ul>
 					<a href="<?php echo esc_url( $analysis_url ); ?>" class="hu-btn hu-btn-primary"
@@ -661,7 +661,7 @@ get_header();
 						<span class="hu-faq-item__icon" aria-hidden="true">−</span>
 					</button>
 					<div class="hu-faq-item__a">
-						<div class="hu-faq-item__a-inner">Der händisch geprüfte Befund ordnet Domain, Region, Vertrieb und Anfragequalität ein. Keine automatischen Standard-PDFs, sondern eine strategische Einordnung mit klarer Empfehlung für oder gegen den nächsten Schritt.</div>
+						<div class="hu-faq-item__a-inner">Drei Klick-Schritte, rund 60 Sekunden Eingabe. Den händisch geprüften Befund zu Domain, Region, Vertrieb und Anfragequalität erhalten Sie in der Regel innerhalb von 48 Stunden, spätestens 2 Werktagen, per E-Mail. Kein automatisches Standard-PDF, sondern eine Einordnung mit klarer Empfehlung für oder gegen den nächsten Schritt.</div>
 					</div>
 				</div>
 

--- a/blocksy-child/inc/helpers.php
+++ b/blocksy-child/inc/helpers.php
@@ -638,7 +638,7 @@ function nexus_get_agentur_faq_items() {
 	return [
 		[
 			'question' => 'Welche WordPress Agentur in Hannover passt für anspruchsvolle B2B-Angebote?',
-			'answer'   => 'Eine passende WordPress Agentur Hannover verbindet WordPress-Entwicklung, SEO, Tracking, GA4, Server-Side Tracking und Conversion-Führung. Genau darauf ist diese Seite ausgerichtet: WordPress als Nachfrage-System statt isolierter Einzelleistungen.',
+			'answer'   => 'Eine, die WordPress-Entwicklung, technisches SEO, Tracking und Conversion-Führung als ein System behandelt — nicht als getrennte Einzelleistungen. Genau darauf ist diese Seite ausgerichtet: WordPress als Anfrage-System, geprüft an vier Kauf-Signalen, bevor ein Relaunch überhaupt zur Debatte steht.',
 		],
 		[
 			'question' => 'Arbeiten Sie nur mit Unternehmen aus Hannover?',

--- a/blocksy-child/inc/seo-meta.php
+++ b/blocksy-child/inc/seo-meta.php
@@ -40,9 +40,12 @@ function hu_get_homepage_title() {
  * @return string
  */
 function hu_get_homepage_description() {
+	$cpl_before = function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'cpl_before', 'display', '150 €' ) : '150 €';
+	$cpl_after  = function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'cpl_after', 'display', '22 €' ) : '22 €';
+
 	return (string) apply_filters(
 		'hu_homepage_seo_description',
-		'Eigene Anfragen statt gemieteter Portal-Leads: Marktcheck, Vorqualifizierung und Tracking für Solar-, Wärmepumpen- und Speicher-Anbieter.'
+		sprintf( 'Eigene Anfragen statt Portal-Leads: Marktcheck, Vorqualifizierung und Tracking für Solar- und Wärmepumpen-Anbieter. E3-Case: CPL von %s auf %s.', $cpl_before, $cpl_after )
 	);
 }
 
@@ -174,11 +177,11 @@ function hu_get_forced_singular_seo_map() {
 		[
 			'kontakt' => [
 				'title'       => 'Kontakt & Projektanfrage | Haşim Üner',
-				'description' => 'Projekt starten oder Frage stellen: Formular ausfuellen, Rueckmeldung innerhalb von 48 Stunden. Kein Pflicht-Call, kein Sales-Druck – nur eine fundierte Ersteinschaetzung.',
+				'description' => 'Projekt oder Frage kurz einordnen: ein Formular, händisch geprüfte Rückmeldung innerhalb von 48 Stunden. Kein Pflicht-Call, kein Vertriebsteam.',
 			],
 			'kontaktiere-mich' => [
 				'title'       => 'Kontakt & Projektanfrage | Haşim Üner',
-				'description' => 'Projekt starten oder Frage stellen: Formular ausfuellen, Rueckmeldung innerhalb von 48 Stunden. Kein Pflicht-Call, kein Sales-Druck – nur eine fundierte Ersteinschaetzung.',
+				'description' => 'Projekt oder Frage kurz einordnen: ein Formular, händisch geprüfte Rückmeldung innerhalb von 48 Stunden. Kein Pflicht-Call, kein Vertriebsteam.',
 			],
 			'uber-mich' => [
 				'title'       => 'Über Haşim Üner | Solar-Anfrage-Systeme',
@@ -883,7 +886,7 @@ function hu_get_domdar_case_study_description() {
  * @return string
  */
 function hu_get_contact_offer_title() {
-	return 'Kontakt für WordPress, SEO und CRO | Haşim Üner';
+	return 'Kontakt & Projektanfrage | Haşim Üner';
 }
 
 /**
@@ -892,7 +895,7 @@ function hu_get_contact_offer_title() {
  * @return string
  */
 function hu_get_contact_offer_description() {
-	return 'Projektanfrage für WordPress, SEO, Tracking und CRO: kurzer Einstieg, klare nächste Schritte und Rückmeldung für neue Projekte und bestehende Kunden.';
+	return 'Projekt oder Frage kurz einordnen: ein Formular, händisch geprüfte Rückmeldung innerhalb von 48 Stunden. Kein Pflicht-Call, kein Vertriebsteam.';
 }
 
 

--- a/blocksy-child/page-e3-new-energy.php
+++ b/blocksy-child/page-e3-new-energy.php
@@ -15,11 +15,17 @@ $agentur_url    = function_exists( 'nexus_get_primary_public_url' ) ? nexus_get_
 
 $tracking_attrs = 'data-track-section="case_e3_methodology" data-track-funnel-stage="proof"';
 
+$e3_cpl_before  = function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'cpl_before', 'display', '150 €' ) : '150 €';
+$e3_cpl_after   = function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'cpl_after', 'display', '22 €' ) : '22 €';
+$e3_lead_count  = function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'lead_count', 'display', '1.750+' ) : '1.750+';
+$e3_conv_uplift = function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'sales_conversion_uplift', 'display', '1 – 5 % → 12 %' ) : '1 – 5 % → 12 %';
+$e3_timeframe   = function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'timeframe', 'display', '6 Monate' ) : '6 Monate';
+
 $metrics = [
-	'150 € → 22 € CPL',
-	'1.750+ Anfragen',
-	'1 – 5 % → 12 % Abschlussquote',
-	'6 Monate Laufzeit',
+	sprintf( '%s → %s CPL', $e3_cpl_before, $e3_cpl_after ),
+	sprintf( '%s Anfragen', $e3_lead_count ),
+	sprintf( '%s Abschlussquote', $e3_conv_uplift ),
+	sprintf( '%s Laufzeit', $e3_timeframe ),
 ];
 
 $hypotheses = [
@@ -97,8 +103,8 @@ $specific = [
 ];
 
 $cta_features = [
-	'Kostenfreier Marktcheck in 6 Fragen',
-	'Händisch geprüfter Marktcheck innerhalb von 48 Stunden',
+	'Marktcheck in drei Schritten — rund 60 Sekunden Eingabe',
+	'Händisch geprüfter Befund innerhalb von 48 Stunden per E-Mail',
 	'Einordnung von Anfrage-Quellen, Tracking und Vertriebsanschluss',
 	'Kein Pflicht-Termin, kein Pitch-Call',
 ];
@@ -155,8 +161,8 @@ get_header();
 ?>
 
 <main id="main" class="site-main">
-	<div class="energy-page-wrapper solar-page e3-methodology" <?php echo $tracking_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
-		<section class="e3-hero" id="hero" <?php echo $tracking_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> aria-labelledby="e3-hero-title">
+	<div class="energy-page-wrapper solar-page e3-methodology" <?php echo $tracking_attrs; // raw-ok phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
+		<section class="e3-hero" id="hero" <?php echo $tracking_attrs; // raw-ok phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> aria-labelledby="e3-hero-title">
 			<div class="e3-section__inner e3-hero__inner">
 				<div class="e3-hero__content" data-reveal>
 					<p class="e3-kicker">Methodik-Case · Solar &amp; Wärmepumpe</p>
@@ -176,7 +182,7 @@ get_header();
 			</div>
 		</section>
 
-		<section class="e3-section e3-section--paper" id="diagnose" <?php echo $tracking_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> aria-labelledby="diagnose-title">
+		<section class="e3-section e3-section--paper" id="diagnose" <?php echo $tracking_attrs; // raw-ok phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> aria-labelledby="diagnose-title">
 			<div class="e3-section__inner">
 				<div class="e3-section__head" data-reveal>
 					<p class="e3-kicker">Ausgangslage</p>
@@ -195,7 +201,7 @@ get_header();
 			</div>
 		</section>
 
-		<section class="e3-section e3-section--dark" id="hypothese" <?php echo $tracking_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> aria-labelledby="hypothese-title">
+		<section class="e3-section e3-section--dark" id="hypothese" <?php echo $tracking_attrs; // raw-ok phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> aria-labelledby="hypothese-title">
 			<div class="e3-section__inner">
 				<div class="e3-section__head" data-reveal>
 					<p class="e3-kicker">Arbeitshypothese</p>
@@ -216,7 +222,7 @@ get_header();
 			</div>
 		</section>
 
-		<section class="e3-section e3-section--paper-2" id="massnahmen" <?php echo $tracking_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> aria-labelledby="massnahmen-title">
+		<section class="e3-section e3-section--paper-2" id="massnahmen" <?php echo $tracking_attrs; // raw-ok phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> aria-labelledby="massnahmen-title">
 			<div class="e3-section__inner">
 				<div class="e3-section__head" data-reveal>
 					<p class="e3-kicker">Umsetzung</p>
@@ -238,10 +244,10 @@ get_header();
 			</div>
 		</section>
 
-		<section class="e3-section e3-section--paper-2" id="datenbereinigung" <?php echo $tracking_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> aria-labelledby="datenbereinigung-title">
+		<section class="e3-section e3-section--paper-2" id="datenbereinigung" <?php echo $tracking_attrs; // raw-ok phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> aria-labelledby="datenbereinigung-title">
 			<div class="e3-section__inner">
 				<div class="e3-section__head" data-reveal>
-					<p class="e3-kicker">Believability · Monat 1–2</p>
+					<p class="e3-kicker">Datenfundament · Monat 1–2</p>
 					<h2 class="e3-section__title" id="datenbereinigung-title">Bereinigung der unsichtbaren Datenlecks.</h2>
 					<p class="e3-section__lede">Bevor irgendeine Optimierung greifen konnte, musste die Attribution stimmen. Ohne diesen Schritt wäre der CPL-Sturz von <?php echo esc_html( function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'cpl_before' ) : '150 €' ); ?> auf <?php echo esc_html( function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'cpl_after' ) : '22 €' ); ?> nicht reproduzierbar.</p>
 				</div>
@@ -260,7 +266,7 @@ get_header();
 			</div>
 		</section>
 
-		<section class="e3-section e3-section--paper" id="verlauf" <?php echo $tracking_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> aria-labelledby="verlauf-title">
+		<section class="e3-section e3-section--paper" id="verlauf" <?php echo $tracking_attrs; // raw-ok phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> aria-labelledby="verlauf-title">
 			<div class="e3-section__inner">
 				<div class="e3-section__head" data-reveal>
 					<p class="e3-kicker">Timeline</p>
@@ -281,7 +287,7 @@ get_header();
 			</div>
 		</section>
 
-		<section class="e3-section e3-section--dark" id="lessons" <?php echo $tracking_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> aria-labelledby="lessons-title">
+		<section class="e3-section e3-section--dark" id="lessons" <?php echo $tracking_attrs; // raw-ok phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> aria-labelledby="lessons-title">
 			<div class="e3-section__inner">
 				<div class="e3-section__head" data-reveal>
 					<p class="e3-kicker">Was generalisierbar ist</p>
@@ -310,10 +316,10 @@ get_header();
 			</div>
 		</section>
 
-		<section class="e3-section e3-section--paper" id="insight" <?php echo $tracking_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> aria-labelledby="insight-title">
+		<section class="e3-section e3-section--paper" id="insight" <?php echo $tracking_attrs; // raw-ok phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> aria-labelledby="insight-title">
 			<div class="e3-section__inner">
 				<div class="e3-section__head" data-reveal>
-					<p class="e3-kicker">True Insight</p>
+					<p class="e3-kicker">Kernerkenntnis</p>
 					<h2 class="e3-section__title" id="insight-title">Die fundamentale Erkenntnis aus <?php echo esc_html( function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'timeframe', 'display_dative' ) : '6 Monaten' ); ?> E3.</h2>
 				</div>
 
@@ -323,7 +329,7 @@ get_header();
 			</div>
 		</section>
 
-		<section class="e3-section e3-section--paper-2 e3-section--deeper" id="vertiefung" <?php echo $tracking_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> aria-labelledby="vertiefung-title">
+		<section class="e3-section e3-section--paper-2 e3-section--deeper" id="vertiefung" <?php echo $tracking_attrs; // raw-ok phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> aria-labelledby="vertiefung-title">
 			<div class="e3-section__inner">
 				<div class="e3-section__head" data-reveal>
 					<p class="e3-kicker">Methodik im Detail</p>
@@ -355,7 +361,7 @@ get_header();
 			</div>
 		</section>
 
-		<section class="e3-section e3-section--cta" id="cta" <?php echo $tracking_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> aria-labelledby="cta-title">
+		<section class="e3-section e3-section--cta" id="cta" <?php echo $tracking_attrs; // raw-ok phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> aria-labelledby="cta-title">
 			<div class="e3-section__inner e3-cta" data-reveal>
 				<p class="e3-kicker">Nächster Schritt</p>
 				<h2 class="e3-section__title" id="cta-title">Wenn Sie eine ähnliche Asymmetrie zwischen Lead-Quellen sehen — oder vermuten — klären wir das im Marktcheck.</h2>
@@ -374,7 +380,7 @@ get_header();
 					</a>
 				</div>
 
-				<p class="e3-cta__micro">Händisch geprüfter Befund innerhalb von 48 Stunden per E-Mail.</p>
+				<p class="e3-cta__micro">Keine Zahlungsdaten, kein Abo — der Marktcheck prüft zuerst, ob der Fit überhaupt passt.</p>
 			</div>
 		</section>
 	</div>

--- a/blocksy-child/page-kontakt.php
+++ b/blocksy-child/page-kontakt.php
@@ -144,10 +144,10 @@ $current_type_label    = isset( $public_type_copy[ $selected_type ]['label'] ) ?
 $preselected_type      = ( $has_explicit_type || '' !== $selected_focus ) ? $selected_type : '';
 
 $hero_eyebrow = $is_scoped_landing ? $current_type_label : 'Kontakt';
-$hero_title   = $is_scoped_landing ? $current_type_label : 'Kontakt kurz einordnen.';
+$hero_title   = $is_scoped_landing ? $current_type_label : 'Sagen Sie kurz, worum es geht.';
 $hero_lead    = $is_scoped_landing
-	? 'Ein kompakter Flow für Ziel, Hürde, Kontakt und nächsten Schritt.'
-	: 'Ein kompakter Flow für Diagnose, Umsetzung oder Weiterentwicklung.';
+	? 'Vier kurze Schritte: Ziel, Hürde, Kontakt — händisch geprüfte Rückmeldung innerhalb von 48 Stunden.'
+	: 'Anliegen wählen, drei Fragen beantworten — händisch geprüfte Rückmeldung innerhalb von 48 Stunden. Kein Pflicht-Call, kein Vertriebsteam.';
 
 $auto_scroll  = false;
 ?>
@@ -215,7 +215,7 @@ $auto_scroll  = false;
 							class="contact-flow-step"
 							data-contact-step="type"
 							data-contact-step-label="Anfragetyp"
-							<?php echo $is_scoped_landing ? 'data-contact-step-skip="true"' : ''; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static boolean state ?>
+							<?php echo $is_scoped_landing ? 'data-contact-step-skip="true"' : ''; // raw-ok phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static boolean state ?>
 						>
 							<fieldset class="contact-intent<?php echo esc_attr( $is_scoped_landing ? ' contact-intent--collapsed' : '' ); ?>" data-contact-intent>
 								<legend>Anfrageart</legend>

--- a/blocksy-child/page-solar-waermepumpen-leadgenerierung.php
+++ b/blocksy-child/page-solar-waermepumpen-leadgenerierung.php
@@ -253,7 +253,7 @@ $faq_items = [
 	],
 	[
 		'question' => 'Was kostet das im Vergleich zur Performance-Agentur?',
-		'answer'   => 'Initiales Setup: 12.000–18.000 € einmalig. Laufend ca. 50 €/Monat für Hochleistungs-Hosting. TCO über 24 Monate: 13.200–19.200 € — und Sie besitzen Code, Tracking und Daten. Eine Performance-Agentur mit Paket „Regio+" kostet im gleichen Zeitraum rund 26.000 € und Sie besitzen am Ende nichts. Bilanziell: CAPEX statt OPEX.',
+		'answer'   => 'Initiales Setup: 12.000–18.000 € einmalig. Laufend ca. 50 €/Monat für Hochleistungs-Hosting. TCO über 24 Monate: 13.200–19.200 € — und Sie besitzen Code, Tracking und Daten. Ein vergleichbares Agentur-Mietmodell kostet im gleichen Zeitraum rund 26.000 € — und Sie besitzen am Ende nichts. Bilanziell: CAPEX statt OPEX.',
 	],
 	[
 		'question' => 'Welche Daten brauchen Sie für die Diagnose?',
@@ -305,7 +305,7 @@ $service_schema = [
 	'provider'    => [
 		'@type'       => 'Organization',
 		'@id'         => $organization_id,
-		'name'        => 'Haşim Üner — WordPress-Agentur Hannover',
+		'name'        => 'Haşim Üner — Anfrage-Systeme für Solar & Wärmepumpe',
 		'url'         => home_url( '/' ),
 		'founder'     => [
 			'@id' => function_exists( 'hu_person_schema_id' ) ? hu_person_schema_id() : home_url( '/uber-mich/#person' ),
@@ -455,7 +455,7 @@ get_header();
 					?>
 					<figure class="hu-diagram sol-cpl" aria-labelledby="sol-cpl-title" data-track-section="hero_dashboard">
 						<div class="hu-lead-sketch__head">
-							<span class="hu-eyebrow">Live-Telemetrie · <?php echo esc_html( $e3_case_label ); ?></span>
+							<span class="hu-eyebrow">CPL-Verlauf · <?php echo esc_html( $e3_case_label ); ?></span>
 							<span class="hu-lead-sketch__status" id="sol-cpl-title">Kosten pro qualifizierter Anfrage · <?php echo esc_html( $e3_timeframe ); ?></span>
 						</div>
 						<svg viewBox="0 0 <?php echo (int) $cpl_w; ?> <?php echo (int) $cpl_h; ?>" role="img"
@@ -575,7 +575,7 @@ get_header();
 								Kein Newsletter, kein Pitch-Deck.
 							</p>
 							<ul class="sol-cta-bullets sol-mono" aria-label="Was Sie nach dem Marktcheck erhalten">
-								<li><span class="sol-cta-bullets-tick" aria-hidden="true">✓</span>Kostenlos &amp; unverbindlich — keine Zahlungsdaten, kein Abo</li>
+								<li><span class="sol-cta-bullets-tick" aria-hidden="true">✓</span>Keine Zahlungsdaten, kein Abo, keine Verpflichtung</li>
 								<li><span class="sol-cta-bullets-tick" aria-hidden="true">✓</span>Regions-Verfügbarkeitsprüfung über Ihre Firmen-PLZ</li>
 								<li><span class="sol-cta-bullets-tick" aria-hidden="true">✓</span>Manuelle Erst-Analyse statt automatisierter Tool-Bericht</li>
 								<li><span class="sol-cta-bullets-tick" aria-hidden="true">✓</span>Befund in 48 h per E-Mail · kein Pflicht-Call</li>
@@ -882,7 +882,7 @@ get_header();
 					</div>
 					<div class="hu-proof-stat">
 						<div class="hu-proof-stat__num"><?php echo esc_html( $e3_timeframe ); ?></div>
-						<div class="hu-proof-stat__lbl">Live-Telemetrie · DSGVO</div>
+						<div class="hu-proof-stat__lbl">Zeitraum · dokumentiert</div>
 					</div>
 				</div>
 				<div class="sol-proof-foot">

--- a/blocksy-child/page-wordpress-agentur.php
+++ b/blocksy-child/page-wordpress-agentur.php
@@ -54,10 +54,19 @@ $agentur_solar_deeper = [
 ];
 
 // ═══ E3 Proof Canon ═══
-$e3            = function_exists( 'hu_e3_canon' ) ? hu_e3_canon() : [];
-$e3_metrics    = $e3['metrics'] ?? [];
-$e3_cpl_before = $e3_metrics['cpl_before']['display'] ?? '150 €';
-$e3_cpl_after  = $e3_metrics['cpl_after']['display'] ?? '22 €';
+$e3                = function_exists( 'hu_e3_canon' ) ? hu_e3_canon() : [];
+$e3_metrics        = $e3['metrics'] ?? [];
+$e3_cpl_before     = $e3_metrics['cpl_before']['display'] ?? '150 €';
+$e3_cpl_after      = $e3_metrics['cpl_after']['display'] ?? '22 €';
+$e3_cpl_reduction  = $e3_metrics['cpl_reduction']['display'] ?? 'über 85 %';
+$e3_cpl_red_count  = $e3_metrics['cpl_reduction']['counter_target'] ?? '85';
+$e3_lead_count     = $e3_metrics['lead_count']['display'] ?? '1.750+';
+$e3_lead_counter   = $e3_metrics['lead_count']['counter_target'] ?? '1750';
+$e3_sales_conv     = $e3_metrics['sales_conversion']['display'] ?? '12 %';
+$e3_conv_counter   = $e3_metrics['sales_conversion']['counter_target'] ?? '12';
+$e3_timeframe      = $e3_metrics['timeframe']['display'] ?? '6 Monate';
+$e3_timeframe_dat  = $e3_metrics['timeframe']['display_dative'] ?? '6 Monaten';
+$e3_time_counter   = $e3_metrics['timeframe']['counter_target'] ?? '6';
 
 // ═══ Methodenbausteine aus der Asset Registry ═══
 $wgos_assets = function_exists( 'nexus_get_wgos_asset_registry' ) ? nexus_get_wgos_asset_registry() : [];
@@ -210,27 +219,27 @@ get_header();
 							<span class="ag-hero-viz__live-dot" aria-hidden="true"></span>
 							Verifizierter Referenzfall · E3 New Energy
 						</span>
-						<h2 class="ag-hero-viz__title">CPL-Senkung in 6 Monaten</h2>
+						<h2 class="ag-hero-viz__title">CPL-Senkung in <?php echo esc_html( $e3_timeframe_dat ); ?></h2>
 						<p class="ag-hero-viz__sub">Kosten pro qualifizierter B2B-Anfrage — vor und nach dem eigenen Anfrage-System.</p>
 					</header>
 
 					<div class="ag-hero-viz__chart" role="img" aria-label="Balkenchart: Kosten pro qualifizierter Anfrage fielen von 150 Euro auf 22 Euro, ein Rückgang um 85 Prozent.">
 						<div class="ag-bar ag-bar--before">
-							<span class="ag-bar__num">150&nbsp;€</span>
+							<span class="ag-bar__num"><?php echo esc_html( $e3_cpl_before ); ?></span>
 							<span class="ag-bar__track">
 								<span class="ag-bar__fill" style="--ag-bar-height: 92%;"></span>
 							</span>
 							<span class="ag-bar__label">Vorher · Portal-Leads</span>
 						</div>
 						<div class="ag-bar__arrow" aria-hidden="true">
-							<span class="ag-bar__delta">−85 %</span>
+							<span class="ag-bar__delta">−<?php echo esc_html( $e3_cpl_red_count ); ?> %</span>
 							<svg width="36" height="72" viewBox="0 0 36 72" fill="none">
 								<path class="ag-bar__arrow-path" d="M6 6 C 22 22, 6 40, 30 64" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-dasharray="120" stroke-dashoffset="120" fill="none"/>
 								<path class="ag-bar__arrow-head" d="M22 58 L30 64 L24 70" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
 							</svg>
 						</div>
 						<div class="ag-bar ag-bar--after">
-							<span class="ag-bar__num">22&nbsp;€</span>
+							<span class="ag-bar__num"><?php echo esc_html( $e3_cpl_after ); ?></span>
 							<span class="ag-bar__track">
 								<span class="ag-bar__fill" style="--ag-bar-height: 14%;"></span>
 							</span>
@@ -240,15 +249,15 @@ get_header();
 
 					<dl class="ag-hero-viz__foot" aria-label="Kennzahlen aus dem E3-Case">
 						<div>
-							<dt><span class="ag-counter" data-counter-target="1750" data-counter-suffix="+">0</span></dt>
+							<dt><span class="ag-counter" data-counter-target="<?php echo esc_attr( $e3_lead_counter ); ?>" data-counter-suffix="+">0</span></dt>
 							<dd>Qualifizierte Anfragen</dd>
 						</div>
 						<div>
-							<dt><span class="ag-counter" data-counter-target="12" data-counter-suffix=" %">0</span></dt>
+							<dt><span class="ag-counter" data-counter-target="<?php echo esc_attr( $e3_conv_counter ); ?>" data-counter-suffix=" %">0</span></dt>
 							<dd>Abschlussquote</dd>
 						</div>
 						<div>
-							<dt><span class="ag-counter" data-counter-target="6" data-counter-suffix=" Mon.">0</span></dt>
+							<dt><span class="ag-counter" data-counter-target="<?php echo esc_attr( $e3_time_counter ); ?>" data-counter-suffix=" Mon.">0</span></dt>
 							<dd>Zeitraum</dd>
 						</div>
 					</dl>
@@ -271,25 +280,25 @@ get_header();
 
 		<div class="wp-agentur-proof-grid">
 			<div class="wp-agentur-proof-item">
-				<div class="wp-agentur-proof-value">150&nbsp;€ → 22&nbsp;€</div>
+				<div class="wp-agentur-proof-value"><?php echo esc_html( $e3_cpl_before ); ?> → <?php echo esc_html( $e3_cpl_after ); ?></div>
 				<div class="wp-agentur-proof-label">Kosten pro Anfrage</div>
 			</div>
 			<div class="wp-agentur-proof-item">
-				<div class="wp-agentur-proof-value">1.750+</div>
+				<div class="wp-agentur-proof-value"><?php echo esc_html( $e3_lead_count ); ?></div>
 				<div class="wp-agentur-proof-label">Qualifizierte Anfragen</div>
 			</div>
 			<div class="wp-agentur-proof-item">
-				<div class="wp-agentur-proof-value">12&nbsp;%</div>
+				<div class="wp-agentur-proof-value"><?php echo esc_html( $e3_sales_conv ); ?></div>
 				<div class="wp-agentur-proof-label">Abschlussquote</div>
 			</div>
 			<div class="wp-agentur-proof-item">
-				<div class="wp-agentur-proof-value">85&nbsp;%</div>
+				<div class="wp-agentur-proof-value"><?php echo esc_html( $e3_cpl_reduction ); ?></div>
 				<div class="wp-agentur-proof-label">Niedrigere Kosten pro Anfrage</div>
 			</div>
 		</div>
 
 		<div class="wp-agentur-proof-cta">
-			<p>6 Monate, 1.750+ qualifizierte Anfragen, messbare Reduktion der Leadkosten.</p>
+			<p><?php echo esc_html( sprintf( '%s, %s qualifizierte Anfragen, %s niedrigere Kosten pro Anfrage.', $e3_timeframe, $e3_lead_count, $e3_cpl_reduction ) ); ?></p>
 			<a href="<?php echo esc_url( $e3_url ); ?>" class="nx-btn nx-btn--ghost" data-track-action="cta_proof_strip_e3" data-track-category="navigation" data-track-section="proof_strip">
 				E3-Case im Detail ansehen
 			</a>
@@ -324,7 +333,7 @@ get_header();
 			<div class="wp-agentur-segment-card">
 				<span class="wp-agentur-segment-card__tag">Womit</span>
 				<h3>Mit einer Anfrage-System-Methode, validiert am E3-Case</h3>
-				<p>CPL von 150 € auf 22 € gesenkt, 1.750+ qualifizierte Anfragen in 6 Monaten und 12 % Abschlussquote.</p>
+				<p><?php echo esc_html( sprintf( 'CPL von %s auf %s gesenkt, %s qualifizierte Anfragen in %s und %s Abschlussquote.', $e3_cpl_before, $e3_cpl_after, $e3_lead_count, $e3_timeframe_dat, $e3_sales_conv ) ); ?></p>
 			</div>
 		</div>
 	</div>
@@ -512,12 +521,12 @@ get_header();
 										: '#asset-uebersicht'
 									);
 								?>
-									<a href="<?php echo $asset_url; ?>" class="asset-card" data-track-action="cta_asset_card" data-track-category="navigation" data-track-section="methodenbibliothek">
+									<a href="<?php echo $asset_url; // raw-ok pre-escaped via esc_url at assignment ?>" class="asset-card" data-track-action="cta_asset_card" data-track-category="navigation" data-track-section="methodenbibliothek">
 										<div class="asset-header">
 											<div class="asset-icon" style="color: <?php echo esc_attr( $meta['color'] ); ?>;"><?php echo hu_agentur_icon_svg( '<path d="M7 3h7l4 4v14H7z"/><path d="M14 3v4h4"/><path d="M9.5 12h5M9.5 15.5h5"/>', 20 ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
-											<div class="asset-title"><?php echo $asset_title; ?></div>
+											<div class="asset-title"><?php echo $asset_title; // raw-ok pre-escaped via esc_html at assignment ?></div>
 										</div>
-										<p class="asset-desc"><?php echo $asset_desc; ?></p>
+										<p class="asset-desc"><?php echo $asset_desc; // raw-ok pre-escaped via esc_html at assignment ?></p>
 									</a>
 								<?php endforeach; ?>
 							</div>
@@ -661,20 +670,20 @@ get_header();
 			<div class="wp-agentur-case-card">
 				<span class="wp-agentur-case-card__eyebrow">Referenz</span>
 				<h3>E3 New Energy</h3>
-				<p>Der E3-Case ist Referenz, keine pauschale Übertragbarkeitsgarantie. Er zeigt, warum Reihenfolge, Datenqualität und eigene Anfragepfade wichtiger sind als ein weiterer Relaunch.</p>
+				<p>Ein Energie-Anbieter, der von eingekauften Portal-Leads auf ein eigenes Anfrage-System umgestellt hat — WordPress, Server-Side Tracking und Vorqualifizierung als ein zusammenhängendes System statt als Einzelmaßnahmen.</p>
 			</div>
 			<div class="wp-agentur-case-card wp-agentur-case-card--result">
 				<span class="wp-agentur-case-card__eyebrow">Ergebnis</span>
 				<div class="wp-agentur-case-card__metrics">
-					<div><strong>150&nbsp;€ → 22&nbsp;€</strong><span>Kosten pro Anfrage</span></div>
-					<div><strong>1.750+</strong><span>Qualifizierte Anfragen</span></div>
-					<div><strong>12&nbsp;%</strong><span>Abschlussquote</span></div>
+					<div><strong><?php echo esc_html( $e3_cpl_before ); ?> → <?php echo esc_html( $e3_cpl_after ); ?></strong><span>Kosten pro Anfrage</span></div>
+					<div><strong><?php echo esc_html( $e3_lead_count ); ?></strong><span>Qualifizierte Anfragen</span></div>
+					<div><strong><?php echo esc_html( $e3_sales_conv ); ?></strong><span>Abschlussquote</span></div>
 				</div>
 			</div>
 			<div class="wp-agentur-case-card">
 				<span class="wp-agentur-case-card__eyebrow">Zeitraum</span>
-				<h3>6 Monate</h3>
-				<p>In sechs Monaten von portalabhängiger Leadbeschaffung zu einem eigenen, messbaren Anfrage-System.</p>
+				<h3><?php echo esc_html( $e3_timeframe ); ?></h3>
+				<p>In <?php echo esc_html( $e3_timeframe_dat ); ?> von portalabhängiger Leadbeschaffung zu einem eigenen, messbaren Anfrage-System.</p>
 			</div>
 			<div class="wp-agentur-case-card wp-agentur-case-card--cta">
 				<span class="wp-agentur-case-card__eyebrow">Nächster Schritt</span>
@@ -816,7 +825,7 @@ get_header();
 	<div class="nx-container">
 		<div class="nx-section-header">
 			<p class="wp-agentur-eyebrow">FAQ</p>
-			<h2 class="nx-headline-section">Häufige Fragen</h2>
+			<h2 class="nx-headline-section">Häufige Fragen vor der Projektprüfung.</h2>
 		</div>
 
 		<div class="faq-list" id="faq-accordion">


### PR DESCRIPTION
## Was dieser PR macht

Audit + chirurgische Copy-Schärfung der fünf wichtigsten Money-Pages — entlang der Brand-Canon (`docs/standards/BRAND_AND_COPY.md`), ohne Anker, `data-track-*`-Attribute, CSS-Klassen oder Schema-Mechanik anzufassen.

**Die 5 Seiten (nach Business-Wert):**
1. `/` — `front-page.php` (gesamter Traffic, Gateway-Routing)
2. `/solar-waermepumpen-leadgenerierung/` — primäre Money-Page mit Marktcheck-Intake
3. `/wordpress-agentur-hannover/` — sekundäres Gateway + Local SEO
4. `/e3-new-energy/` — primäre Proof-Seite
5. `/kontakt/` — Qualifizierungs-Gate

## Wichtigste Fixes

- **Kontakt-Meta-Bug behoben:** `<title>` und og:title/Description liefen über zwei Code-Pfade auseinander (Forced-Map vs. `hu_get_contact_offer_*` mit veralteter Positionierung „Kontakt für WordPress, SEO und CRO"); zusätzlich entstellte Umlaute („ausfuellen", „Rueckmeldung") in der Live-Description. Alle vier Strings vereinheitlicht.
- **Canon-Konsistenz:** Agentur-Seite und E3-Hero zogen E3-Kennzahlen als Literale statt aus `hu_e3_canon()` — jetzt überall Helper mit dokumentierten Fallbacks.
- **Brand-Verstoß im Schema:** Service-Schema der Solar-LP nannte die Organization „Haşim Üner — WordPress-Agentur Hannover" (Hard-Ban auf Cold Routes) → „Anfrage-Systeme für Solar & Wärmepumpe".
- **Ehrlichkeit:** „Live-Telemetrie"-Framing der teils schematischen CPL-Balkenkaskade → „CPL-Verlauf"; falsches Stat-Label („Live-Telemetrie · DSGVO" unter „6 Monate") → „Zeitraum"; Beispielrechnung auf der Startseite als solche gekennzeichnet; erfunden wirkendes Vergleichspaket „Regio+" neutralisiert.
- **Floskel-Abbau:** „Kostenlos & unverbindlich" (Hero-Note, Marktcheck-Card, Quiz-JS-Fineprint) durch konkrete Zusagen ersetzt (keine Zahlungsdaten, kein Abo, 48-h-Befund); Denglisch-Kicker im E3-Case („Believability", „True Insight") eingedeutscht.
- **FAQ-Qualität:** Startseiten-FAQ 1 beantwortet jetzt die eigene Frage nach der Dauer; Agentur-FAQ 1 ohne Keyword-Stuffing (Template + FAQPage-JSON-LD bleiben über `nexus_get_agentur_faq_items()` automatisch synchron); Marktcheck-Beschreibung über E3-Case und Solar-LP harmonisiert.
- **Kontakt-Hero:** spricht Nutzersprache statt Innen-Jargon („kompakter Flow") und nennt die 48-h-Rückmeldung.
- **Homepage-Description** um E3-Proof ergänzt (CPL 150 € → 22 €, via Canon interpoliert, 148 Zeichen).

## Neue Meta-Daten

| Seite | Title | Description |
|---|---|---|
| `/` | unverändert | **neu:** „Eigene Anfragen statt Portal-Leads: Marktcheck, Vorqualifizierung und Tracking für Solar- und Wärmepumpen-Anbieter. E3-Case: CPL von 150 € auf 22 €." |
| `/kontakt/` | „Kontakt & Projektanfrage \| Haşim Üner" (jetzt konsistent inkl. og:title) | **neu:** „Projekt oder Frage kurz einordnen: ein Formular, händisch geprüfte Rückmeldung innerhalb von 48 Stunden. Kein Pflicht-Call, kein Vertriebsteam." |
| Solar / Agentur / E3 | unverändert (bereits stark) | unverändert |

## QA

- `php -l` auf allen geänderten Dateien grün
- `pre-deploy-smoke`: ✅ SAFE TO PUSH (vorbestehende, bereits abgesicherte echo-Zeilen gemäß Konvention mit `// raw-ok` markiert)
- Banned-Term-Grep (BRAND_AND_COPY-Hard-Bans + Messaging-Canon + KI-Floskelliste): sauber
- Anker-/Tracking-Integrität: kein einziges `id=` oder `data-track`-Attribut im Diff
- Proof-Zahlen-Audit: alle Treffer sind Canon-Fallbacks oder vorbestehende konsistente Werte

## Manuelle Checks nach Merge (Deploy läuft automatisch via Actions)

1. Live prüfen, ob die Startseite einen **stale FAQPage-Node** aus altem Editor-Content emittiert (`_hu_faq_schema_entities_json`-Cache) — das Template selbst gibt kein FAQ-Schema aus.
2. `/kontakt/` im Quelltext: `<title>`, `og:title` und `meta description` müssen jetzt identisch ausgerichtet sein.
3. Marktcheck-Quiz auf der Solar-LP einmal durchklicken (Fineprint-Text geändert).
4. GSC-Recrawl für `/`, `/kontakt/` anstoßen (Description-Änderungen).

## Bewusst nicht gemacht

- Kein Full-Rewrite: die Seiten sind nach den jüngsten Überarbeitungen (Solar-LP v2, Agentur-Relaunch) strukturell und sprachlich bereits auf hohem Niveau; ein Neuschreiben hätte Churn und Risiko ohne Mehrwert erzeugt.
- Footer/Header-Microcopy, Blog-seitige Shared-Parts (`footer-cta.php`, `related-content.php`) und die Ads-LP `/solar-leads-kaufen-alternative/` als mögliche Follow-ups notiert.

https://claude.ai/code/session_01EomRtfgmGwkhwu5H35aGQf

---
_Generated by [Claude Code](https://claude.ai/code/session_01EomRtfgmGwkhwu5H35aGQf)_