### PR TITLE
Add Claude Opus agent profile

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,68 @@
+# Claude Code Instructions
+
+You are working in Hasim Üner's WordPress performance-marketing repository.
+
+Use this file as the project entry point for Claude Code / Opus-class agents. Do not treat it as a replacement for the repo skills. Route into the relevant skill first, then inspect files.
+
+## First steps
+
+1. Read `agents/skills/CONTEXT.md`.
+2. Pick the matching skill before editing.
+3. For broad website, SEO, offer, tracking, CRO, landing page, lead generation, or content automation work, start with:
+
+```bash
+agents/skills/wordpress-performance-marketing/scripts/render-checklist.sh full
+```
+
+4. For frontend HTML, CSS, JavaScript, forms, accessibility, or Core Web Vitals work, also load `modern-web-guidance` before implementation.
+5. Keep changes small and reviewable.
+
+## Project defaults
+
+- This repo is for WordPress technical implementation, service pages, funnel logic, SEO/CRO architecture, schema helpers, internal linking, and agent-ready planning.
+- Do not assume RankMath. Use the custom WordPress SEO Cockpit context where relevant.
+- Do not assume cookie-based tracking, ad pixels, or consent banners by default.
+- Google Analytics for WordPress may exist, but tracking changes must be explicit and separate from planning notes.
+- Current offer priorities: SEO audit, tracking audit, autopost/content automation, landing pages, lead generation, WordPress technical implementation.
+- Prefer repo-verifiable findings over generic marketing advice.
+
+## Opus operating style
+
+Use Opus for deeper reasoning, not bigger uncontrolled edits.
+
+Before changing files, produce a compact plan with:
+
+- relevant files inspected
+- assumed business goal
+- likely repo tasks
+- manual WordPress/admin tasks
+- risk level
+
+When editing:
+
+- Do one coherent change per branch.
+- Do not touch live-critical theme or deployment files without explicit scope.
+- Separate strategy documents from code changes.
+- Preserve existing project language and positioning.
+- Avoid returning to old Shopify positioning unless a file explicitly requires cleanup of old copy.
+
+## Required output for audits
+
+For repo audits, structure the answer as:
+
+- Critical
+- High leverage
+- Polish
+- Manual WordPress tasks
+- Agent tasks / repo tasks
+
+Always separate repo fixes from editor work, SEO Cockpit work, WordPress admin work, analytics work, and external-platform work.
+
+## Safety and quality rules
+
+- Never add secrets, API keys, analytics IDs, pixels, or third-party scripts unless explicitly requested.
+- Never invent keyword volumes, Search Console data, or analytics numbers.
+- Mark assumptions clearly.
+- If data is missing, create a clean placeholder or task instead of pretending it exists.
+- Prefer PRs over direct commits to `main`.
+- Keep comments and docs concise.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,12 @@ You are working in Hasim Üner's WordPress performance-marketing repository.
 
 Use this file as the project entry point for Claude Code / Opus-class agents. Do not treat it as a replacement for the repo skills. Route into the relevant skill first, then inspect files.
 
+For the deeper Opus behavior profile, also read:
+
+```text
+agents/model-profiles/claude-opus-performance-marketing.md
+```
+
 ## First steps
 
 1. Read `agents/skills/CONTEXT.md`.

--- a/agents/model-profiles/README.md
+++ b/agents/model-profiles/README.md
@@ -1,0 +1,11 @@
+# Agent Model Profiles
+
+This directory contains model-specific operating profiles for repo agents.
+
+Use these profiles only as behavior guidance. The canonical task routing still lives in:
+
+```text
+agents/skills/CONTEXT.md
+```
+
+The skills define what to do. Model profiles define how a model should behave while doing it.

--- a/agents/model-profiles/claude-opus-performance-marketing.md
+++ b/agents/model-profiles/claude-opus-performance-marketing.md
@@ -1,0 +1,97 @@
+# Claude Opus Performance Marketing Profile
+
+Use this profile when running Claude / Opus-class agents against this repository.
+
+The goal is not to make the agent more verbose. The goal is to make it harder for the agent to damage positioning, tracking assumptions, SEO architecture, or live WordPress behavior.
+
+## Best use cases
+
+Use Opus for:
+
+- repo-wide SEO and offer audits
+- money-page architecture
+- internal-link strategy
+- CRO and conversion-copy critique
+- landing-page planning
+- tracking-audit planning without adding scripts
+- SEO Cockpit hardening ideas
+- agent task decomposition
+- PR review before merge
+
+Avoid Opus as a blind bulk editor. It should reason first, then change only what is scoped.
+
+## Repo-specific assumptions
+
+- The site is positioned around technical SEO, SEO audits, tracking audits, WordPress implementation, landing pages, lead generation, and content/autopost systems.
+- Shopify is not the current positioning unless the task is explicitly about old-copy cleanup or legacy content.
+- RankMath is not the default SEO system.
+- SEO Cockpit is the custom WordPress SEO workflow/plugin context.
+- No cookie-based tracking, ad pixels, or consent banners should be added by default.
+- Measurement can be planned via neutral event names and `data-track` attributes, but runtime tracking code needs explicit instruction.
+
+## Decision protocol
+
+Before implementation, classify the task:
+
+1. Strategy only
+2. Docs / agent instructions
+3. Theme/template implementation
+4. Plugin/backend implementation
+5. WordPress admin/editor task
+6. External platform task
+
+If the task crosses categories, split the answer and avoid mixing code changes with manual tasks.
+
+## Audit protocol
+
+For audits, inspect before advising:
+
+- routing table: `agents/skills/CONTEXT.md`
+- relevant skill: usually `agents/skills/wordpress-performance-marketing/SKILL.md`
+- theme files only if the task touches frontend behavior
+- plugin files only if the task touches SEO Cockpit, forms, REST, tracking, or lead routing
+- content/docs files only if the task touches positioning or page structure
+
+Then output:
+
+```text
+Critical
+High leverage
+Polish
+Manual WordPress tasks
+Agent tasks / repo tasks
+```
+
+## PR protocol
+
+For PRs:
+
+- one intent per PR
+- small file set
+- no unrelated formatting
+- no hidden live behavior changes
+- explain business impact, not just technical diff
+- mention what was deliberately not changed
+
+## Red lines
+
+Do not:
+
+- add pixels, cookies, consent code, analytics IDs, or third-party scripts without explicit request
+- invent keyword volumes, GSC clicks, GA4 events, rankings, or conversion data
+- reintroduce Shopify as a current service focus
+- replace existing skills with generic AI-agent advice
+- touch deployment, hosting, or live-critical files during planning-only tasks
+- modify generated assets unless the task explicitly requires it
+
+## Good default output
+
+A good Opus answer should say:
+
+- what the repo currently supports
+- what is missing for SEO/offer/lead-generation value
+- what can be changed in code
+- what must be done in WordPress admin or SEO Cockpit
+- what should become separate issues or PRs
+
+Keep the answer sharp. No motivational filler.


### PR DESCRIPTION
## What changed

- Adds root `CLAUDE.md` as the Claude Code / Opus entry point.
- Adds `agents/model-profiles/` for model-specific operating profiles.
- Adds `claude-opus-performance-marketing.md` focused on SEO Cockpit, offers, privacy-first planning, repo audits, and safe PR behavior.

## Why

This gives Claude / Opus-class agents clear repo-specific behavior without replacing the existing skill system.

## Not changed

- No theme files changed.
- No plugin runtime files changed.
- No tracking scripts, pixels, cookies, consent code, or analytics IDs added.
- No live behavior changed.

## Review notes

The profile is intentionally strict: Opus should reason deeply, but make smaller scoped edits.