### PR TITLE
Fix typos and de-duplicate proof stats on white-label page

### DIFF
--- a/blocksy-child/assets/css/whitelabel.css
+++ b/blocksy-child/assets/css/whitelabel.css
@@ -335,14 +335,6 @@
 	margin: 0.85rem -0.25rem 0.25rem;
 }
 
-.wl-dash__tiles {
-	display: grid;
-	grid-template-columns: repeat(2, 1fr);
-	gap: 0.65rem;
-	margin: 0.75rem 0 0;
-	padding: 0;
-}
-
 /* Counter-CLS-Schutz: tabular digits + reservierte Mindestbreiten,
    damit JS-Animation von 0 hoch keinen Layout-Shift produziert. */
 .wl-counter {
@@ -352,32 +344,6 @@
 }
 .wl-dash__primary-after .wl-counter { min-width: 3.2ch; }
 .wl-dash__primary-delta .wl-counter { min-width: 4.2ch; }
-.wl-dash__tile dd .wl-counter      { min-width: 5ch; }
-
-.wl-dash__tile {
-	background: hsl(30 5% 9% / 0.65);
-	border: 1px solid hsl(30 10% 100% / 0.05);
-	border-radius: 10px;
-	padding: 0.85rem 0.95rem;
-	min-width: 0;
-}
-
-.wl-dash__tile dt {
-	font-size: 0.68rem;
-	text-transform: uppercase;
-	letter-spacing: 0.14em;
-	color: hsl(30 6% 90% / 0.55);
-	margin-bottom: 0.35rem;
-}
-
-.wl-dash__tile dd {
-	margin: 0;
-	font-family: var(--nx-font-heading);
-	font-size: clamp(1.15rem, 1.7vw, 1.4rem);
-	font-weight: 600;
-	color: var(--nx-text);
-	letter-spacing: -0.01em;
-}
 
 .wl-dash__chips {
 	display: flex;

--- a/blocksy-child/inc/canon/e3-proof-canon.php
+++ b/blocksy-child/inc/canon/e3-proof-canon.php
@@ -18,6 +18,7 @@ define( 'HU_E3_SALES_CONVERSION_PERCENT', 12 );
 define( 'HU_E3_SALES_CONVERSION_BEFORE_LOW', 1 );
 define( 'HU_E3_SALES_CONVERSION_BEFORE_HIGH', 2 );
 define( 'HU_E3_TIMEFRAME_MONTHS', 6 );
+define( 'HU_E3_ROAS', 34 );
 
 /**
  * Return the canonical E3 proof data.
@@ -74,6 +75,12 @@ function hu_e3_canon() {
 				'display' => '1 – 5 % → 12 %',
 				'short'   => '6× bis 12× höhere Abschlussquote',
 				'label'   => 'Anstieg der Abschlussquote durch eigenes System',
+			],
+			'roas'             => [
+				'value'          => HU_E3_ROAS,
+				'display'        => '34×',
+				'counter_target' => '34',
+				'label'          => 'Return on Ad Spend',
 			],
 			'timeframe'        => [
 				'value'          => HU_E3_TIMEFRAME_MONTHS,

--- a/blocksy-child/page-whitelabel-retainer.php
+++ b/blocksy-child/page-whitelabel-retainer.php
@@ -22,12 +22,10 @@ $cpl_after      = function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'cpl_after',
 $cpl_reduction  = function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'cpl_reduction', 'display', '−85 %' )   : '−85 %';
 $lead_count     = function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'lead_count', 'display', '1.750+' )     : '1.750+';
 $sales_conv     = function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'sales_conversion', 'display', '12 %' ) : '12 %';
-$timeframe      = function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'timeframe', 'display', '6 Monate' )    : '6 Monate';
+$timeframe      = function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'timeframe', 'display_dative', '6 Monaten' ) : '6 Monaten';
+$roas           = function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'roas', 'display', '34×' )              : '34×';
 
-$cpl_before_int    = function_exists( 'hu_e3_metric' ) ? (int) hu_e3_metric( 'cpl_before', 'counter_target', 150 ) : 150;
 $cpl_after_int     = function_exists( 'hu_e3_metric' ) ? (int) hu_e3_metric( 'cpl_after',  'counter_target', 22 )  : 22;
-$lead_count_int    = function_exists( 'hu_e3_metric' ) ? (int) hu_e3_metric( 'lead_count', 'counter_target', 1750 ) : 1750;
-$sales_conv_int    = function_exists( 'hu_e3_metric' ) ? (int) hu_e3_metric( 'sales_conversion', 'counter_target', 12 ) : 12;
 $cpl_reduction_int = function_exists( 'hu_e3_metric' ) ? (int) hu_e3_metric( 'cpl_reduction', 'counter_target', 85 ) : 85;
 
 $problem_cards = [
@@ -51,7 +49,7 @@ $problem_cards = [
 $solution_steps = [
 	[
 		'step'  => '01',
-		'title' => 'Ihr briefed',
+		'title' => 'Ihr brieft',
 		'copy'  => 'Kurzes Setup-Gespräch mit eurem Projektleiter. NDA möglich. Keine direkte Kundenansprache.',
 	],
 	[
@@ -232,25 +230,6 @@ $hero_chips = [ 'GA4', 'GTM', 'Server-Side', 'Consent V2', 'WordPress', 'n8n' ];
 						</svg>
 					</div>
 
-					<dl class="wl-dash__tiles">
-						<div class="wl-dash__tile">
-							<dt>Qualifizierte Leads</dt>
-							<dd><span class="wl-counter" data-counter-target="<?php echo esc_attr( $lead_count_int ); ?>" data-counter-suffix="+"><?php echo esc_html( $lead_count ); ?></span></dd>
-						</div>
-						<div class="wl-dash__tile">
-							<dt>CPL-Senkung</dt>
-							<dd><span class="wl-counter" data-counter-target="<?php echo esc_attr( $cpl_reduction_int ); ?>" data-counter-prefix="−" data-counter-suffix=" %"><?php echo esc_html( $cpl_reduction ); ?></span></dd>
-						</div>
-						<div class="wl-dash__tile">
-							<dt>Zeitraum</dt>
-							<dd><span class="wl-counter" data-counter-target="6" data-counter-suffix=" Mon.">6 Mon.</span></dd>
-						</div>
-						<div class="wl-dash__tile">
-							<dt>Abschlussquote</dt>
-							<dd><span class="wl-counter" data-counter-target="<?php echo esc_attr( $sales_conv_int ); ?>" data-counter-suffix=" %"><?php echo esc_html( $sales_conv ); ?></span></dd>
-						</div>
-					</dl>
-
 					<div class="wl-dash__chips" role="list" aria-label="Stack-Komponenten">
 						<?php foreach ( $hero_chips as $chip ) : ?>
 							<span class="wl-chip" role="listitem"><?php echo esc_html( $chip ); ?></span>
@@ -385,8 +364,8 @@ $hero_chips = [ 'GA4', 'GTM', 'Server-Side', 'Consent V2', 'WordPress', 'n8n' ];
 					<div class="wl-proof__label">Qualifizierte Anfragen</div>
 				</div>
 				<div class="wl-proof__item" role="listitem">
-					<div class="wl-proof__value"><?php echo esc_html( $cpl_reduction ); ?></div>
-					<div class="wl-proof__label">Niedrigere Kosten pro Anfrage</div>
+					<div class="wl-proof__value"><?php echo esc_html( $roas ); ?></div>
+					<div class="wl-proof__label">Return on Ad Spend (ROAS)</div>
 				</div>
 				<div class="wl-proof__item" role="listitem">
 					<div class="wl-proof__value"><?php echo esc_html( $sales_conv ); ?></div>

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -127,12 +127,12 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, int given\\.$#"
-			count: 5
+			count: 2
 			path: blocksy-child/page-whitelabel-retainer.php
 
 		-
 			message: "#^Parameter \\#3 \\$fallback of function hu_e3_metric expects string, int given\\.$#"
-			count: 5
+			count: 2
 			path: blocksy-child/page-whitelabel-retainer.php
 
 		-


### PR DESCRIPTION
- Typo: "Ihr briefed" -> "Ihr brieft" in the solution flow (step 01)
- Hero card grammar: "in 6 Monate" -> "in 6 Monaten" via canon display_dative
- Slim the hero dashboard to a lean hook (headline CPL + sparkline + chips); remove the four stat tiles that duplicated the Live-Beleg section
- Replace the redundant "über 85 %" Live-Beleg tile with 34x ROAS, added as a new metric in the E3 proof canon (single source of truth)
- Remove the now-unused counter-target vars and the dead tile CSS


Claude-Session: https://claude.ai/code/session_018Mjh8BuubmKJpYKXphaoYH