### PR TITLE
SEO-Cockpit-Hebel: Solar-Proof, Kannibalisierung, Koko-Beobachtbarkeit, Offpage-Hannover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 2026-06
 
+### Solar-Proof früher, Cluster-Hublink & Koko-Cockpit-Beobachtbarkeit
+
+- `/solar-waermepumpen-leadgenerierung/`: kompakter **Proof-Bar** direkt unter Hero/Trust-Strip (E3-Kennzahlen 150 €→22 €, 1.750+, 12 %, über 85 % als Teaser → `#ergebnisse`), damit der Umsatzbeleg nicht erst bei ~73 % Scrolltiefe sichtbar wird; Kontextzeile macht die CPL-Zahl belegbar statt kontextlos. Funnel und Marktcheck-Formular unverändert.
+- Sekundärer, risikoärmerer CTA an der Fit-Sektion („Erst den E3-Case ansehen" → `#ergebnisse`) neben dem primären Marktcheck-CTA — für Besucher, die noch nicht intake-bereit sind.
+- Kannibalisierung „leadgenerierung photovoltaik": Cluster-Subpages setzen jetzt einen term-nahen **Einbahn-Hublink** zurück auf die Money Page (`hu_render_solar_cluster_links()`), um das Signal auf dem Hub zu bündeln (Hub → Cluster bestand bereits über die Vertiefung-Sektion).
+- SEO-Cockpit / Koko: **Live-Selbsttest** in der Diagnostik (HTTP-Status + Roh-Body + normalisiertes Ergebnis für die aktuelle Range), Koko-Fehler werden **nicht mehr als 0/0 gecacht** (kein eingefrorener Cron-Fehler überdeckt echte Daten), und „Cache bis n/a" zeigt bei Sync-Fehler einen interpretierbaren Status. Macht den 0/0-Bug diagnostizierbar — die sichtbare „0 zurück"-Note belegt ein erfolgreiches 200→0/0 (Range/Param/Shape), keinen Permission-Fehler.
+
 ### Solar-Landingpage v2: Ink/Creme-Redesign + Marktcheck-CRO
 
 - `/solar-waermepumpen-leadgenerierung/` komplett auf das geteilte `.hu-hp`-Brand-System umgestellt (Ink `#0B0F12` im Wechsel mit Creme-Sektionen, Kupfer `#E08A3C`) — Basis ist der Claude-Design-Handoff „Solar-Leadgenerierung v2"; `homepage-redesign.css` wird wiederverwendet, das Page-CSS ist nur noch ein schlankes Delta (~3.100 → ~950 Zeilen).

--- a/blocksy-child/assets/css/solar-leadgenerierung-solara.css
+++ b/blocksy-child/assets/css/solar-leadgenerierung-solara.css
@@ -622,6 +622,77 @@
   flex-shrink: 0;
 }
 
+/* ─── 5b) Proof-Bar (E3-Kennzahlen früh, Teaser → #ergebnisse) ─ */
+.solara-landing .sol-proofbar {
+  border-bottom: 1px solid var(--line);
+  padding: 22px 0;
+  background: var(--bg);
+}
+.solara-landing .sol-proofbar-inner {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 16px 32px;
+  justify-content: space-between;
+}
+.solara-landing .sol-proofbar-eyebrow {
+  flex-shrink: 0;
+  font-size: 10.5px;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+.solara-landing .sol-proofbar-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px 30px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  flex: 1;
+  justify-content: center;
+}
+.solara-landing .sol-proofbar-stats li {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.solara-landing .sol-proofbar-num {
+  font-family: 'Satoshi', 'Figtree', sans-serif;
+  font-size: 19px;
+  font-weight: 800;
+  line-height: 1.1;
+  color: var(--fg-2);
+  white-space: nowrap;
+}
+.solara-landing .sol-proofbar-num-accent { color: var(--accent); }
+.solara-landing .sol-proofbar-lbl {
+  font-size: 10px;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+}
+.solara-landing .sol-proofbar-link {
+  flex-shrink: 0;
+  font-size: 11.5px;
+  letter-spacing: .04em;
+  color: var(--accent);
+  white-space: nowrap;
+  transition: opacity .15s;
+}
+.solara-landing .sol-proofbar-link:hover { opacity: .78; }
+.solara-landing .sol-proofbar-context {
+  margin: 12px 0 0;
+  font-size: 10.5px;
+  letter-spacing: .04em;
+  color: var(--fg-4);
+  text-align: center;
+}
+@media (max-width: 820px) {
+  .solara-landing .sol-proofbar-inner { justify-content: center; }
+  .solara-landing .sol-proofbar-stats { justify-content: center; }
+}
+
 /* ─── 6) Sticky Section-Nav ─────────────────────────────────── */
 .solara-landing .sol-section-nav {
   position: sticky;
@@ -744,6 +815,12 @@
   align-items: flex-start;
   gap: 12px;
   margin-top: 30px;
+}
+.solara-landing .sol-section-cta-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
 }
 .solara-landing .sol-section-cta-micro {
   font-size: 10.5px;

--- a/blocksy-child/inc/helpers.php
+++ b/blocksy-child/inc/helpers.php
@@ -1265,6 +1265,7 @@ add_action( 'init', 'nexus_maybe_ensure_qualifizierte_pv_anfragen_page', 27 );
 function nexus_get_legacy_offer_redirect_map() {
 	$agentur_url = nexus_get_primary_public_url( 'agentur', home_url( '/wordpress-agentur-hannover/' ) );
 	$request_url = nexus_get_primary_request_url();
+	$energy_url  = nexus_get_energy_systems_url();
 
 	return [
 		// High-probability external entry paths. Internal/historical tool,
@@ -1276,6 +1277,10 @@ function nexus_get_legacy_offer_redirect_map() {
 		'/wordpress-tech-audit/'     => $request_url,
 		'/wordpress-agentur/'        => $agentur_url,
 		'/alle-loesungen-im-detail/' => nexus_get_page_url( [ 'alle-loesungen' ], home_url( '/alle-loesungen/' ) ),
+		// Retired (Entwurf) Blog-Slug: 301 auf die Solar-Money-Page, damit
+		// nachlaufende Impressionen/Backlinks das Hub-Signal stützen statt zu
+		// kannibalisieren oder ins Leere (404) zu laufen.
+		'/photovoltaik-leads-kaufen-alternative/' => $energy_url,
 	];
 }
 

--- a/blocksy-child/inc/seo-cockpit/seo-cockpit-diagnostics.php
+++ b/blocksy-child/inc/seo-cockpit/seo-cockpit-diagnostics.php
@@ -125,6 +125,39 @@ function nexus_get_seo_cockpit_diagnostics( $detail_url = '' ) {
 		(string) ( $koko['label'] ?? 'Koko-Status unbekannt.' )
 	);
 
+	// Live-Selbsttest: zeigt, was Koko für genau die Cockpit-Range zurückgibt.
+	// Entlarvt, ob 0/0 ein erfolgreiches leeres 200 (Range/Param/Shape) oder
+	// ein Fehler ist — nur für berechtigte Verwalter, da uncached.
+	if (
+		nexus_current_user_can_manage_seo_cockpit()
+		&& ! empty( $koko['rest_available'] )
+		&& function_exists( 'nexus_seo_cockpit_koko_probe' )
+		&& function_exists( 'nexus_get_seo_cockpit_date_ranges' )
+		&& function_exists( 'nexus_get_seo_cockpit_requested_range_days' )
+	) {
+		$probe_ranges = nexus_get_seo_cockpit_date_ranges( nexus_get_seo_cockpit_requested_range_days() );
+		$probe        = nexus_seo_cockpit_koko_probe( (string) $probe_ranges['current_start'], (string) $probe_ranges['current_end'] );
+		$probe_views  = (float) ( $probe['normalized']['pageviews'] ?? 0 );
+		$probe_vis    = (float) ( $probe['normalized']['visitors'] ?? 0 );
+		$probe_raw    = (string) ( $probe['raw'] ?? '' );
+		$probe_raw    = function_exists( 'mb_substr' ) ? mb_substr( $probe_raw, 0, 200 ) : substr( $probe_raw, 0, 200 );
+
+		$checks[] = nexus_build_seo_cockpit_diagnostic(
+			'koko',
+			'Koko-Selbsttest (live)',
+			( ! empty( $probe['ok'] ) && ( $probe_views > 0 || $probe_vis > 0 ) ) ? 'ok' : 'warning',
+			sprintf(
+				'HTTP %d · Range %s–%s · normalisiert: %s Besucher / %s Aufrufe · Roh-Body: %s',
+				(int) ( $probe['status_code'] ?? 0 ),
+				(string) $probe_ranges['current_start'],
+				(string) $probe_ranges['current_end'],
+				(string) round( $probe_vis ),
+				(string) round( $probe_views ),
+				'' !== $probe_raw ? $probe_raw : '(leer)'
+			)
+		);
+	}
+
 	$checks[] = nexus_build_seo_cockpit_diagnostic(
 		'links',
 		'Interner Linkgraph',

--- a/blocksy-child/inc/seo-cockpit/seo-cockpit-koko.php
+++ b/blocksy-child/inc/seo-cockpit/seo-cockpit-koko.php
@@ -379,13 +379,19 @@ function nexus_get_seo_cockpit_koko_totals( $start, $end ) {
 		]
 	);
 
-	$totals = is_wp_error( $response ) ? [
-		'visitors'  => 0.0,
-		'pageviews' => 0.0,
-		'pages'     => 0,
-		'error'     => $response->get_error_message(),
-	] : nexus_normalize_seo_cockpit_koko_totals( $response );
+	if ( is_wp_error( $response ) ) {
+		// Fehler bewusst NICHT cachen: sonst friert ein im Cron (ohne
+		// User-Kontext) entstandener Fehler die 0/0-Antwort für eine Stunde
+		// ein und überdeckt echte Daten beim nächsten Admin-Aufruf.
+		return [
+			'visitors'  => 0.0,
+			'pageviews' => 0.0,
+			'pages'     => 0,
+			'error'     => $response->get_error_message(),
+		];
+	}
 
+	$totals = nexus_normalize_seo_cockpit_koko_totals( $response );
 	set_transient( $cache_key, $totals, HOUR_IN_SECONDS );
 
 	return $totals;
@@ -414,8 +420,11 @@ function nexus_get_seo_cockpit_koko_series( $start, $end ) {
 		]
 	);
 
-	$series = is_wp_error( $response ) ? nexus_normalize_seo_cockpit_koko_date_series( $start, $end, [] ) : nexus_normalize_seo_cockpit_koko_date_series( $start, $end, $response );
+	if ( is_wp_error( $response ) ) {
+		return nexus_normalize_seo_cockpit_koko_date_series( $start, $end, [] );
+	}
 
+	$series = nexus_normalize_seo_cockpit_koko_date_series( $start, $end, $response );
 	set_transient( $cache_key, $series, HOUR_IN_SECONDS );
 
 	return $series;
@@ -450,8 +459,11 @@ function nexus_get_seo_cockpit_koko_posts( $start, $end, $limit = 10, $params = 
 		)
 	);
 
-	$posts = is_wp_error( $response ) ? [] : nexus_normalize_seo_cockpit_koko_posts( $response, $limit );
+	if ( is_wp_error( $response ) ) {
+		return [];
+	}
 
+	$posts = nexus_normalize_seo_cockpit_koko_posts( $response, $limit );
 	set_transient( $cache_key, $posts, HOUR_IN_SECONDS );
 
 	return $posts;
@@ -607,4 +619,56 @@ function nexus_get_seo_cockpit_koko_detail_data( $url, $context, $ranges ) {
 	}
 
 	return $detail;
+}
+
+/**
+ * Run an uncached, live Koko totals probe for cockpit diagnostics.
+ *
+ * Spiegelt exakt die Parameter der regulären Totals-Abfrage, damit der
+ * Selbsttest sichtbar macht, was Koko für genau diese Range zurückgibt
+ * (HTTP-Status + Roh-Body + normalisiertes Ergebnis) — ohne den
+ * Stunden-Cache zu treffen. Nur für berechtigte Admins gedacht.
+ *
+ * @param string $start Start date (Y-m-d).
+ * @param string $end   End date (Y-m-d).
+ * @return array<string, mixed>
+ */
+function nexus_seo_cockpit_koko_probe( $start, $end ) {
+	$status = nexus_get_koko_analytics_status();
+	$route  = nexus_get_seo_cockpit_koko_route( 'totals' );
+	$params = [
+		'start_date' => (string) $start,
+		'end_date'   => (string) $end,
+	];
+
+	$result = [
+		'ok'          => false,
+		'status_code' => 0,
+		'route'       => $route,
+		'params'      => $params,
+		'raw'         => '',
+		'normalized'  => [
+			'visitors'  => 0.0,
+			'pageviews' => 0.0,
+			'pages'     => 0,
+		],
+		'message'     => (string) ( $status['label'] ?? '' ),
+	];
+
+	if ( empty( $status['rest_available'] ) || '' === $route || ! function_exists( 'rest_do_request' ) ) {
+		return $result;
+	}
+
+	$request = new WP_REST_Request( 'GET', $route );
+	$request->set_query_params( $params );
+
+	$response               = rest_do_request( $request );
+	$result['status_code']  = (int) $response->get_status();
+	$data                   = $response->get_data();
+	$result['ok']           = $result['status_code'] >= 200 && $result['status_code'] < 300;
+	$result['raw']          = (string) wp_json_encode( $data );
+	$result['normalized']   = nexus_normalize_seo_cockpit_koko_totals( $data );
+	$result['message']      = '';
+
+	return $result;
 }

--- a/blocksy-child/inc/seo-cockpit/seo-cockpit-ui.php
+++ b/blocksy-child/inc/seo-cockpit/seo-cockpit-ui.php
@@ -1240,7 +1240,15 @@ function nexus_render_seo_cockpit_dashboard() {
 			</div>
 			<div class="nexus-seo-cockpit__strip-cell">
 				<strong>Cache bis</strong>
-				<span><?php echo esc_html( ! empty( $runtime['cache_expires_at'] ) ? wp_date( 'd.m.Y H:i', (int) $runtime['cache_expires_at'] ) : 'n/a' ); ?></span>
+				<span><?php
+				if ( ! empty( $runtime['cache_expires_at'] ) ) {
+					echo esc_html( wp_date( 'd.m.Y H:i', (int) $runtime['cache_expires_at'] ) );
+				} elseif ( 'error' === (string) ( $runtime['last_sync_status'] ?? '' ) ) {
+					echo esc_html( 'letzter Sync fehlgeschlagen' );
+				} else {
+					echo esc_html( 'n/a' );
+				}
+				?></span>
 			</div>
 			<div class="nexus-seo-cockpit__strip-cell">
 				<strong>Koko Analytics</strong>
@@ -1419,7 +1427,7 @@ function nexus_render_seo_cockpit_dashboard() {
 									$primary = is_array( $page['primary'] ?? null ) ? $page['primary'] : [];
 									$lead_page = is_array( $lead_snapshot['page_map'][ (string) $page['url'] ] ?? null ) ? $lead_snapshot['page_map'][ (string) $page['url'] ] : [];
 									?>
-									<tr<?php echo $index >= $problem_visible ? ' class="nexus-seo-cockpit__row--extra"' : ''; ?>>
+									<tr<?php echo $index >= $problem_visible ? ' class="nexus-seo-cockpit__row--extra"' : ''; // raw-ok static class string ?>>
 										<td>
 											<span class="nexus-seo-cockpit__badge is-<?php echo esc_attr( (string) ( $primary['priority_bucket'] ?? 'low' ) ); ?>">
 												<?php
@@ -1556,7 +1564,7 @@ function nexus_render_seo_cockpit_dashboard() {
 										$wp_label = nexus_get_seo_cockpit_page_role_label( nexus_get_seo_cockpit_page_role( $context, $url ) );
 									}
 									?>
-									<tr<?php echo $index >= $tp_visible ? ' class="nexus-seo-cockpit__row--extra"' : ''; ?>>
+									<tr<?php echo $index >= $tp_visible ? ' class="nexus-seo-cockpit__row--extra"' : ''; // raw-ok static class string ?>>
 										<td class="nexus-seo-cockpit__cell--url"><a href="<?php echo esc_url( nexus_get_seo_cockpit_detail_url( $url ) ); ?>" title="<?php echo esc_attr( $url ); ?>"><?php echo esc_html( nexus_get_seo_cockpit_short_url( $url ) ); ?></a></td>
 										<td><?php echo esc_html( number_format_i18n( (float) ( $row['clicks'] ?? 0 ) ) ); ?></td>
 										<td><?php echo esc_html( number_format_i18n( (float) ( $row['impressions'] ?? 0 ) ) ); ?></td>
@@ -1620,7 +1628,7 @@ function nexus_render_seo_cockpit_dashboard() {
 							</thead>
 							<tbody>
 								<?php foreach ( $tq_rows as $index => $row ) : ?>
-									<tr<?php echo $index >= $tq_visible ? ' class="nexus-seo-cockpit__row--extra"' : ''; ?>>
+									<tr<?php echo $index >= $tq_visible ? ' class="nexus-seo-cockpit__row--extra"' : ''; // raw-ok static class string ?>>
 										<td><strong><?php echo esc_html( nexus_get_seo_cockpit_row_label( $row ) ); ?></strong></td>
 										<td><?php echo esc_html( number_format_i18n( (float) ( $row['clicks'] ?? 0 ) ) ); ?></td>
 										<td><?php echo esc_html( number_format_i18n( (float) ( $row['impressions'] ?? 0 ) ) ); ?></td>
@@ -1665,7 +1673,7 @@ function nexus_render_seo_cockpit_dashboard() {
 									</thead>
 									<tbody>
 										<?php foreach ( $koko_pages_rows as $index => $row ) : ?>
-											<tr<?php echo $index >= $koko_pages_visible ? ' class="nexus-seo-cockpit__row--extra"' : ''; ?>>
+											<tr<?php echo $index >= $koko_pages_visible ? ' class="nexus-seo-cockpit__row--extra"' : ''; // raw-ok static class string ?>>
 												<td class="nexus-seo-cockpit__cell--url">
 													<?php if ( ! empty( $row['url'] ) ) : ?>
 														<a href="<?php echo esc_url( nexus_get_seo_cockpit_detail_url( (string) $row['url'] ) ); ?>" title="<?php echo esc_attr( (string) $row['url'] ); ?>"><?php echo esc_html( (string) ( ! empty( $row['title'] ) ? $row['title'] : nexus_get_seo_cockpit_short_url( (string) $row['url'] ) ) ); ?></a>
@@ -1938,7 +1946,7 @@ function nexus_render_seo_cockpit_quick_wins_table( $rows, $limit = 5 ) {
 			<tbody>
 				<?php foreach ( $rows as $index => $row ) : ?>
 					<?php $delta = nexus_get_seo_cockpit_metric_delta( 'clicks', (float) ( $row['clicks'] ?? 0 ), (float) ( $row['prev_clicks'] ?? 0 ) ); ?>
-					<tr<?php echo $index >= $limit ? ' class="nexus-seo-cockpit__row--extra"' : ''; ?>>
+					<tr<?php echo $index >= $limit ? ' class="nexus-seo-cockpit__row--extra"' : ''; // raw-ok static class string ?>>
 						<td><strong><?php echo esc_html( (string) $row['query'] ); ?></strong></td>
 						<td class="nexus-seo-cockpit__cell--url"><a href="<?php echo esc_url( (string) ( $row['detail_url'] ?? '' ) ); ?>"><?php echo esc_html( nexus_get_seo_cockpit_short_url( (string) $row['page'] ) ); ?></a></td>
 						<td><?php echo esc_html( number_format_i18n( (float) $row['impressions'] ) ); ?></td>

--- a/blocksy-child/inc/seo-subpage-cluster-links.php
+++ b/blocksy-child/inc/seo-subpage-cluster-links.php
@@ -122,6 +122,13 @@ function hu_render_solar_cluster_links() {
 	if ( empty( $links ) ) {
 		return;
 	}
+
+	// Einbahn-Hublink: jede Cluster-Seite verweist mit term-nahem Anker
+	// zurück auf die Money Page, um „leadgenerierung photovoltaik" dort zu
+	// bündeln (Hub → Cluster existiert bereits über die Vertiefung-Sektion).
+	$hub_url = function_exists( 'nexus_get_energy_systems_url' )
+		? nexus_get_energy_systems_url()
+		: home_url( '/solar-waermepumpen-leadgenerierung/' );
 	?>
 	<section class="related-content seo-cluster-links" aria-label="Weiterführende Themen im Solar-Cluster" data-track-section="solar_cluster_links">
 		<div class="related-content__head">
@@ -129,6 +136,14 @@ function hu_render_solar_cluster_links() {
 			<h2 class="related-content__heading"><?php esc_html_e( 'Passende Themen im Solar- & Wärmepumpen-Cluster', 'blocksy-child' ); ?></h2>
 		</div>
 		<ul class="seo-cluster-links__list">
+			<li class="seo-cluster-links__item seo-cluster-links__item--hub">
+				<a class="seo-cluster-links__link seo-cluster-links__link--hub"
+				   href="<?php echo esc_url( $hub_url ); ?>"
+				   data-track-action="solar_cluster_to_hub_click"
+				   data-track-category="internal_link">
+					<?php esc_html_e( 'Leadgenerierung für Photovoltaik & Wärmepumpe', 'blocksy-child' ); ?>
+				</a>
+			</li>
 			<?php foreach ( $links as $link ) : ?>
 				<li class="seo-cluster-links__item">
 					<a class="seo-cluster-links__link"

--- a/blocksy-child/page-solar-waermepumpen-leadgenerierung.php
+++ b/blocksy-child/page-solar-waermepumpen-leadgenerierung.php
@@ -604,6 +604,41 @@ get_header();
 		</section>
 
 		<!-- ════════════════════════════════════════════════════════════
+		     PROOF-BAR — E3-Kennzahlen früh sichtbar (Teaser → #ergebnisse)
+		     ════════════════════════════════════════════════════════════ -->
+		<section class="sol-proofbar" aria-label="Belegte Ergebnisse aus dem <?php echo esc_attr( $e3_case_label ); ?>-Case" data-track-section="proof_bar">
+			<div class="hu-container">
+				<div class="sol-proofbar-inner">
+					<span class="sol-proofbar-eyebrow sol-mono">Belegt · <?php echo esc_html( $e3_case_label ); ?></span>
+					<ul class="sol-proofbar-stats">
+						<li>
+							<span class="sol-proofbar-num"><?php echo esc_html( $e3_cpl_before ); ?> → <span class="sol-proofbar-num-accent"><?php echo esc_html( $e3_cpl_after ); ?></span></span>
+							<span class="sol-proofbar-lbl">CPL pro Anfrage</span>
+						</li>
+						<li>
+							<span class="sol-proofbar-num"><?php echo esc_html( $e3_lead_count ); ?></span>
+							<span class="sol-proofbar-lbl">Qualifizierte Anfragen</span>
+						</li>
+						<li>
+							<span class="sol-proofbar-num"><?php echo esc_html( $e3_sales_conversion ); ?></span>
+							<span class="sol-proofbar-lbl">Abschluss · Anfrage → Vertrag</span>
+						</li>
+						<li>
+							<span class="sol-proofbar-num sol-proofbar-num-accent"><?php echo esc_html( $e3_cpl_reduction ); ?></span>
+							<span class="sol-proofbar-lbl">Weniger Kosten pro Anfrage</span>
+						</li>
+					</ul>
+					<a class="sol-proofbar-link sol-mono" href="#ergebnisse"
+						data-track-action="cta_solar_proofbar_to_results"
+						data-track-category="proof"
+						data-track-section="proof_bar"
+					>Wie die Zahlen zustande kommen →</a>
+				</div>
+				<p class="sol-proofbar-context sol-mono">Ein realer Fall über <?php echo esc_html( $e3_timeframe ); ?>, eigener Anfrageweg statt Portal-Leads — dokumentiert, keine pauschale Übertragbarkeitsgarantie.</p>
+			</div>
+		</section>
+
+		<!-- ════════════════════════════════════════════════════════════
 		     STICKY IN-PAGE SECTION NAV
 		     Wird nach dem Hero sticky · CRO: schnelle Orientierung,
 		     ohne den globalen Header zu ersetzen (SEO/Brand bleibt).
@@ -948,15 +983,25 @@ get_header();
 					</article>
 				</div>
 				<div class="sol-section-cta">
-					<a class="hu-btn hu-btn-primary" href="#marktcheck"
-						data-track-action="cta_solar_fit_to_intake"
-						data-track-category="lead_gen"
-						data-track-section="fit_check"
-						data-track-funnel-stage="intake_open"
-					>
-						<span>Marktcheck beantragen</span>
-						<?php echo $arrow_svg; // raw-ok phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-					</a>
+					<div class="sol-section-cta-actions">
+						<a class="hu-btn hu-btn-primary" href="#marktcheck"
+							data-track-action="cta_solar_fit_to_intake"
+							data-track-category="lead_gen"
+							data-track-section="fit_check"
+							data-track-funnel-stage="intake_open"
+						>
+							<span>Marktcheck beantragen</span>
+							<?php echo $arrow_svg; // raw-ok phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+						</a>
+						<a class="hu-btn hu-btn-ghost" href="#ergebnisse"
+							data-track-action="cta_solar_fit_to_results"
+							data-track-category="proof"
+							data-track-section="fit_check"
+						>
+							Erst den <?php echo esc_html( $e3_case_label ); ?>-Case ansehen
+							<?php echo $arrow_svg; // raw-ok phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+						</a>
+					</div>
 					<div class="sol-section-cta-micro sol-mono">Regions-Verfügbarkeitsprüfung · Manuelle Erst-Analyse · Fit-Entscheid mit drei Hebeln</div>
 				</div>
 			</div>

--- a/docs/seo/offpage-authority-playbook.md
+++ b/docs/seo/offpage-authority-playbook.md
@@ -102,6 +102,39 @@ Ziel: bestehende Assets aktiv für Linkaufbau nutzen, Crawl-Frequenz erhöhen.
 
 ---
 
+## Lokaler Track — „WordPress Agentur Hannover" (parallel zum Solar-Track)
+
+Für das lokale Commercial-Keyword **„wordpress agentur hannover"** (aktuell Pos ~32) wirkt ein anderer Hebel als bei den Solar-Begriffen: nicht topische Solar-Links, sondern **lokale Entitäts- und Citation-Signale**. Die Money-Page (`/wordpress-agentur-hannover/`) ist on-page fertig (LocalBusiness-Schema mit Geo/NAP, H1 trifft den Term, Standort-Sektion). Es fehlt die **externe lokale Bestätigung**.
+
+### L1 — Google Business Profil (lokal, höchste Priorität)
+
+- Dasselbe GBP wie in Phase 1.1, aber **lokal optimiert**: Primärkategorie „Webdesigner" bzw. „Internetmarketing-Dienst", Sekundär „Werbeagentur".
+- Als Service-Area-Business: **Hannover + Region Hannover** explizit als Einzugsgebiet hinterlegen (deckt sich mit `areaServed` im Schema).
+- Beschreibung mit „WordPress-Agentur in Hannover für B2B-Anfrage-Systeme", Link auf `/wordpress-agentur-hannover/` (nicht nur die Solar-Page).
+- Erste 3–5 echte Kunden-/Partner-Bewertungen — lokaler Trust-Faktor Nr. 1.
+
+### L2 — Lokale & Branchen-Citations (NAP zeichengenau aus `/impressum/`)
+
+Dieselbe kanonische NAP-Schreibweise (Firmierung · Pattensen/Region Hannover · `/wordpress-agentur-hannover/`) in:
+
+- **Regional:** Branchenbuch Region Hannover, Das Örtliche / Gelbe Seiten Hannover, regionale B2B-/Mittelstandsverzeichnisse.
+- **IHK Hannover:** Mitglieds-/Firmenverzeichnis-Eintrag (starkes lokales Entitätssignal).
+- **B2B-Standard DACH:** wlw.de, 11880, Cylex, Yelp DE — mit identischer NAP.
+- **NAP-Disziplin gilt absolut:** eine Schreibweise überall, identisch zum Impressum (siehe Phase 1.2). Solar- und Agentur-Citations nutzen dieselbe Entität — **nicht** zwei konkurrierende Profile anlegen.
+
+### L3 — Lokale Relevanz-Links
+
+- Hannover-/Niedersachsen-Unternehmensnetzwerke, lokale Gründer-/Mittelstands-Initiativen, Co-Working-/Startup-Verzeichnisse der Region.
+- Lokale Kunden/Partner um eine Referenz-Erwähnung mit Link auf `/wordpress-agentur-hannover/` bitten (ein einziger themen- **und** ortsrelevanter Link wiegt schwer).
+- Gastbeitrag/Interview in einem regionalen Wirtschafts-/Gründer-Medium (Angle: „B2B-Website als Anfrage-System statt Schaufenster" — die E3-Datenstory trägt auch lokal).
+
+### Erwartung & Messung (lokal)
+
+- Frühindikator: GBP live + 5 konsistente Citations → „wordpress agentur hannover" sollte als Erstes aus Pos 30+ Richtung Pos 10–20 wandern (lokale Terme reagieren schneller auf Citations als breite Solar-Terme auf topische Links).
+- Monatlich in der Search Console: Position „wordpress agentur hannover" + „wordpress hannover", lokale Impressionen, Brand-Suchen „haşim üner".
+
+---
+
 ## Was NICHT tun (Anti-Pattern für junge Domains)
 
 - **Keine** gekauften Link-Pakete / PBNs / Massenverzeichnisse — bei junger Domain

--- a/plans/wordpress-agentur-hannover-relaunch.md
+++ b/plans/wordpress-agentur-hannover-relaunch.md
@@ -1,5 +1,9 @@
 # Plan: WordPress Agentur Hannover – Champions-League Relaunch
 
+> ✅ **UMGESETZT (Stand 2026-06-16).** Dieser Plan ist vollständig ausgeführt und nur noch historisch — **nicht erneut ausführen.**
+> Ist-Zustand der Live-Seite: WGOS-Bibliothek dynamisch aus der Registry (`blocksy-child/page-wordpress-agentur.php`), kein eingebettetes Light-Mode-CSS mehr (globales Dark-Design-System), vollständiges LocalBusiness/ProfessionalService-Schema mit Hannover-Geo/NAP (`blocksy-child/inc/org-schema.php`), H1 trifft „WordPress Agentur Hannover", Standort-Sektion, dynamische FAQ, Sticky-CTA.
+> Der verbleibende Hebel für „wordpress agentur hannover" ist **Offpage** — siehe `docs/seo/offpage-authority-playbook.md` (lokaler Track).
+
 Stand: 2026-05-15 | Mode: Architect | Ziel: Code-Implementierung vorbereiten
 
 ---


### PR DESCRIPTION
## Kontext

Umsetzung der umsatznahen SEO-Cockpit-Prioritäten (Stand 15.06.2026) — bewusst auf den belegten Umsatzpfad fokussiert statt auf Vanity-Traffic. Drei Commits, drei Runden.

## Änderungen

### Runde 1 — Solar Money Page, Kannibalisierung, Koko (`f847014`)
- **Solar-Money-Page** (`page-solar-waermepumpen-leadgenerierung.php` + `solar-leadgenerierung-solara.css`): kompakter Proof-Bar mit den E3-Kennzahlen (150 €→22 €, 1.750+, 12 %, über 85 %) direkt unter Hero/Trust (vorher erst bei ~73 % Scrolltiefe), Teaser auf `#ergebnisse`; sekundärer „E3-Case ansehen"-CTA an der Fit-Sektion. Funnel/Formular unverändert.
- **Kannibalisierung „leadgenerierung photovoltaik"**: term-naher Einbahn-Hublink von den Cluster-Subpages zurück auf die Money Page (`hu_render_solar_cluster_links()`).
- **Koko-Cockpit** beobachtbar + resilient: Live-Selbsttest in der Diagnostik (HTTP-Status + Roh-Body + normalisiertes Ergebnis), Koko-Fehler werden **nicht** mehr als 0/0 in den 12-h-Snapshot gecacht, „Cache bis n/a" zeigt bei Sync-Fehler einen interpretierbaren Status. (Befund: das sichtbare 0/0 ist ein erfolgreiches 200→0/0, kein Permission-Fehler → Range/Param/Shape, am Live-System zu fixen.)

### Runde 1.5 — 301-Konsolidierung (`4ef92c1`)
- `/photovoltaik-leads-kaufen-alternative/` (auf Entwurf, 404) per 301 auf die Solar-Money-Page (`nexus_get_legacy_offer_redirect_map()`) — fängt nachlaufende Impressionen/Backlinks ein und schließt die Kannibalisierung ab. Keine internen Links zeigen mehr auf den alten Slug.

### Runde 2 — Offpage statt Relaunch (`e59dcaf`)
- Befund: Der Hannover-Relaunch ist im Code **bereits umgesetzt** (dynamische WGOS-Bibliothek, LocalBusiness-Schema mit Hannover-Geo/NAP, H1 trifft den Head-Term) → kein Code-Hebel mehr offen, der echte Hebel ist Offpage.
- Neuer **lokaler Offpage-Track** für „wordpress agentur hannover" im Authority-Playbook (GBP lokal, Hannover-/IHK-/B2B-Citations mit NAP-Disziplin, lokale Relevanz-Links); veralteter Relaunch-Plan als „erledigt/historisch" markiert.

## Verifikation
- `pre-deploy-smoke` grün, `php -l` auf allen geänderten Dateien fehlerfrei.
- Additive Copy-/Link-/Diagnostik-/Doc-Änderungen; keine Funnel-/REST-/Schema-Eigentums-Eingriffe.

## Offen (Live-System / manuell — kein Repo)
- Nach Deploy den Koko-Selbsttest (Cockpit → Diagnostik) ablesen → eigentlicher Koko-Daten-Fix als Folge-Commit.
- Koko „eigene Besuche ausschließen" aktivieren (Eigen-Traffic).
- 301 nach Deploy prüfen (`curl -I` → 301 auf die Money Page).
- Offpage-Playbook inkl. neuem lokalem Hannover-Track manuell umsetzen.

https://claude.ai/code/session_01MZv9Lm5TmVNGMW4BFUEyNX

---
_Generated by [Claude Code](https://claude.ai/code/session_01MZv9Lm5TmVNGMW4BFUEyNX)_