### PR TITLE
Specialize agent skill for SEO Cockpit, offers, and privacy-first planning

### DIFF
--- a/agents/skills/wordpress-performance-marketing/SKILL.md
+++ b/agents/skills/wordpress-performance-marketing/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: wordpress-performance-marketing
-description: Audit or improve WordPress sites across technical SEO, CRO, content strategy, and tracking readiness. Use when the task is performance marketing for a WordPress property, especially in B2B contexts.
+description: Audit or improve the Hasim Üner WordPress repo as a revenue system across technical SEO, offer architecture, money pages, CRO, content strategy, SEO Cockpit, and privacy-first measurement readiness. Use when the task mentions SEO audit, tracking audit, autopost, landing page, lead generation, offers, money pages, funnels, or repo-level performance marketing.
 ---
 
 # WordPress Performance Marketing
 
-Use this skill for audits and implementation work where SEO, UX, content, and measurement have to behave like one system.
+Use this skill for repo work where SEO, UX, content, offer logic, lead generation, and measurement have to behave like one system.
+
+This is the main planning skill for the Hasim Üner website repo. It is not a generic plugin checklist.
 
 ## Run First
 
@@ -13,17 +15,97 @@ Use this skill for audits and implementation work where SEO, UX, content, and me
 agents/skills/wordpress-performance-marketing/scripts/render-checklist.sh full
 ```
 
-Supported modes: `full`, `seo`, `cro`, `content`, `tracking`.
+Supported modes: `full`, `seo`, `cro`, `content`, `tracking`, `offers`.
 
 ## Project Defaults
 
-See `docs/standards/BRAND_AND_COPY.md` for positioning, tone, and copy direction.
+- Treat the repo as the source for theme logic, templates, service pages, funnels, schema helpers, seeded content, and internal-link architecture.
+- Do not assume RankMath. The repo uses a custom WordPress SEO Cockpit plugin/workflow where applicable.
+- Do not assume cookie-based tracking as default. The current direction is privacy-first and may start without advertising or heavy tracking.
+- Do not add consent banners, ad pixels, or GA4/GTM runtime changes unless the task explicitly asks for them.
+- Google Analytics for WordPress may exist, but measurement notes must stay separate from code changes unless instructed otherwise.
+- Offer priorities include SEO audit, tracking audit, autopost, landing pages, lead generation, WordPress/technical implementation, and related performance-marketing services.
+- Prefer repo-verifiable findings over generic marketing advice.
+
+## Core Agent Mission
+
+When asked to plan or improve the repo, produce concrete output in this order:
+
+1. Inspect repo structure and identify relevant theme/plugin/content files.
+2. Map current pages, offers, CTAs, internal links, and reusable sections.
+3. Identify missing or weak money pages.
+4. Separate repo-changeable tasks from WordPress-admin/manual tasks.
+5. Suggest minimal high-leverage implementation steps.
+6. Avoid touching live-critical files unless the task is explicit and scoped.
+
+## SEO / Money Page Rules
+
+For every money page or service page, check:
+
+- One clear search intent.
+- One primary offer.
+- Title, meta description, H1, canonical ownership, indexability, schema ownership.
+- Strong above-the-fold promise.
+- Proof, process, FAQ, objections, CTA, and internal links.
+- Local or topical relevance where useful.
+- Links to related service pages and supporting content.
+
+Potential money-page clusters:
+
+- SEO Audit
+- Technical SEO Audit
+- WordPress SEO Audit
+- Tracking Audit
+- Server-side / privacy-first tracking readiness
+- Landingpage Erstellung
+- Leadgenerierung System
+- Autopost / content automation
+- WordPress Entwicklung
+- Website Relaunch / Website Optimierung
+
+## CRO Rules
+
+- Keep one dominant CTA per section cluster.
+- Avoid too many choices above the fold.
+- Make the offer concrete before adding visual polish.
+- Prefer audit-first or diagnostic CTAs when trust is not established yet.
+- Copy must say what business outcome improves, not just which tool is used.
+
+## Tracking Rules
+
+Current default: no ad-tracking assumption.
+
+Allowed by default:
+
+- Keep or add neutral `data-track` attributes for future measurement.
+- Document recommended events separately.
+- Suggest form-submit, CTA-click, phone/email-click, audit-request, and lead-magnet events as planning notes.
+
+Not allowed unless explicitly requested:
+
+- Adding pixels.
+- Adding cookie-setting scripts.
+- Adding consent-manager logic.
+- Assuming active ads.
+- Treating GA4/GTM as already final.
+
+## Content / Autopost Rules
+
+For content automation or autopost planning:
+
+- Start from offers and money pages, not random topics.
+- Build clusters around demand, objections, proof, comparisons, and technical education.
+- Every post should point to one next action or one supporting page.
+- Avoid generic AI slop. Use concrete examples, local context, technical clarity, and business impact.
 
 ## Delivery Format
+
+Use this structure:
 
 - `Critical`
 - `High leverage`
 - `Polish`
 - `Manual WordPress tasks`
+- `Agent tasks / repo tasks`
 
-Separate repo fixes from editor or external-platform work.
+Always separate repo fixes from editor work, SEO Cockpit work, WordPress admin work, analytics work, and external-platform work.

--- a/agents/skills/wordpress-performance-marketing/scripts/render-checklist.sh
+++ b/agents/skills/wordpress-performance-marketing/scripts/render-checklist.sh
@@ -8,7 +8,9 @@ print_seo() {
   cat <<'EOF'
 [SEO]
 - Confirm one H1 and coherent heading order.
-- Check title, description, canonical, robots, and schema ownership.
+- Check title, description, canonical, robots, indexability, and schema ownership.
+- Do not assume RankMath; account for the custom WP SEO Cockpit workflow.
+- Map money pages, supporting pages, internal links, and primary search intent.
 - Verify canonical internal links point to primary URLs only.
 - Review Core Web Vitals risks: hero media, blocking CSS/JS, layout shifts.
 EOF
@@ -21,6 +23,7 @@ print_cro() {
 - Verify audit-first funnel alignment and risk-reversal copy.
 - Remove CTA drift, proof fragmentation, and unnecessary choice points.
 - Check mobile scannability and section order.
+- Make outcomes concrete before adding visual polish.
 EOF
 }
 
@@ -31,16 +34,28 @@ print_content() {
 - Replace vague agency wording with concrete business outcomes.
 - Link to one service page and related proof or cluster assets.
 - Keep terminology stable across hero, proof, and CTA blocks.
+- For autopost planning, connect every topic to an offer, objection, proof point, or money page.
 EOF
 }
 
 print_tracking() {
   cat <<'EOF'
 [TRACKING]
-- Preserve or add data-track attributes on core CTA surfaces.
-- Confirm repo-owned event hooks versus external GTM/GA4 setup.
-- Call out missing consent, routing, or CRM assumptions explicitly.
-- Keep measurement notes separate from runtime code changes.
+- Do not assume cookie-based tracking, ad pixels, or active campaigns.
+- Preserve or add neutral data-track attributes on core CTA surfaces only when useful.
+- Confirm repo-owned event hooks versus external Google Analytics for WP / GA4 / GTM setup.
+- Recommended planning events: CTA click, form submit, audit request, email click, phone click, lead source.
+- Keep measurement notes separate from runtime code changes unless explicitly requested.
+EOF
+}
+
+print_offers() {
+  cat <<'EOF'
+[OFFERS]
+- Prioritize SEO audit, tracking audit, autopost, landing pages, lead generation, and WordPress technical implementation.
+- Check whether each offer has: problem, outcome, proof, process, CTA, FAQ, and internal-link target.
+- Separate money pages from supporting education posts.
+- Flag missing offer pages, weak CTAs, unclear package boundaries, and duplicated positioning.
 EOF
 }
 
@@ -50,6 +65,7 @@ case "$mode" in
     print_cro
     print_content
     print_tracking
+    print_offers
     ;;
   seo)
     print_seo
@@ -63,8 +79,11 @@ case "$mode" in
   tracking)
     print_tracking
     ;;
+  offers)
+    print_offers
+    ;;
   *)
-    echo "Usage: $0 {full|seo|cro|content|tracking}" >&2
+    echo "Usage: $0 {full|seo|cro|content|tracking|offers}" >&2
     exit 1
     ;;
 esac


### PR DESCRIPTION
## Was geändert wurde

- `wordpress-performance-marketing` Skill auf Hasims echte Repo-Logik angepasst
- RankMath-Annahme entfernt
- Cookie-/Ads-Tracking nicht mehr als Default angenommen
- Custom WP SEO Cockpit als relevanter SEO-Kontext ergänzt
- Angebotslogik ergänzt: SEO-Audit, Tracking-Audit, Autopost, Landingpages, Leadgenerierung, WordPress technische Umsetzung
- Checklist-Script um `offers` erweitert

## Warum

Der Agent soll nicht generisch WordPress prüfen, sondern das Repo als Umsatzsystem verstehen: Money Pages, Angebote, CRO, SEO Cockpit, Content-Cluster und spätere Messbarkeit sauber trennen.

## Wichtig

Keine Live-Theme-Dateien geändert. Nur Agenten-Dokumentation und Checklist-Script.