### PR TITLE
SEO-Hebel aus dem Cockpit: Snippet-Fixes, Anker-Konzentration, DSGVO-/Anbieter-Intent

### DIFF
--- a/blocksy-child/inc/org-schema.php
+++ b/blocksy-child/inc/org-schema.php
@@ -755,8 +755,8 @@ function hu_output_schema()
                     ],
                     [
                         '@type'       => 'Offer',
-                        'name'        => 'Laufende WordPress-Betreuung',
-                        'description' => 'Wartung, Updates und kontrollierte Weiterentwicklung für etablierte WordPress-Systeme im Rahmen laufender Mandate.',
+                        'name'        => 'WordPress-Wartung in Hannover',
+                        'description' => 'Wartungsvertrag mit Updates, Monitoring und kontrollierter Weiterentwicklung für etablierte WordPress-Systeme im Rahmen laufender Mandate.',
                         'url'         => home_url('/wordpress-agentur-hannover/#wordpress-wartung'),
                     ],
                 ],

--- a/blocksy-child/inc/seo-meta.php
+++ b/blocksy-child/inc/seo-meta.php
@@ -171,6 +171,8 @@ function hu_get_category_archive_seo( $term = null ) {
  */
 function hu_get_forced_singular_seo_map() {
 	$e3_cpl_reduction = function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'cpl_reduction', 'display', 'über 85 %' ) : 'über 85 %';
+	$e3_cpl_before    = function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'cpl_before', 'display', '150 €' ) : '150 €';
+	$e3_cpl_after     = function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'cpl_after', 'display', '22 €' ) : '22 €';
 
 	return (array) apply_filters(
 		'hu_forced_singular_seo_map',
@@ -192,11 +194,11 @@ function hu_get_forced_singular_seo_map() {
 			// daher keine oeffentlichen Meta-Signale mehr.
 			'wordpress-agentur-hannover' => [
 				'title'       => 'WordPress Agentur Hannover für B2B-Anfragen',
-				'description' => 'WordPress Agentur Hannover für B2B-Websites, die Anfragen tragen müssen: technisches SEO, Tracking und CRO. Mit E3-Proof und Projektprüfung statt Standard-Relaunch.',
+				'description' => sprintf( 'WordPress Agentur Hannover für B2B-Anfragen: technisches SEO, Tracking, CRO. Erst Projektprüfung, dann Umsetzung — belegt am E3-Case (CPL %s → %s).', $e3_cpl_before, $e3_cpl_after ),
 			],
 			'wordpress-agentur' => [
 				'title'       => 'WordPress Agentur Hannover für B2B-Anfragen',
-				'description' => 'WordPress Agentur Hannover für B2B-Websites, die Anfragen tragen müssen: technisches SEO, Tracking und CRO. Mit E3-Proof und Projektprüfung statt Standard-Relaunch.',
+				'description' => sprintf( 'WordPress Agentur Hannover für B2B-Anfragen: technisches SEO, Tracking, CRO. Erst Projektprüfung, dann Umsetzung — belegt am E3-Case (CPL %s → %s).', $e3_cpl_before, $e3_cpl_after ),
 			],
 			'ergebnisse' => [
 				'title'       => 'Ergebnisse & Case Studies | WordPress, SEO, CRO',
@@ -231,7 +233,7 @@ function hu_get_forced_singular_seo_map() {
 			],
 			'solar-leads-kaufen-alternative' => [
 				'title'       => 'Solar Leads kaufen? Alternative ohne Portal-Abhängigkeit',
-				'description' => sprintf( 'Solar Leads kaufen oder eigene Anfragen aufbauen? Portal-Leads sind oft mehrfach verkauft. Der Marktcheck prüft, ob ein eigenes System den CPL senken kann – E3: %s.', $e3_cpl_reduction ),
+				'description' => sprintf( 'Solar Leads kaufen oder eigene Anfragen aufbauen? Portal-Leads werden mehrfach verkauft. Der Vergleich pro Anfrage — E3-Case: %s niedrigerer CPL.', $e3_cpl_reduction ),
 			],
 			'server-side-tracking-b2b' => [
 				'title'       => 'Server-Side Tracking für B2B-Leadgenerierung – DSGVO & CAPI',

--- a/blocksy-child/page-b2b-solar-leads.php
+++ b/blocksy-child/page-b2b-solar-leads.php
@@ -307,7 +307,7 @@ get_header();
 				   data-track-action="cta_money_page"
 				   data-track-category="b2b_solar_leads"
 				   data-track-section="final">
-					System & Methode ansehen
+					Leadgenerierung für Photovoltaik &amp; Wärmepumpe ansehen
 				</a>
 			</div>
 		</div>

--- a/blocksy-child/page-server-side-tracking-b2b.php
+++ b/blocksy-child/page-server-side-tracking-b2b.php
@@ -120,6 +120,10 @@ $faq = [
 		'question' => 'Welche CRMs werden unterstützt?',
 		'answer'   => 'Standardmäßig HubSpot, Brevo, Pipedrive und das hauseigene Nexus-CRM. Andere CRMs mit REST-API oder Webhook-Endpunkt lassen sich integrieren – das ist Teil der Integrationsphase.',
 	],
+	[
+		'question' => 'Server-Side-Tracking-Agentur oder Anbieter — worauf kommt es bei der Auswahl an?',
+		'answer'   => 'Auf drei Fragen: Läuft der sGTM-Container auf Ihrer eigenen Subdomain oder beim Dienstleister? Gehören GA4-, Meta- und Server-Zugänge Ihrem Betrieb? Gibt es eine dokumentierte Übergabe? Wer dreimal mit „beim Anbieter" antwortet, mietet seine eigene Datenebene. Hier gilt: Setup auf Ihrer Infrastruktur, alle Zugänge bei Ihnen, Dokumentation inklusive.',
+	],
 ];
 
 // ── Schema.org: Service + FAQPage + BreadcrumbList ───────────
@@ -176,7 +180,7 @@ get_header();
 				Server-Side Tracking: Volle Attribution trotz Cookieless, ITP und Ad-Blockern
 			</h1>
 			<p class="hu-intercept__lead">
-				Klassisches Client-Tracking verliert <strong>40 – 60 %</strong> der Conversions. Server-Side Tracking auf eigenem Server in Frankfurt liefert vollständige Daten an GA4 und Meta CAPI – DSGVO-konform mit Consent Mode v2. Grundlage für jede ehrliche Marketing-Entscheidung im B2B.
+				Klassisches Client-Tracking verliert <strong>30 – 60 %</strong> der Conversions. Server-Side Tracking auf eigenem Server in Frankfurt liefert vollständige Daten an GA4 und Meta CAPI – DSGVO-konform mit Consent Mode v2. Grundlage für jede ehrliche Marketing-Entscheidung im B2B.
 			</p>
 			<?php get_template_part( 'template-parts/seo-subpage-byline', null, [ 'template_path' => __FILE__ ] ); ?>
 			<div class="hu-intercept__cta">
@@ -248,7 +252,7 @@ get_header();
 
 	<section class="hu-intercept__faq" id="faq" aria-labelledby="hu-sst-faq-title">
 		<div class="hu-intercept__container">
-			<h2 class="hu-intercept__h2" id="hu-sst-faq-title">Häufige Fragen zu Server-Side Tracking</h2>
+			<h2 class="hu-intercept__h2" id="hu-sst-faq-title">Häufige Fragen: DSGVO, Kosten und Anbieter-Auswahl</h2>
 			<div class="hu-intercept__faq-list">
 				<?php foreach ( $faq as $item ) : ?>
 					<details class="hu-intercept__faq-item">

--- a/blocksy-child/page-solar-waermepumpen-leadgenerierung.php
+++ b/blocksy-child/page-solar-waermepumpen-leadgenerierung.php
@@ -230,7 +230,7 @@ $deeper_clusters = [
 		'group' => 'Funnel & Tracking',
 		'items' => [
 			[ 't' => 'Lead-Funnel Solar',                    's' => 'Fünf Stufen einer belastbaren Solar-Funnel-Architektur.',          'url' => home_url( '/lead-funnel-solar/' ) ],
-			[ 't' => 'Server-Side Tracking für B2B',         's' => 'GA4, Meta CAPI und Consent Mode v2 auf eigenem Server.',           'url' => home_url( '/server-side-tracking-b2b/' ) ],
+			[ 't' => 'Server-Side Tracking für B2B',         's' => 'GA4, Meta CAPI und Consent Mode v2 — DSGVO-konform auf eigenem Server.', 'url' => home_url( '/server-side-tracking-b2b/' ) ],
 		],
 	],
 	[

--- a/blocksy-child/page-wordpress-agentur.php
+++ b/blocksy-child/page-wordpress-agentur.php
@@ -33,7 +33,7 @@ $agentur_solar_deeper = [
 	],
 	[
 		't'   => 'Server-Side Tracking für B2B',
-		's'   => 'GA4, Meta CAPI und Consent Mode v2 auf eigenem Server – Grundlage sauberer Attribution.',
+		's'   => 'GA4, Meta CAPI und Consent Mode v2 — DSGVO-konform auf eigenem Server, Grundlage sauberer Attribution.',
 		'url' => home_url( '/server-side-tracking-b2b/' ),
 	],
 	[
@@ -356,7 +356,7 @@ get_header();
 			<a class="wp-agentur-intent-card" href="#technisches-seo" data-track-action="cta_intent_technical_seo" data-track-category="navigation" data-track-section="wordpress_agentur_hannover">
 				<span class="wp-agentur-intent-card__kicker">SEO &amp; Technik</span>
 				<h3>Technisches SEO, Core Web Vitals und saubere Seitenarchitektur</h3>
-				<p>Für WordPress-Seiten, die bereits Nachfrage sehen, aber bei Position, Klickrate oder Seitentiefe hängen bleiben.</p>
+				<p>WordPress-Suchmaschinenoptimierung für Seiten, die bereits Nachfrage sehen, aber bei Position, Klickrate oder Seitentiefe hängen bleiben.</p>
 			</a>
 			<a class="wp-agentur-intent-card" href="<?php echo esc_url( home_url( '/server-side-tracking-b2b/' ) ); ?>" data-track-action="cta_intent_tracking" data-track-category="navigation" data-track-section="wordpress_agentur_hannover">
 				<span class="wp-agentur-intent-card__kicker">Messbarkeit</span>
@@ -792,8 +792,8 @@ get_header();
 				<p>Persönliche Reviews, Workshops und Strategie-Sessions in Pattensen bei Hannover — oder remote im DACH-Raum.</p>
 			</div>
 			<div class="wp-agentur-local-card" id="wordpress-wartung">
-				<h3>Laufende WordPress-Betreuung</h3>
-				<p>Für Bestandskunden mit etabliertem WordPress-System: Wartung, Updates und Weiterentwicklung im Rahmen laufender Mandate.</p>
+				<h3>WordPress-Wartung in Hannover</h3>
+				<p>Für Bestandskunden mit etabliertem WordPress-System: Wartungsvertrag mit Updates, Monitoring und Weiterentwicklung im Rahmen laufender Mandate.</p>
 			</div>
 		</div>
 

--- a/blocksy-child/template-parts/related-content.php
+++ b/blocksy-child/template-parts/related-content.php
@@ -45,7 +45,7 @@ if ( 'post' === $related_type && is_singular( 'post' ) && ! empty( $category_ids
 
 	$primary_link_map = [
 		'solar-waermepumpen-anfrage-systeme' => [
-			'label' => __( 'Anfrage-Systeme ansehen', 'blocksy-child' ),
+			'label' => __( 'Leadgenerierung für Photovoltaik & Wärmepumpe', 'blocksy-child' ),
 			'url'   => function_exists( 'nexus_get_energy_systems_url' ) ? nexus_get_energy_systems_url() : home_url( '/solar-waermepumpen-leadgenerierung/' ),
 			'text'  => __( 'Passender System-Einstieg:', 'blocksy-child' ),
 		],


### PR DESCRIPTION
## Was dieser PR macht

Setzt die P1/P2-Findings aus dem SEO Cockpit (28-Tage-Fenster, Stand 11.06.2026) als fünf priorisierte Hebel um. Kleine, risikoarme Änderungen: Snippets, Anker-Konzentration, Intent-Abdeckung — keine neuen Seiten, kein Umbau.

## Hebel im Detail

### H1 — Agentur-Snippet (Cockpit P1·86 + P1·83: `description_long`)
Seite mit den meisten Impressionen der Site (454, Pos. 32,6, CTR 0,2 %). Description war 167 Zeichen und wurde in den SERPs abgeschnitten.
**Neu (152 Zeichen, CPL via `hu_e3_metric()` interpoliert):**
> „WordPress Agentur Hannover für B2B-Anfragen: technisches SEO, Tracking, CRO. Erst Projektprüfung, dann Umsetzung — belegt am E3-Case (CPL 150 € → 22 €)."

### H2 — `/solar-leads-kaufen-alternative/` (Pos. 18,9 = Striking Distance)
Description von 175 auf 152 Zeichen, Kaufen-vs-Aufbauen-Intent vorn:
> „Solar Leads kaufen oder eigene Anfragen aufbauen? Portal-Leads werden mehrfach verkauft. Der Vergleich pro Anfrage — E3-Case: über 85 % niedrigerer CPL."

### H3 — Kannibalisierung „leadgenerierung photovoltaik" (P3·52)
Primärziel: `/solar-waermepumpen-leadgenerierung/`. Keyword-Anker „Leadgenerierung für Photovoltaik & Wärmepumpe" im Related-Content-Kategorie-Mapping (`template-parts/related-content.php`) und als Rück-Link von `/b2b-solar-leads/`.

### H4 — `/server-side-tracking-b2b/` (P2·73: 214 Impr., Pos. 64,4)
Query-Cluster verlangt „DSGVO" + „Agentur/Anbieter": neue FAQ „Server-Side-Tracking-Agentur oder Anbieter — worauf kommt es bei der Auswahl an?" (speist das FAQPage-Schema automatisch über das `$faq`-Array), FAQ-H2 trägt DSGVO sichtbar, verweisende Deeper-Anker auf Solar-LP und Agentur-Seite sagen „DSGVO-konform". Bonus: Hero (40–60 %) und FAQ (30–60 %) widersprachen sich bei der Tracking-Verlustquote → harmonisiert auf 30–60 %.

### H5 — Striking-Distance-Subqueries der Agentur-Seite
„wordpress wartung hannover" (18,9), „wartungsvertrag" (22,3), „suchmaschinenoptimierung hannover" (19,2) fehlten in Headings:
- H3 der `#wordpress-wartung`-Karte: „WordPress-Wartung in Hannover", Body nennt „Wartungsvertrag"; zugehöriges Schema-Offer in `org-schema.php` synchronisiert.
- „WordPress-Suchmaschinenoptimierung" in der SEO-Intent-Card.

## Bewusst nicht bedient

- „woocommerce agentur hannover" (71 Impr.): kollidiert mit der Abgrenzung (keine Shop-Projekte).
- Handels-Intent („photovoltaik b2b lösung/shop") auf `/b2b-solar-leads/`: falscher Intent, Seite wird nicht verbogen.
- Eigene Wärmepumpen-LP (15 Impr., Pos. 45,5): Datenlage zu dünn — Kandidat für später, erst Solar-Cluster konsolidieren.

## QA

- `php -l` auf allen 7 geänderten Dateien grün; `pre-deploy-smoke` ✅ SAFE TO PUSH
- Anker-IDs und `data-track`-Attribute unverändert (nur Heading-/Anker-**Texte**)
- Beide neuen Descriptions exakt 152 Zeichen (belegt per `mb_strlen`)
- Banned-Term-Grep (Brand-Canon + Floskelliste) sauber
- FAQ-Schema-Sync: neue FAQ läuft über dasselbe Quell-Array wie das Accordion

## Manuelle Schritte nach Merge (Deploy via Actions)

1. Blog-Post `/photovoltaik-leads-kaufen-alternative/` (editor-owned): früh im Text Link auf die Solar-LP mit Anker „Leadgenerierung Photovoltaik ohne Portale"; Post auf den Kauf-Intent fokussiert halten.
2. GSC-Recrawl: `/wordpress-agentur-hannover/`, `/solar-leads-kaufen-alternative/`, `/server-side-tracking-b2b/`.
3. CRM: Lead „Byldtech" nachfassen (Cockpit P2·62, fällig 28.05.) — wertvollster Eintrag im ganzen Board.

https://claude.ai/code/session_01EomRtfgmGwkhwu5H35aGQf

---
_Generated by [Claude Code](https://claude.ai/code/session_01EomRtfgmGwkhwu5H35aGQf)_