### PR TITLE
Über-mich (Editorial) auf CRO-Rückgrat umgebaut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 2026-06
 
+### Über-mich (Editorial) auf CRO-Rückgrat umgebaut
+
+- `/uber-mich/` (Editorial-Template): Hero führt jetzt mit Outcome-H1 („Ich beende Portal-Abhängigkeit …") statt der Küchentisch-Story; primärer Marktcheck-CTA + Trust-Microcopy + eine E3-Proof-Zeile stehen above the fold.
+- Neuer **Proof-Strip** direkt unter dem Hero mit E3-Canon (150 €→22 €, 1.750+, 12 %, 6 Monate) aus `hu_e3_canon()`; **veraltete Zahlen entfernt** (vorher hardcodet „−83 %" / „neun Monaten").
+- Biografischer Pfad als Kompetenz-Beleg geschärft; neue **Fit-/Qualifizierungs-Sektion** (3 Voraussetzungen) und interner **Experten-Link-Cluster** (6 Sub-Pages, 3 System-Ebenen) für E-E-A-T und `#person`-Signal.
+- Editorial-natives **Founding-Cohort-Band** aus `hu_founding_canon()` (Scarcity/Offer-Frame) und wiederverwendeter mobiler **Sticky-CTA** (`template-parts/seo-subpage-sticky-cta.php` + JS) ergänzt; Styles im bestehenden Cream/Kupfer-System (`about-editorial.css`), `prefers-reduced-motion` respektiert.
+
 ### Solar-Proof früher, Cluster-Hublink & Koko-Cockpit-Beobachtbarkeit
 
 - `/solar-waermepumpen-leadgenerierung/`: kompakter **Proof-Bar** direkt unter Hero/Trust-Strip (E3-Kennzahlen 150 €→22 €, 1.750+, 12 %, über 85 % als Teaser → `#ergebnisse`), damit der Umsatzbeleg nicht erst bei ~73 % Scrolltiefe sichtbar wird; Kontextzeile macht die CPL-Zahl belegbar statt kontextlos. Funnel und Marktcheck-Formular unverändert.

--- a/blocksy-child/assets/css/about-editorial.css
+++ b/blocksy-child/assets/css/about-editorial.css
@@ -427,3 +427,426 @@
 		transition: none;
 	}
 }
+
+/* -----------------------------------------------------------
+   Hero actions (früher CTA) + Proof-Signal
+----------------------------------------------------------- */
+.about-editorial__hero-actions {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 18px 28px;
+	margin-top: 32px;
+}
+
+.about-editorial__cta-meta--start {
+	justify-content: flex-start;
+	margin: 0;
+}
+
+.about-editorial__hero-proof {
+	margin: 26px 0 0;
+	padding-top: 22px;
+	border-top: 1px solid var(--ae-line-soft);
+	font-family: 'JetBrains Mono', ui-monospace, monospace;
+	font-size: 13px;
+	line-height: 1.5;
+	letter-spacing: 0.01em;
+	color: var(--ae-accent-2);
+}
+
+/* -----------------------------------------------------------
+   Proof-Strip (E3-Canon)
+----------------------------------------------------------- */
+.about-editorial__proof {
+	display: grid;
+	grid-template-columns: repeat(2, 1fr);
+	gap: 1px;
+	margin-bottom: clamp(80px, 12vw, 128px);
+	background: var(--ae-line);
+	border: 1px solid var(--ae-line);
+	border-radius: var(--ae-radius);
+	overflow: hidden;
+}
+
+@media (min-width: 760px) {
+	.about-editorial__proof {
+		grid-template-columns: repeat(4, 1fr);
+	}
+}
+
+.about-editorial__proof-item {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	padding: 24px 22px;
+	background: var(--ae-bg-2);
+}
+
+.about-editorial__proof-k {
+	font-family: 'Satoshi', 'Figtree', sans-serif;
+	font-size: clamp(22px, 3vw, 30px);
+	font-weight: 800;
+	line-height: 1.05;
+	color: var(--ae-accent);
+}
+
+.about-editorial__proof-l {
+	font-size: 13px;
+	line-height: 1.5;
+	color: var(--ae-ink-3);
+}
+
+/* -----------------------------------------------------------
+   Fit / Qualifizierung
+----------------------------------------------------------- */
+.about-editorial__fit {
+	margin-bottom: clamp(80px, 12vw, 128px);
+}
+
+.about-editorial__fit-head,
+.about-editorial__expertise-head {
+	margin-bottom: 32px;
+}
+
+.about-editorial__fit-intro {
+	max-width: 60ch;
+	margin: 0;
+	font-size: clamp(17px, 1.8vw, 19px);
+	line-height: 1.6;
+	color: var(--ae-ink-2);
+}
+
+.about-editorial__fit-list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: grid;
+	gap: 16px;
+}
+
+@media (min-width: 760px) {
+	.about-editorial__fit-list {
+		grid-template-columns: repeat(3, 1fr);
+	}
+}
+
+.about-editorial__fit-item {
+	display: flex;
+	gap: 14px;
+	padding: 24px;
+	background: var(--ae-bg-2);
+	border: 1px solid var(--ae-line-soft);
+	border-radius: var(--ae-radius);
+}
+
+.about-editorial__fit-icon {
+	flex-shrink: 0;
+	width: 26px;
+	height: 26px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	border-radius: 9999px;
+	background: rgba(140, 98, 57, 0.12);
+	color: var(--ae-accent);
+}
+
+.about-editorial__fit-icon svg {
+	width: 15px;
+	height: 15px;
+}
+
+.about-editorial__fit-body {
+	display: grid;
+	gap: 6px;
+}
+
+.about-editorial__fit-body strong {
+	font-family: 'Satoshi', 'Figtree', sans-serif;
+	font-size: 15.5px;
+	font-weight: 700;
+	line-height: 1.3;
+	color: var(--ae-ink);
+}
+
+.about-editorial__fit-body span {
+	font-size: 14px;
+	line-height: 1.55;
+	color: var(--ae-ink-3);
+}
+
+/* -----------------------------------------------------------
+   Fachliche Schwerpunkte (interner Link-Cluster, E-E-A-T)
+----------------------------------------------------------- */
+.about-editorial__expertise {
+	margin-bottom: clamp(80px, 12vw, 128px);
+}
+
+.about-editorial__expertise-cluster {
+	display: grid;
+	gap: 28px;
+}
+
+@media (min-width: 760px) {
+	.about-editorial__expertise-cluster {
+		grid-template-columns: repeat(3, 1fr);
+	}
+}
+
+.about-editorial__expertise-title {
+	margin: 0 0 14px;
+	padding-bottom: 12px;
+	border-bottom: 1px solid var(--ae-line);
+	font-family: 'JetBrains Mono', ui-monospace, monospace;
+	font-size: 12px;
+	font-weight: 500;
+	letter-spacing: 0.12em;
+	text-transform: uppercase;
+	color: var(--ae-accent);
+}
+
+.about-editorial__expertise-list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: grid;
+	gap: 10px;
+}
+
+.about-editorial__expertise-link {
+	display: block;
+	padding: 16px 18px;
+	background: var(--ae-bg-2);
+	border: 1px solid var(--ae-line-soft);
+	border-radius: var(--ae-radius);
+	text-decoration: none;
+	transition: border-color 0.25s ease, transform 0.25s ease;
+}
+
+.about-editorial__expertise-link:hover,
+.about-editorial__expertise-link:focus-visible {
+	border-color: rgba(140, 98, 57, 0.4);
+	transform: translateY(-2px);
+}
+
+.about-editorial__expertise-link:focus-visible {
+	outline: 2px solid var(--ae-accent);
+	outline-offset: 2px;
+}
+
+.about-editorial__expertise-link-t {
+	display: block;
+	margin-bottom: 4px;
+	font-family: 'Satoshi', 'Figtree', sans-serif;
+	font-size: 15px;
+	font-weight: 700;
+	color: var(--ae-ink);
+}
+
+.about-editorial__expertise-link-s {
+	display: block;
+	font-size: 13px;
+	line-height: 1.5;
+	color: var(--ae-ink-3);
+}
+
+/* -----------------------------------------------------------
+   Founding-Cohort-Band (Scarcity, editorial-nativ)
+----------------------------------------------------------- */
+.about-editorial__cohort {
+	max-width: 760px;
+	margin: 0 auto clamp(80px, 12vw, 128px);
+	padding: clamp(32px, 5vw, 48px);
+	background:
+		linear-gradient(180deg, rgba(140, 98, 57, 0.06), rgba(140, 98, 57, 0.02)),
+		var(--ae-bg-2);
+	border: 1px solid var(--ae-line);
+	border-radius: var(--ae-radius);
+}
+
+.about-editorial__cohort-title {
+	margin: 12px 0 14px;
+	font-family: 'Satoshi', 'Figtree', sans-serif;
+	font-size: clamp(24px, 3.2vw, 32px);
+	font-weight: 800;
+	line-height: 1.1;
+	color: var(--ae-ink);
+}
+
+.about-editorial__cohort-text {
+	max-width: 60ch;
+	margin: 0 0 18px;
+	font-size: 15.5px;
+	line-height: 1.65;
+	color: var(--ae-ink-2);
+}
+
+.about-editorial__cohort-status {
+	display: inline-flex;
+	align-items: center;
+	gap: 10px;
+	margin: 0;
+	font-family: 'JetBrains Mono', ui-monospace, monospace;
+	font-size: 12.5px;
+	font-weight: 500;
+	color: var(--ae-accent-2);
+}
+
+.about-editorial__cohort-dot {
+	flex-shrink: 0;
+	width: 8px;
+	height: 8px;
+	border-radius: 9999px;
+	background: var(--ae-accent);
+	box-shadow: 0 0 0 4px rgba(140, 98, 57, 0.15);
+}
+
+/* -----------------------------------------------------------
+   Mobiler Sticky-CTA — wiederverwendete Komponente
+   (Markup: template-parts/seo-subpage-sticky-cta.php,
+    Verhalten: assets/js/seo-subpage-sticky-cta.js)
+   Reserviert über --hu-sticky-cta-h Platz → kein CLS.
+----------------------------------------------------------- */
+body {
+	padding-bottom: var(--hu-sticky-cta-h, 0);
+}
+
+.hu-sticky-cta {
+	position: fixed;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	z-index: 9000;
+	background: rgba(20, 16, 10, 0.96);
+	backdrop-filter: blur(10px);
+	-webkit-backdrop-filter: blur(10px);
+	border-top: 1px solid rgba(140, 98, 57, 0.4);
+	box-shadow: 0 -8px 24px rgba(0, 0, 0, 0.32);
+	transform: translateY(100%);
+	transition: transform 0.28s cubic-bezier(0.22, 1, 0.36, 1);
+	color: #f5f1ea;
+	font-family: 'Figtree', system-ui, sans-serif;
+}
+
+.hu-sticky-cta[hidden] {
+	display: none;
+}
+
+.hu-sticky-cta.is-visible {
+	transform: translateY(0);
+}
+
+.hu-sticky-cta__inner {
+	display: flex;
+	align-items: center;
+	gap: 14px;
+	padding: 12px 14px;
+	max-width: 760px;
+	margin: 0 auto;
+}
+
+.hu-sticky-cta__text {
+	margin: 0;
+	flex: 1 1 auto;
+	min-width: 0;
+}
+
+.hu-sticky-cta__lead {
+	display: block;
+	font-weight: 700;
+	font-size: 0.95rem;
+	line-height: 1.2;
+	color: #fff;
+}
+
+.hu-sticky-cta__sub {
+	display: block;
+	font-size: 0.78rem;
+	line-height: 1.3;
+	color: rgba(245, 241, 234, 0.7);
+	margin-top: 2px;
+}
+
+.hu-sticky-cta__primary {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	flex-shrink: 0;
+	padding: 12px 18px;
+	border-radius: 6px;
+	background: #d79a4f;
+	color: #1a0f05;
+	font-weight: 700;
+	font-size: 0.92rem;
+	text-decoration: none;
+	transition: background-color 0.18s ease, color 0.18s ease;
+	min-height: 48px;
+}
+
+.hu-sticky-cta__primary:hover,
+.hu-sticky-cta__primary:focus-visible {
+	background: #e6ad65;
+	color: #1a0f05;
+}
+
+.hu-sticky-cta__primary:focus-visible {
+	outline: 2px solid #fff;
+	outline-offset: 2px;
+}
+
+.hu-sticky-cta__primary-icon {
+	font-size: 1.05rem;
+	line-height: 1;
+}
+
+.hu-sticky-cta__close {
+	flex-shrink: 0;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 36px;
+	height: 36px;
+	min-width: 36px;
+	min-height: 36px;
+	border: 1px solid rgba(245, 241, 234, 0.22);
+	border-radius: 6px;
+	background: transparent;
+	color: rgba(245, 241, 234, 0.78);
+	font-size: 1.4rem;
+	line-height: 1;
+	cursor: pointer;
+	transition: color 0.18s ease, border-color 0.18s ease, background-color 0.18s ease;
+}
+
+.hu-sticky-cta__close:hover,
+.hu-sticky-cta__close:focus-visible {
+	color: #fff;
+	border-color: rgba(245, 241, 234, 0.55);
+	background: rgba(245, 241, 234, 0.06);
+}
+
+.hu-sticky-cta__close:focus-visible {
+	outline: 2px solid #d79a4f;
+	outline-offset: 2px;
+}
+
+@media (min-width: 761px) {
+	.hu-sticky-cta {
+		display: none !important;
+	}
+
+	body {
+		padding-bottom: 0 !important;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.hu-sticky-cta {
+		transition: none;
+	}
+
+	.about-editorial__expertise-link {
+		transition: none;
+	}
+}

--- a/blocksy-child/inc/enqueue.php
+++ b/blocksy-child/inc/enqueue.php
@@ -211,6 +211,7 @@ function hu_enqueue_assets() {
 	// ── E1) Template: Über Mich (Editorial Variante) ──────────────
 	if ( is_page_template( 'template-about-editorial.php' ) ) {
 		hu_enqueue_css( 'nexus-about-editorial-css', 'about-editorial.css', [ 'nexus-design-system' ] );
+		hu_enqueue_js( 'nexus-seo-subpage-sticky-cta-js', 'seo-subpage-sticky-cta.js', [] );
 	}
 
 	// ── E2) Kontakt ───────────────────────────────────────────────

--- a/blocksy-child/template-about-editorial.php
+++ b/blocksy-child/template-about-editorial.php
@@ -1,8 +1,10 @@
 <?php
 /**
  * Template Name: Über Mich (Editorial)
- * Description: Biografisch-editoriale Alternative zur Standard-Über-Mich-Seite.
- *              Fokus: Unternehmer-DNA, Mediensystem-Analyse, Drop-Cap-Erzählung.
+ * Description: Biografisch-editoriale Über-Mich-Seite mit CRO-Rückgrat.
+ *              Outcome-Hero + früher CTA + E3-Proof above the fold, biografischer
+ *              Pfad als Kompetenz-Beleg, Manifest, Fit-Qualifizierung, interner
+ *              Experten-Cluster (E-E-A-T), Founding-Cohort-Band, mobiler Sticky-CTA.
  *
  * Parallel zu template-about.php. Auswahl pro Page im WP-Admin.
  *
@@ -13,16 +15,53 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-$request_url  = function_exists( 'nexus_get_primary_request_url' ) ? nexus_get_primary_request_url() : home_url( '/solar-waermepumpen-leadgenerierung/#marktcheck' );
-$request_cta  = function_exists( 'nexus_get_primary_request_cta_label' ) ? nexus_get_primary_request_cta_label() : 'Marktcheck mit Fit-Entscheid starten';
-$portrait_url = function_exists( 'hu_get_profile_image_url' ) ? hu_get_profile_image_url() : get_stylesheet_directory_uri() . '/assets/img/hasim-portrait.png';
+$request_url   = function_exists( 'nexus_get_primary_request_url' ) ? nexus_get_primary_request_url() : home_url( '/solar-waermepumpen-leadgenerierung/#marktcheck' );
+$request_cta   = function_exists( 'nexus_get_primary_request_cta_label' ) ? nexus_get_primary_request_cta_label() : 'Marktcheck mit Fit-Entscheid starten';
+$portrait_url  = function_exists( 'hu_get_profile_image_url' ) ? hu_get_profile_image_url() : get_stylesheet_directory_uri() . '/assets/img/hasim-portrait.png';
 $portrait_path = get_stylesheet_directory() . '/assets/img/hasim-portrait.png';
 
-// Biografischer Pfad — von Herkunft zur Methode.
+// ── E3-Canon (Proof immer aus der zentralen Quelle, nie hardcodet) ──
+$e3_canon     = function_exists( 'hu_e3_canon' ) ? hu_e3_canon() : [];
+$e3_metrics   = isset( $e3_canon['metrics'] ) && is_array( $e3_canon['metrics'] ) ? $e3_canon['metrics'] : [];
+$e3_cpl_before = $e3_metrics['cpl_before']['display'] ?? '150 €';
+$e3_cpl_after  = $e3_metrics['cpl_after']['display'] ?? '22 €';
+$e3_cpl_red    = $e3_metrics['cpl_reduction']['display'] ?? 'über 85 %';
+$e3_leads      = $e3_metrics['lead_count']['display'] ?? '1.750+';
+$e3_conv       = $e3_metrics['sales_conversion']['display'] ?? '12 %';
+$e3_timeframe  = $e3_metrics['timeframe']['display'] ?? '6 Monate';
+$e3_tf_dative  = $e3_metrics['timeframe']['display_dative'] ?? '6 Monaten';
+
+// ── Founding-Canon (für das native Cohort-Band) ──
+$founding        = function_exists( 'hu_founding_canon' ) ? hu_founding_canon() : [];
+$f_label         = (string) ( $founding['label'] ?? 'Founding Cohort 2026' );
+$f_total         = max( 1, (int) ( $founding['slots_total'] ?? 3 ) );
+$f_remaining     = max( 0, min( $f_total, (int) ( $founding['slots_remaining'] ?? $f_total ) ) );
+$f_end_timestamp = strtotime( (string) ( $founding['end_date'] ?? '2026-09-30' ) );
+$f_end_label     = $f_end_timestamp ? date_i18n( 'd.m.Y', $f_end_timestamp ) : (string) ( $founding['end_date'] ?? '' );
+$f_slot_line     = sprintf( '%1$d von %2$d Plätzen offen', $f_remaining, $f_total );
+
+// Hero-Proof-Zeile (ein Trust-Signal above the fold).
+$hero_proof_line = sprintf(
+	'E3 New Energy: %1$s → %2$s pro Anfrage · %3$s qualifizierte Anfragen · %4$s',
+	$e3_cpl_before,
+	$e3_cpl_after,
+	$e3_leads,
+	$e3_timeframe
+);
+
+// Proof-Strip (kompaktes E3-Band früh auf der Seite).
+$about_proof = [
+	[ 'k' => sprintf( '%s → %s', $e3_cpl_before, $e3_cpl_after ), 'l' => 'Kosten pro Anfrage (vorher gekaufte Portal-Leads → eigenes System)' ],
+	[ 'k' => $e3_leads,    'l' => 'qualifizierte Anfragen im E3-Case' ],
+	[ 'k' => $e3_conv,     'l' => 'Abschlussquote (vorher 1 – 5 %)' ],
+	[ 'k' => $e3_timeframe, 'l' => 'Zeitraum bis zum belastbaren Ergebnis' ],
+];
+
+// Biografischer Pfad — Herkunft als Kompetenz-Beleg, nicht als weiche Story.
 $about_hero_path = [
 	[
 		't' => 'Die Vertriebs-Schule',
-		's' => 'Aufgewachsen im – bis heute aktiven – Bauunternehmen des Vaters. Danach acht Jahre B2B-Beratung am echten Entscheider: Bedarf erkennen, Einwände auflösen, verbindlich abschließen. Gelernt im Gespräch, nicht im Seminar.',
+		's' => 'Aufgewachsen im – bis heute aktiven – Bauunternehmen des Vaters. Danach acht Jahre B2B-Beratung am echten Entscheider: Bedarf erkennen, Einwände auflösen, verbindlich abschließen. Deshalb baue ich Anfragewege aus echten Verkaufsgesprächen, nicht aus Designgeschmack.',
 	],
 	[
 		't' => 'Der analytische Blick',
@@ -30,7 +69,7 @@ $about_hero_path = [
 	],
 	[
 		't' => 'Der eigene Beweis',
-		's' => 'Eigenen Shop von Null aufgebaut und am eigenen Geld gespürt, was Plattform-Abhängigkeit kostet. Dieselbe Logik auf Energie skaliert — und bei E3 New Energy bewiesen.',
+		's' => 'Eigenen Shop von Null aufgebaut und am eigenen Geld gespürt, was Plattform-Abhängigkeit kostet. Dieselbe Logik auf Energie skaliert – und bei E3 New Energy belegt.',
 	],
 ];
 
@@ -56,6 +95,62 @@ $about_work_principles = [
 	],
 ];
 
+// Fit-Check: drei Voraussetzungen, damit schwache Leads gar nicht erst anfragen.
+$about_fit_points = [
+	[
+		't' => 'Fokus auf Solar, Wärmepumpe oder Speicher.',
+		's' => 'Echte Spezialisierung. Keine branchenübergreifenden Experimente, keine Generalisten-Lösungen.',
+	],
+	[
+		't' => 'Eigener, funktionierender Vertrieb.',
+		's' => 'Das System erzeugt exklusive, hochpreisige Anfragen. Die müssen konsequent bearbeitet werden — durch ein Vertriebsteam oder eine abschlussstarke Geschäftsführung, nicht durch reine Vermittlung.',
+	],
+	[
+		't' => 'Verständnis für Infrastruktur statt Landingpage.',
+		's' => 'Ein eigenes Anfrage-System ist ein digitaler Vermögenswert. Wer eine günstige Landingpage sucht, ist hier falsch.',
+	],
+];
+
+// Fachliche Schwerpunkte: 3 System-Ebenen, 6 interne Seiten (E-E-A-T + interne Verlinkung).
+$about_expertise_structured = [
+	'Infrastruktur & Funnel' => [
+		[
+			't'   => 'Lead-Funnel-Architektur',
+			's'   => 'Fünf Stufen vom Suchwort bis zum Auftrag, mit Vorqualifizierung und Sales-Anschluss.',
+			'url' => home_url( '/lead-funnel-solar/' ),
+		],
+		[
+			't'   => 'Portal-Leads vs. eigenes System',
+			's'   => '24-Monats-TCO, Exklusivität und Asset-Eigentum im strategischen Vergleich.',
+			'url' => home_url( '/eigene-leadgenerierung-vs-portale/' ),
+		],
+	],
+	'Daten & Tracking' => [
+		[
+			't'   => 'Server-Side Tracking',
+			's'   => 'GA4, Meta CAPI und Consent Mode v2 auf eigenem Server – DSGVO-konform und cookieless-ready.',
+			'url' => home_url( '/server-side-tracking-b2b/' ),
+		],
+		[
+			't'   => 'Cost per Lead Photovoltaik',
+			's'   => 'CPL-Analyse mit drei Szenarien-Vergleich und versteckten Kostentreibern.',
+			'url' => home_url( '/cost-per-lead-photovoltaik/' ),
+		],
+	],
+	'Qualität & Vertrieb' => [
+		[
+			't'   => 'Qualifizierte PV-Anfragen',
+			's'   => 'Vier Merkmale, an denen sich eine hochwertige Solar-Anfrage erkennen lässt.',
+			'url' => home_url( '/qualifizierte-pv-anfragen/' ),
+		],
+		[
+			't'   => 'B2B Solar Leads (Gewerbe)',
+			's'   => 'Buying-Center-Funnel für gewerbliche Photovoltaik-Projekte ab 50.000 €.',
+			'url' => home_url( '/b2b-solar-leads/' ),
+		],
+	],
+];
+
 get_header();
 ?>
 
@@ -63,19 +158,48 @@ get_header();
 	<div class="about-editorial" data-track-section="about_editorial_page">
 		<div class="about-editorial__inner">
 
-			<!-- HERO -->
+			<!-- HERO — Outcome + früher CTA + ein Proof-Signal -->
 			<header class="about-editorial__hero">
-				<span class="about-editorial__kicker">Inquiry Systems Architect</span>
-				<h1 class="about-editorial__h1">Ich habe am Küchentisch gelernt, was eine schlechte Anfrage kostet.</h1>
+				<span class="about-editorial__kicker">Architekt für eigene Anfrage-Systeme</span>
+				<h1 class="about-editorial__h1">Ich beende Portal-Abhängigkeit — mit Anfrage-Systemen, die Ihrem Betrieb gehören.</h1>
 				<p class="about-editorial__lead">
-					Ich entwerfe keine austauschbaren Webseiten. Ich konstruiere autarke Anfrage-Systeme für den inhabergeführten Solar- und SHK-Mittelstand.
+					Für inhabergeführte Solar- und Wärmepumpen-Betriebe, die geteilte Portal-Leads durch eigene Daten, saubere Vorqualifizierung und direkten CRM-Anschluss ersetzen wollen.
 				</p>
+
+				<div class="about-editorial__hero-actions">
+					<a
+						href="<?php echo esc_url( $request_url ); ?>"
+						class="about-editorial__cta-btn"
+						data-track-action="cta_about_editorial_hero"
+						data-track-category="lead_gen"
+						data-track-section="about_editorial_hero"
+					>
+						<?php echo esc_html( $request_cta ); ?>
+					</a>
+					<p class="about-editorial__cta-meta about-editorial__cta-meta--start">
+						<span>Exklusive Erst-Analyse</span>
+						<span>Prüfung auf Regions-Verfügbarkeit</span>
+						<span>Händischer Befund innerhalb von 48 Stunden</span>
+					</p>
+				</div>
+
+				<p class="about-editorial__hero-proof"><?php echo esc_html( $hero_proof_line ); ?></p>
 			</header>
+
+			<!-- PROOF-STRIP — E3-Canon früh, nicht erst am Seitenende -->
+			<section class="about-editorial__proof" aria-label="Belege aus dem E3-Case">
+				<?php foreach ( $about_proof as $proof_item ) : ?>
+					<div class="about-editorial__proof-item">
+						<span class="about-editorial__proof-k"><?php echo esc_html( $proof_item['k'] ); ?></span>
+						<span class="about-editorial__proof-l"><?php echo esc_html( $proof_item['l'] ); ?></span>
+					</div>
+				<?php endforeach; ?>
+			</section>
 
 			<!-- BIOGRAFISCHER PFAD + PORTRAIT-CARD -->
 			<section class="about-editorial__split">
 				<div class="about-editorial__path-col">
-					<h2 class="about-editorial__section-kicker">Evolution der Methode</h2>
+					<h2 class="about-editorial__section-kicker">Warum ich Anfrage-Systeme baue</h2>
 					<ol class="about-editorial__path" role="list">
 						<?php foreach ( $about_hero_path as $index => $step ) : ?>
 							<li class="about-editorial__path-item">
@@ -103,15 +227,15 @@ get_header();
 					<dl class="about-editorial__meta">
 						<div class="about-editorial__meta-row">
 							<dt>Status</dt>
-							<dd>Aktiv · Pattensen</dd>
+							<dd>Aktiv · Pattensen bei Hannover</dd>
 						</div>
 						<div class="about-editorial__meta-row">
 							<dt>Fokus</dt>
-							<dd>Solar &amp; SHK-Infrastruktur</dd>
+							<dd>Solar &amp; Wärmepumpe</dd>
 						</div>
 						<div class="about-editorial__meta-row">
 							<dt>Methode</dt>
-							<dd>Anfrage-Kraftwerk</dd>
+							<dd>Eigenes Anfrage-System</dd>
 						</div>
 					</dl>
 				</aside>
@@ -138,20 +262,85 @@ get_header();
 			<section class="about-editorial__bio" id="about-editorial-hintergrund">
 				<h2 class="about-editorial__section-kicker">Der Hintergrund</h2>
 				<div class="about-editorial__bio-prose">
-					<p class="about-editorial__dropcap">Mein Vater ist Bauunternehmer. Ich bin mit dem Wissen aufgewachsen, was es heißt, Verantwortung für Projekte, Margen und ein fest angestelltes Team zu tragen — und trage es bis heute mit, wenn am Küchentisch über Auftragslage und Zahlungsmoral geredet wird.</p>
+					<p class="about-editorial__dropcap">Mein Vater ist Bauunternehmer. Ich bin mit der Verantwortung für Projekte, Margen und ein fest angestelltes Team aufgewachsen — und mit dem Wissen, was eine schlechte Anfrage einen Betrieb wirklich kostet.</p>
 					<p>Vertrieb habe ich danach nicht in Seminaren gelernt, sondern in acht Jahren B2B-Beratung: Bedarf strukturiert aufnehmen, mit Entscheidern verbindlich kommunizieren, langfristige Beziehungen über zuverlässige Follow-ups halten.</p>
 					<p>Dann habe ich selbst gegründet — einen eigenen Online-Shop, von der ersten Zeile Code bis zur letzten Conversion. Dort habe ich am eigenen Geld erlebt, was es bedeutet, seine Nachfrage selbst zu erzeugen, statt sie von Plattformen zu mieten. Genau diese Erfahrung ist der Kern dessen, was ich heute baue.</p>
 					<p>Mein Studium der Medienwissenschaft an der Universität Paderborn war dabei der analytische Werkzeugkasten: Ich schaue nicht darauf, was auf einer Website schön aussieht, sondern wie Daten fließen, wo Aufmerksamkeit versickert und welche Signale zwischen Oberfläche und B2B-Entscheider übertragen werden müssen, damit Vertrauen entsteht.</p>
-					<p>Die meisten WordPress-Websites scheitern, weil sie von Designern gebaut wurden, die nie ein echtes Verkaufsgespräch geführt haben. Sie informieren den Nutzer zu Tode, statt Entscheidungen zu provozieren. Ich verbinde acht Jahre Vertriebs-Pragmatismus mit analytischer Präzision — und seit dem Case bei E3 New Energy (−83 % Cost-per-Lead, über 1.750 qualifizierte Anfragen in neun Monaten) wende ich diese Methode exklusiv auf den Solar- und Wärmepumpen-Mittelstand an.</p>
+					<p>Die meisten WordPress-Websites scheitern, weil sie von Designern gebaut wurden, die nie ein echtes Verkaufsgespräch geführt haben. Sie informieren den Nutzer zu Tode, statt Entscheidungen zu provozieren. Ich verbinde acht Jahre Vertriebs-Pragmatismus mit analytischer Präzision — und seit dem Case bei E3 New Energy (<?php echo esc_html( sprintf( '%1$s weniger Kosten pro Anfrage, %2$s qualifizierte Anfragen in %3$s', $e3_cpl_red, $e3_leads, $e3_tf_dative ) ); ?>) wende ich diese Methode exklusiv auf den Solar- und Wärmepumpen-Mittelstand an.</p>
 				</div>
 			</section>
 
-			<!-- CTA -->
+			<!-- FIT / QUALIFIZIERUNG -->
+			<section class="about-editorial__fit" aria-labelledby="about-editorial-fit-title">
+				<div class="about-editorial__fit-head">
+					<h2 id="about-editorial-fit-title" class="about-editorial__section-kicker">Wann eine Zusammenarbeit Sinn ergibt</h2>
+					<p class="about-editorial__fit-intro">Nicht jeder Betrieb braucht sofort ein eigenes Anfrage-System. Drei Dinge müssen stimmen — sonst spare ich Ihnen und mir die Zeit.</p>
+				</div>
+				<ul class="about-editorial__fit-list" role="list">
+					<?php foreach ( $about_fit_points as $fit_item ) : ?>
+						<li class="about-editorial__fit-item">
+							<span class="about-editorial__fit-icon" aria-hidden="true">
+								<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12l5 5L20 7" /></svg>
+							</span>
+							<div class="about-editorial__fit-body">
+								<strong><?php echo esc_html( $fit_item['t'] ); ?></strong>
+								<span><?php echo esc_html( $fit_item['s'] ); ?></span>
+							</div>
+						</li>
+					<?php endforeach; ?>
+				</ul>
+			</section>
+
+			<!-- FACHLICHE SCHWERPUNKTE — interner Link-Cluster (E-E-A-T) -->
+			<section class="about-editorial__expertise" aria-labelledby="about-editorial-expertise-title">
+				<div class="about-editorial__expertise-head">
+					<h2 id="about-editorial-expertise-title" class="about-editorial__section-kicker">Fachliche Schwerpunkte</h2>
+					<p class="about-editorial__fit-intro">Sechs Felder entlang der drei System-Ebenen — jedes als eigene Seite mit Methode, Beispielen und Bezug zum E3-Case.</p>
+				</div>
+				<div class="about-editorial__expertise-cluster">
+					<?php foreach ( $about_expertise_structured as $expertise_category => $expertise_items ) : ?>
+						<div class="about-editorial__expertise-column">
+							<h3 class="about-editorial__expertise-title"><?php echo esc_html( $expertise_category ); ?></h3>
+							<ul class="about-editorial__expertise-list" role="list">
+								<?php foreach ( $expertise_items as $field ) : ?>
+									<li>
+										<a
+											class="about-editorial__expertise-link"
+											href="<?php echo esc_url( $field['url'] ); ?>"
+											data-track-action="cta_about_editorial_expertise"
+											data-track-category="navigation"
+											data-track-section="about_editorial_expertise"
+										>
+											<span class="about-editorial__expertise-link-t"><?php echo esc_html( $field['t'] ); ?></span>
+											<span class="about-editorial__expertise-link-s"><?php echo esc_html( $field['s'] ); ?></span>
+										</a>
+									</li>
+								<?php endforeach; ?>
+							</ul>
+						</div>
+					<?php endforeach; ?>
+				</div>
+			</section>
+
+			<!-- FOUNDING-COHORT-BAND — Scarcity + Offer-Frame (editorial-nativ) -->
+			<section class="about-editorial__cohort" aria-labelledby="about-editorial-cohort-title">
+				<span class="about-editorial__cta-eyebrow"><?php echo esc_html( $f_label ); ?></span>
+				<h2 id="about-editorial-cohort-title" class="about-editorial__cohort-title">E3 New Energy war der erste Case, nicht die Grenze.</h2>
+				<p class="about-editorial__cohort-text">
+					Dieselbe Arbeitsweise öffne ich für maximal drei passende Solar- oder Wärmepumpen-Betriebe. Der Einstieg bleibt der Marktcheck, damit vor einer Umsetzung klar ist, ob Markt, Budget und Tracking-Realität zusammenpassen.
+				</p>
+				<p class="about-editorial__cohort-status">
+					<span class="about-editorial__cohort-dot" aria-hidden="true"></span>
+					<?php echo esc_html( $f_slot_line ); ?><?php if ( '' !== $f_end_label ) : ?> · Founding-Konditionen bis <?php echo esc_html( $f_end_label ); ?><?php endif; ?>
+				</p>
+			</section>
+
+			<!-- FINAL CTA -->
 			<footer class="about-editorial__cta-card">
 				<span class="about-editorial__cta-eyebrow">Exklusiver Marktcheck</span>
-				<h2 class="about-editorial__cta-title">Bereit für ein autarkes System?</h2>
+				<h2 class="about-editorial__cta-title">Bereit für ein eigenes Anfrage-System?</h2>
 				<p class="about-editorial__cta-text">
-					Wir analysieren, wie viel Werbebudget aktuell in Portal-Lücken versickert und wie ein eigenes Anfrage-Kraftwerk für Ihren Betrieb aussehen muss.
+					Wir analysieren, wie viel Werbebudget aktuell in Portal-Lücken versickert und wie ein eigenes Anfrage-System für Ihren Betrieb aussehen muss. Manueller, tiefer Marktcheck, händische Prüfung der Regions-Verfügbarkeit, Befund innerhalb von 48 Stunden per E-Mail. Kein Verkaufsgespräch.
 				</p>
 				<a
 					href="<?php echo esc_url( $request_url ); ?>"
@@ -171,6 +360,17 @@ get_header();
 
 		</div>
 	</div>
+
+	<?php
+	get_template_part(
+		'template-parts/seo-subpage-sticky-cta',
+		null,
+		[
+			'marktcheck_url' => $request_url,
+			'track_category' => 'about_editorial_sticky',
+		]
+	);
+	?>
 </main>
 
 <?php


### PR DESCRIPTION
Hero führt mit Outcome-H1 statt Küchentisch-Story; primärer Marktcheck-CTA, Trust-Microcopy und eine E3-Proof-Zeile stehen above the fold. Neuer Proof-Strip, Fit-/Qualifizierungs-Sektion, interner Experten-Link-Cluster (E-E-A-T), natives Founding-Cohort-Band und wiederverwendeter mobiler Sticky-CTA ergänzt.

Veraltete E3-Zahlen ("−83 %" / "neun Monaten") entfernt und durchgängig auf den zentralen E3-Canon (über 85 % / 6 Monate, hu_e3_canon()) umgestellt.


Claude-Session: https://claude.ai/code/session_01Cxsr2C88fiZ9ui22uSupgP