### PR TITLE
fix(blog): Konverter-Bug (zerhackte CTA/Listen) + Klartext-Kästen + Rechner-Button + Outreach-Paket

### DIFF
--- a/blocksy-child/assets/content/blog/photovoltaik-leads-tco-rechnung.md
+++ b/blocksy-child/assets/content/blog/photovoltaik-leads-tco-rechnung.md
@@ -32,7 +32,7 @@ Dieser Artikel rechnet das ehrlich durch: gekaufte Portal-Leads, gemietete Agent
 
 Eine kompakte Übersicht für den Sofort-Vergleich liegt auf der Seite [Solar Leads kaufen – die Alternative](/solar-leads-kaufen-alternative/). Hier gehen wir tiefer.
 
-## 1. Leads kaufen ist keine Kundengewinnung – es ist Miete
+## 1. Solar-Leads kaufen ist keine Kundengewinnung – es ist Miete
 
 Die meisten Solarbetriebe bewerten ihre Anfragequellen falsch.
 
@@ -66,23 +66,11 @@ Eine Anfrage für 80 Euro wirkt kontrollierbar. Eine Anfrage für 180 Euro wirkt
 
 Diese Bewertung ist wertlos, solange die Abschlussquote fehlt. Die ausführliche Einordnung dazu steht auf [Cost per Lead Photovoltaik](/cost-per-lead-photovoltaik/); hier geht es um die Auftragsebene.
 
-Die Rechnung ist einfach:
+Die Rechnung ist einfach: **Was ein Auftrag kostet = Preis pro Anfrage geteilt durch Abschlussquote.**
 
-```text
-Kosten pro Auftrag = Kosten pro Anfrage / Abschlussquote
-```
+Ein Beispiel mit einer Portal-Anfrage: 80 Euro pro Anfrage, 5 von 100 Anfragen werden ein Auftrag – dann kostet Sie jeder Auftrag **1.600 Euro**.
 
-Beispiel Portal-Anfrage:
-
-```text
-80 € pro Anfrage / 5 % Abschluss = 1.600 € pro Auftrag
-```
-
-Beispiel eigene Anfrage:
-
-```text
-180 € pro Anfrage / 15 % Abschluss = 1.200 € pro Auftrag
-```
+Und mit einer eigenen Anfrage: 180 Euro pro Anfrage, 15 von 100 werden ein Auftrag – dann kostet der Auftrag nur **1.200 Euro**.
 
 Die zweite Anfrage kostet pro Stück mehr als das Doppelte. Trotzdem ist der Auftrag 400 Euro günstiger gewonnen.
 
@@ -92,13 +80,11 @@ Wenn Ihr Vertrieb 15 Minuten nach der Anfrage anruft, sind Sie nicht automatisch
 
 Das drückt die Abschlussquote. Auf den ersten Blick nicht dramatisch, in der Ergebnisrechnung aber massiv:
 
-```text
-72 € pro Anfrage / 4 % Abschluss = 1.800 € pro Auftrag
-120 € pro Anfrage / 7 % Abschluss = 1.714 € pro Auftrag
-180 € pro Anfrage / 15 % Abschluss = 1.200 € pro Auftrag
-```
+- 72 Euro pro Anfrage bei 4 % Abschluss → **1.800 Euro pro Auftrag**
+- 120 Euro pro Anfrage bei 7 % Abschluss → **1.714 Euro pro Auftrag**
+- 180 Euro pro Anfrage bei 15 % Abschluss → **1.200 Euro pro Auftrag**
 
-Der Einkauf sieht die 60-Euro-Anfrage. Sie als Chef müssen den 1.500-Euro-Auftrag sehen.
+Der Einkauf sieht die billige Anfrage. Sie als Chef müssen den teuren Auftrag sehen.
 
 Bei Photovoltaik mit hohen Auftragswerten ist nicht der Anfragepreis der Hebel. Der Hebel ist die Kombination aus Exklusivität, Tempo, Vertrauen, Vorprüfung und Abschlusswahrscheinlichkeit.
 
@@ -124,7 +110,7 @@ Ein eigener Anfrage-Weg holt diese Erfahrung in den Betrieb: Ihre Seite, Ihre Ka
 
 Das ist der Unterschied zwischen laufenden Kosten und aufgebautem Wert.
 
-Der Fehler vieler Betriebe ist nicht, dass sie Portale testen. Der Fehler ist, Portale zum Hauptkanal zu machen. Ein Portal kann ein Übergang sein. Es sollte nicht Ihre gesamte Kundengewinnung ersetzen.
+Der Fehler vieler Betriebe ist nicht, dass sie Portale nutzen. Der Fehler ist, Portale zum Hauptkanal zu machen. Ein Portal kann ein Übergang sein. Es sollte nicht Ihre gesamte Kundengewinnung ersetzen.
 
 Wer zwölf Monate lang Anfragen kauft, hat danach Rechnungen, Gespräche und ein paar Aufträge. Aber was bleibt als dauerhafter Wert im Betrieb?
 
@@ -166,18 +152,16 @@ Ob die Zahl im Einzelfall genau stimmt, ist zweitrangig. Die Richtung stimmt. La
 
 Das Problem ist selten das Design. Es ist der Unterbau: schwere Baukästen, zu viele Skripte, aufgeblähte Themes, unkomprimierte Bilder, überflüssige Animationen.
 
-Ein guter Anfrage-Weg braucht keinen überladenen Werkzeugkasten. Er braucht eine klare Seite, eine kurze saubere Formularstrecke, schnelle Ladezeiten und ein Nachverfolgen, das auch bei Handynutzern funktioniert. Der passende technische Aufbau ist auf [Stack Solar](/stack-solar/) dokumentiert:
+Ein guter Anfrage-Weg braucht keinen überladenen Werkzeugkasten, sondern vier Dinge:
 
-```text
-Schlanke WordPress-Seite
-+ schnelles Managed-Hosting aus Deutschland
-+ CDN
-+ wenig JavaScript
-+ klare Formularstrecke
-+ sauberes Nachverfolgen bis zum Auftrag
-```
+- eine schlanke, schnelle Website statt eines schweren Baukastens,
+- zuverlässiges Hosting aus Deutschland,
+- eine kurze, klare Formularstrecke,
+- ein sauberes Nachverfolgen jeder Anfrage bis zum Auftrag.
 
-**Werbung · Partnerlink:** [HostPress](https://www.hostpress.de/wordpress-hosting/) ist in diesem Aufbau die bevorzugte Hosting-Basis und zugleich ein Partner – wenn Sie über den Link abschließen, entsteht eine Vergütung, ohne Mehrkosten für Sie. Der Anbieter setzt auf Managed WordPress Hosting aus Deutschland, eigene Serverstandorte, schnellen Speicher, Cache, CDN und tägliche Backups. [Raidboxes](https://raidboxes.io/en/platform/wordpress-management/) ist die zweite sinnvolle Option, wenn zentrale Verwaltung, Backups und Staging im Vordergrund stehen. Der ganze Aufbau steht auf der [Stack-Solar-Seite](/stack-solar/).
+Der passende technische Aufbau ist auf [Stack Solar](/stack-solar/) im Detail dokumentiert.
+
+**Werbung · Partnerlink:** [HostPress](https://www.hostpress.de/wordpress-hosting/) ist in diesem Aufbau die bevorzugte Hosting-Basis und zugleich ein Partner – wenn Sie über den Link abschließen, entsteht eine Vergütung, ohne Mehrkosten für Sie. Der Anbieter setzt auf schnelles, gemanagtes WordPress-Hosting mit Serverstandorten in Deutschland und täglichen Backups. [Raidboxes](https://raidboxes.io/en/platform/wordpress-management/) ist die zweite sinnvolle Option, wenn zentrale Verwaltung, Backups und Staging im Vordergrund stehen.
 
 Weniger spektakulär als ein Agentur-Dashboard. Aber näher an dem, was Aufträge bringt.
 
@@ -193,23 +177,21 @@ Weniger spektakulär als ein Agentur-Dashboard. Aber näher an dem, was Aufträg
 
 Viele Betriebe schalten Werbung auf die falschen Signale. Sie zählen abgeschickte Formulare, Klicks, Terminbuchungen. Das Problem: Die Werbung lernt dann nicht, wer kauft. Sie lernt, wer Formulare ausfüllt. Das ist ein großer Unterschied.
 
-Ein sauber gebauter Anfrage-Weg misst nicht nur den ersten Kontakt. Er verbindet den ganzen Weg: Klick, Seite, Formular, Vorprüfung, Status in der Kundenverwaltung, Vertriebsergebnis, Auftrag. Der technische Kern dafür ist [Server-Side Tracking](/server-side-tracking-b2b/) – also sauberes Nachverfolgen über den eigenen Server statt nur über Browser-Pixel, die von Werbeblockern und Handy-Einstellungen kaputtgemacht werden.
+Ein sauber gebauter Anfrage-Weg misst nicht nur den ersten Kontakt. Er verfolgt den ganzen Weg nach: Klick, Seite, Formular, Vorprüfung, Stand in der Kundenverwaltung, Vertriebsergebnis, Auftrag. Die Technik dahinter heißt [Server-Side Tracking](/server-side-tracking-b2b/) – vereinfacht gesagt: Die wichtigen Ereignisse laufen über Ihren eigenen Server, statt nur über Zählpixel im Browser, die von Werbeblockern und Handy-Einstellungen ausgebremst werden.
 
-Das ist keine Spielerei für Technik-Nerds. Das ist Steuerung.
+Das ist keine Spielerei für Technik-Fans. Das ist Steuerung.
 
 Wenn ein Betrieb nur mit Browser-Pixeln arbeitet, sieht Google oder Meta oft ein verzerrtes Bild: Manche Aufträge fehlen, manche Kontakte werden falsch zugeordnet. Die Folge: Die Werbung optimiert auf ein unsauberes Signal.
 
 Die härteste Währung ist nicht die Anfrage. Es ist die Anfrage, die Ihr Vertrieb als echt und passend einstuft. Also nicht „Formular abgeschickt", sondern:
 
-```text
-Anfrage passt zur Region
-Auftragswert ist wirtschaftlich relevant
-Entscheider ist erreichbar
-Dach/Immobilie grundsätzlich geeignet
-Vertrieb bewertet den Kontakt als ernst
-```
+- Die Anfrage passt zu Ihrer Region.
+- Der Auftragswert ist wirtschaftlich interessant.
+- Der Entscheider ist erreichbar.
+- Dach oder Gebäude sind grundsätzlich geeignet.
+- Ihr Vertrieb stuft den Kontakt als ernsthaft ein.
 
-Erst dieses Signal wird zurück an die Werbung gespielt – nicht jeder Klick, nicht jeder neugierige Preisvergleicher. Dann sucht die Werbung nicht mehr möglichst viele billige Formulare, sondern Muster, die zu echten Aufträgen führen.
+Erst diese Rückmeldung fließt zurück in die Werbung – nicht jeder Klick, nicht jeder neugierige Preisvergleicher. Dann sucht die Werbung nicht mehr möglichst viele billige Formulare, sondern Muster, die zu echten Aufträgen führen.
 
 Wer diese Kette nicht besitzt, wirbt blind. Wer sie besitzt, baut mit jedem Monat eine bessere Datenbasis auf.
 
@@ -239,13 +221,11 @@ Das Ergebnis wird nicht schöngerechnet. Wenn der eigene Weg bei Ihnen nicht tr�
 
 Der Fall E3 New Energy wird oft zu groß erzählt. Das ist gar nicht nötig. Die nackten Zahlen reichen:
 
-```text
-Vorher: 150 € pro gekaufter Anfrage
-Nachher: 22 € pro eigener Anfrage
-Über 1.750 qualifizierte Anfragen
-12 % Abschlussquote nach dem Aufbau
-Zeitraum: 6 Monate
-```
+- **Vorher:** 150 € pro gekaufter Anfrage
+- **Nachher:** 22 € pro eigener Anfrage
+- Über 1.750 qualifizierte Anfragen
+- 12 % Abschlussquote nach dem Aufbau
+- Zeitraum: 6 Monate
 
 Man könnte daraus eine noch spektakulärere Zahl bauen. Machen wir bewusst nicht. Vorsichtig und mit allen Kosten gerechnet – Aufbau, Optimierung, Übergangsmonate – sinken die Kosten pro Auftrag um rund 71 Prozent (von etwa 5.000 € auf etwa 1.450 €). Wer hohe Auftragswerte verkauft, braucht keine überzogene Zahl. Er braucht eine, die ein Chef im Kopf nicht sofort auseinandernimmt.
 
@@ -257,7 +237,7 @@ Der [E3-Fall](/e3-new-energy/) ist deshalb kein Ergebnisversprechen, sondern ein
 
 ## 10. Sie müssen das Rad nicht neu erfinden
 
-Viele Betriebe überschätzen, wie lange so ein Aufbau dauert – weil sie an einen Kaltstart denken: Strategie-Workshop, Zielgruppe, Keywords, Entwürfe, Tracking-Konzept, Formularlogik, Kampagnen, Tests. Wochen werden Monate, bevor die erste brauchbare Anfrage kommt. Das ist die übliche Agentur-Logik – sie beginnt jedes Mal bei null, weil es kein wiederholbares System gibt.
+Viele Betriebe überschätzen, wie lange so ein Aufbau dauert – weil sie an einen Kaltstart denken: Strategie-Workshop, Zielgruppe, Suchbegriffe, Entwürfe, Formularlogik, Kampagnen. Wochen werden Monate, bevor die erste brauchbare Anfrage kommt. Das ist die übliche Agentur-Logik – sie beginnt jedes Mal bei null, weil es kein wiederholbares System gibt.
 
 Bei Photovoltaik ist das unnötig. Der Endzustand ist bekannt: Seiten, die nach Kaufentscheidung aussehen, nicht nach Broschüre. Ein Nachverfolgen, das echte Anfragen misst. Suchbegriffe mit Kaufabsicht. Formularstrecken, die schlechte Kontakte gar nicht erst teuer in den Vertrieb schieben.
 
@@ -277,42 +257,46 @@ Nicht jeder Solarbetrieb sollte einen eigenen Anfrage-Weg bauen.
 
 Wer kein klares Gebiet hat, nicht schnell reagieren kann, keine Angebotsdisziplin hat oder jede Anfrage unabhängig vom Auftragswert annimmt, sollte zuerst den Vertrieb ordnen. Sonst hängt ein besseres System an einem schwachen Ablauf.
 
-Passt, wenn mehreres zusammenkommt:
+Es passt, wenn mehreres zusammenkommt:
 
-```text
-Hohe durchschnittliche Auftragswerte
-klares Zielgebiet
-eigener Vertrieb oder Chef, der selbst abschließt
-schnelle Reaktion auf Anfragen
-Bereitschaft, unpassende Anfragen konsequent auszusortieren
-Budget-Disziplin über mehrere Monate
-```
+- hohe durchschnittliche Auftragswerte,
+- ein klares Zielgebiet,
+- eigener Vertrieb oder ein Chef, der selbst abschließt,
+- schnelle Reaktion auf Anfragen,
+- die Bereitschaft, unpassende Anfragen konsequent auszusortieren,
+- Budget-Disziplin über mehrere Monate.
 
-Passt nicht, wenn die Erwartung lautet:
+Es passt nicht, wenn die Erwartung lautet:
 
-```text
-nächste Woche volle Pipeline
-billigere Leads ohne Änderung am Ablauf
-keine Lust auf Kundenverwaltung und Nachverfolgen
-kein regionaler Fokus
-jeder Kontakt soll irgendwie verkauft werden
-```
+- nächste Woche volle Pipeline,
+- billigere Leads ohne Änderung am Ablauf,
+- keine Lust auf Kundenverwaltung und Nachverfolgen,
+- kein regionaler Fokus,
+- jeder Kontakt soll irgendwie verkauft werden.
 
 Das ist keine Wertung, das ist Passung. Ein eigener Anfrage-Weg verstärkt einen gesunden Kern. Er repariert keinen Betrieb, der noch nicht weiß, welche Aufträge er überhaupt gewinnen will.
 
 ## Häufige Fragen
 
+### Was kosten Solar-Leads?
+
+Gekaufte Solar- und Photovoltaik-Leads liegen je nach Anbieter, Region und Exklusivität meist zwischen 60 und 180 Euro pro Anfrage. Der Stückpreis sagt allein aber wenig: Entscheidend ist, wie viele dieser Anfragen zu Aufträgen werden – und was ein Auftrag Sie damit am Ende kostet.
+
 ### Sind gekaufte Solar-Leads grundsätzlich schlecht?
 
 Nein. Kurzfristig können sie sinnvoll sein: neue Region, Auslastungslücke, akuter Zusatzbedarf. Gefährlich werden sie als Dauerlösung, wenn Sie nie einen eigenen Anfrage-Weg aufbauen und jeden Monat fremde Reichweite mieten.
 
+### Solar-Leads kaufen oder eigene Anfragen aufbauen?
+
+Kaufen bringt schnell Kontakte, aber keinen bleibenden Wert – die Erfahrung und die Daten bleiben beim Portal. Ein eigener Anfrage-Weg braucht Anlauf, gehört danach aber Ihnen und wird mit jedem Monat besser. Für Betriebe mit hohen Auftragswerten und eigenem Vertrieb ist der eigene Weg meist die günstigere Rechnung pro Auftrag.
+
+### Woran erkennt man gute Photovoltaik-Leads?
+
+An vier Merkmalen: Die Anfrage ist exklusiv (nicht an mehrere Betriebe verkauft), sie kommt aus Ihrer Region, sie ist vorgeprüft (Dach, Projektgröße, Kaufabsicht) und sie erreicht Sie schnell nach der Abgabe. Fehlen diese Merkmale, kaufen Sie vor allem Telefonarbeit.
+
 ### Welche Zahl ist wichtiger als der Preis pro Anfrage?
 
 Die Kosten pro Auftrag. Eine billige Anfrage mit 4 Prozent Abschluss kann teurer sein als eine teurere eigene Anfrage mit 15 Prozent Abschluss. Es zählt nicht der Kontaktpreis, sondern der Preis pro gewonnenem Auftrag.
-
-### Warum sind eigene Anfragen oft mehr wert?
-
-Weil sie nur bei Ihnen landen, unter Ihrer Marke laufen, vorher geprüft werden und in Ihrer eigenen Kundenverwaltung liegen. Der Betrieb besitzt die Strecke, die Daten und die Erfahrung.
 
 ### Was ist das Hauptproblem bei gemieteten Agentur-Funnels?
 
@@ -332,11 +316,9 @@ Wenn Sie einfach nur „mehr Leads" wollen, ist das hier der falsche Einstieg.
 
 Der regionale Marktcheck prüft nicht, ob man Ihnen irgendeinen Funnel verkaufen kann. Er prüft drei Dinge:
 
-```text
-Auftragswert: Trägt Ihr durchschnittlicher Auftrag die Kosten eines eigenen Systems?
-Vertriebsreife: Können Sie Anfragen schnell und sauber nachfassen?
-Zielgebiet: Gibt es in Ihrer Region genug Nachfrage und sinnvollen Wettbewerb?
-```
+- **Auftragswert:** Trägt Ihr durchschnittlicher Auftrag die Kosten eines eigenen Systems?
+- **Vertriebsreife:** Können Sie Anfragen schnell und sauber nachfassen?
+- **Zielgebiet:** Gibt es in Ihrer Region genug Nachfrage und sinnvollen Wettbewerb?
 
 Ist die Ampel grün, wird die Anfrage-System-Analyse vorbereitet. Ist sie gelb, benennen wir die Risiken. Ist sie rot, gibt es keine Umsetzungsempfehlung. Das ist Absicht – eine ehrliche Absage statt eines schön formulierten Pitches.
 

--- a/blocksy-child/assets/css/cpo-calculator.css
+++ b/blocksy-child/assets/css/cpo-calculator.css
@@ -242,7 +242,7 @@
 
 .hu-cpo-calculator__summary {
 	display: grid;
-	grid-template-columns: minmax(180px, 0.55fr) minmax(240px, 1fr) auto;
+	grid-template-columns: minmax(180px, 0.55fr) minmax(240px, 1fr);
 	gap: 16px;
 	align-items: center;
 	margin-top: 18px;
@@ -258,14 +258,18 @@
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
+	grid-column: 1 / -1;
+	justify-self: center;
 	min-height: 44px;
-	padding: 0 16px;
+	max-width: 100%;
+	padding: 0.6em 22px;
 	border-radius: 6px;
 	background: #b46a3c;
 	color: #fff7ee;
 	font-weight: 800;
+	text-align: center;
 	text-decoration: none;
-	white-space: nowrap;
+	white-space: normal;
 }
 
 .hu-cpo-calculator__cta:hover,

--- a/blocksy-child/inc/blog-pillar-posts.php
+++ b/blocksy-child/inc/blog-pillar-posts.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return string
  */
 function hu_get_blog_pillar_posts_seed_version() {
-	return '2026-07-01-1';
+	return '2026-07-01-2';
 }
 
 /**
@@ -129,10 +129,12 @@ function hu_blog_pillar_markdown_to_html( $markdown ) {
 		$blockquote_lines = [];
 	};
 
-	$flush_para = static function() use ( &$html, &$paragraph, $flush_list, $flush_blockquote ) {
-		$flush_list();
-		$flush_blockquote();
-
+	// Flushes ONLY the pending paragraph. The list and quote branches call this
+	// while still accumulating their own items; flushing lists/blockquotes here
+	// split every multi-line list into one-item lists and every multi-line
+	// quote/CTA into one box per line (plus empty boxes for `>` separators).
+	// Call sites flush lists and blockquotes explicitly where a break is wanted.
+	$flush_para = static function() use ( &$html, &$paragraph ) {
 		if ( empty( $paragraph ) ) {
 			return;
 		}

--- a/blocksy-child/inc/cpo-calculator.php
+++ b/blocksy-child/inc/cpo-calculator.php
@@ -159,7 +159,7 @@ function hu_cpo_calculator_shortcode() {
 			   data-track-action="cta_marktcheck"
 			   data-track-category="cpo_calculator"
 			   data-track-section="cpo_calculator">
-				Marktcheck mit eigenen Zahlen starten
+				Jetzt Region prüfen
 			</a>
 		</div>
 	</section>

--- a/content/blog-drafts/gastbeitrag-waermepumpe-shk-anfragen.md
+++ b/content/blog-drafts/gastbeitrag-waermepumpe-shk-anfragen.md
@@ -1,0 +1,83 @@
+# Gastbeitrag (Fachmedien-Fassung): Wärmepumpen-Anfragen — warum billige Leads Betriebe teuer zu stehen kommen
+
+- Zielgruppe: SHK-Betriebe, Heizungsbauer, Wärmepumpen-Anbieter (Geschäftsführer/Inhaber)
+- Zweck: redaktioneller Gastbeitrag für Fachmedien (z. B. SBZ, SHK-/Haustechnik-Medien) — KEIN Werbetext
+- Primärer CTA: keiner (bewusst; Link nur in der Autoren-Byline)
+- Byline-Link-Ziel: `/solar-leads-kaufen-lohnt-sich/` (kanonischer Pillar)
+- Bezug: eigenständige Fassung, KEIN Duplikat des Website-Pillars (Exklusivität für die Redaktion)
+- Status: Entwurf für Outreach — vor Versand an das jeweilige Medium redaktionell anpassen
+- Regeln: kein Marktcheck-CTA, kein Affiliate, keine Preis-/Angebotsnennungen, Canon-konform
+
+---
+
+## Gekaufte Wärmepumpen-Leads: Warum der Preis pro Anfrage Betriebe in die Irre führt
+
+Viele SHK-Betriebe kaufen Anfragen für Wärmepumpen über Portale ein. Das wirkt planbar: Man zahlt
+pro Kontakt und bekommt Namen, Telefonnummer und Projektwunsch geliefert. Doch wer nur auf den
+Preis pro Anfrage schaut, bewertet die eigene Kundengewinnung mit der falschen Zahl. Entscheidend
+ist, was ein gewonnener Auftrag am Ende kostet — und da verlieren die vermeintlich billigen
+Anfragen oft.
+
+### Die Rechnung, die im Betriebsalltag fehlt
+
+Was ein Auftrag kostet, ergibt sich aus zwei Größen: dem Preis pro Anfrage und der Quote, mit der
+aus Anfragen Aufträge werden.
+
+Ein Beispiel: Eine Portal-Anfrage für 80 Euro klingt günstig. Wird aber nur eine von zwanzig
+Anfragen zum Auftrag, kostet jeder gewonnene Auftrag 1.600 Euro — nur an Anfragekosten, ohne die
+Arbeitszeit im Vertrieb. Eine selbst gewonnene Anfrage für 180 Euro klingt teuer. Führt aber jede
+siebte zum Auftrag, liegt der Auftrag bei rund 1.200 Euro. Die teurere Anfrage ist in dieser
+Rechnung die günstigere.
+
+Warum die Abschlussquoten so weit auseinanderliegen, hat einen strukturellen Grund: Viele Portale
+verkaufen dieselbe Anfrage an mehrere Betriebe. Der Hausbesitzer erwartet dann mehrere Anrufe,
+vergleicht Preise und entscheidet häufig über den Rabatt. Wer als dritter oder vierter Anbieter
+anruft, startet das Gespräch nicht als Fachbetrieb des Vertrauens, sondern als austauschbarer
+Rückrufer.
+
+### Bei der Wärmepumpe wiegt das doppelt
+
+Eine Wärmepumpe ist kein Katalogprodukt. Zwischen Anfrage und Auftrag liegen Heizlast, Vorlauf-
+temperaturen, Bestandsanalyse, Förderkulisse und oft ein Sanierungsgespräch. Diese Beratungstiefe
+kostet Stunden — pro Anfrage. Wer viele schwach vorgeprüfte Kontakte einkauft, bezahlt also
+zweimal: erst den Lead, dann die Beratungszeit für Interessenten, die nie kaufen wollten oder
+deren Gebäude nicht passt.
+
+Dazu kommt die Abhängigkeit: Das Portal besitzt die Werbung, das Formular und die Daten. Der
+Betrieb bekommt den Kontakt — mehr nicht. Steigen die Preise oder sinkt die Qualität, beginnt die
+Suche von vorn. Zwölf Monate Leadeinkauf hinterlassen Rechnungen und einzelne Aufträge, aber
+keinen bleibenden Wert im Betrieb: keine eigene Sichtbarkeit bei Google, keine eigene Datenbasis,
+keine wachsende Anfragequelle.
+
+### Was ein eigener Anfrage-Weg anders macht
+
+Die Alternative ist kein Hexenwerk, sondern Handwerk in digitaler Form: eine schnelle, schlanke
+eigene Seite für das Wärmepumpen-Angebot, eine kurze Formularstrecke mit Vorprüfung (Gebäude,
+Region, Zeithorizont, Projektrahmen) und ein sauberes Nachverfolgen jeder Anfrage bis zum
+Auftrag. So lernt der Betrieb mit jedem Monat, welche Anfragen wirklich zu Aufträgen werden —
+und die Werbung wird auf Abschlüsse gesteuert statt auf ausgefüllte Formulare.
+
+Drei Fragen zeigen schnell, wo ein Betrieb steht:
+
+- Wissen Sie, was Sie ein gewonnener Auftrag je Anfragequelle kostet — nicht nur der Lead?
+- Gehören Ihnen die Seiten, Formulare und Daten Ihrer Kundengewinnung — oder einem Vermittler?
+- Wird eine unpassende Anfrage aussortiert, bevor sie Vertriebszeit kostet?
+
+Wer alle drei Fragen sicher beantworten kann, hat die Grundlage. Wer nicht, bezahlt die Lücke —
+meist unsichtbar, verteilt auf Leadrechnungen und verlorene Stunden im Vertrieb.
+
+### Fazit
+
+Gekaufte Anfragen können kurzfristig helfen: eine neue Region, eine Auslastungslücke, akuter
+Zusatzbedarf. Als Dauerlösung sind sie für Betriebe mit hohen Auftragswerten selten die
+günstigste Rechnung. Die wichtigere Kennzahl steht nicht auf der Leadrechnung, sondern in der
+eigenen Auftragsliste: Was kostet ein gewonnener Auftrag — und wem gehört der Weg dorthin?
+
+---
+
+**Autoren-Byline (für die Redaktion):**
+
+*Haşim Üner entwickelt eigene Anfrage-Systeme für Solar-, Wärmepumpen- und Speicher-Anbieter —
+von der schnellen Website über die Vorprüfung bis zum Nachverfolgen jeder Anfrage bis zum
+Auftrag. Eine ausführliche Analyse zur Wirtschaftlichkeit gekaufter Leads hat er unter
+https://hasimuener.de/solar-leads-kaufen-lohnt-sich/ veröffentlicht.*

--- a/docs/seo/outreach-plan-2026.md
+++ b/docs/seo/outreach-plan-2026.md
@@ -1,0 +1,90 @@
+# Outreach-Plan 2026 — Fachmedien, Foren, Plattformen
+
+Stand: 2026-07-01. Verantwortlich: Haşim Üner (Versand manuell, außerhalb des Repos).
+Aufbauend auf `docs/seo/offpage-authority-playbook.md` (Phase 2: themenrelevante Links).
+
+> **Ziel.** Themenrelevante Veröffentlichungen und Verlinkungen für den kanonischen Pillar
+> `https://hasimuener.de/solar-leads-kaufen-lohnt-sich/` gewinnen. Der Link entsteht sauber über
+> die **Autoren-Byline** eines redaktionellen Gastbeitrags — nie über „bitte Backlink setzen".
+
+## Assets (fertig im Repo)
+
+| Asset | Datei | Einsatz |
+| --- | --- | --- |
+| Kanonischer Pillar (live) | `blocksy-child/assets/content/blog/photovoltaik-leads-tco-rechnung.md` | Byline-Ziel, Beweis der Substanz |
+| Gastbeitrag SHK/Wärmepumpe | `content/blog-drafts/gastbeitrag-waermepumpe-shk-anfragen.md` | Fachmedien-Pitch (SBZ u. a.) |
+| Proof-Zahlen (E3, kanonisch) | 150 € → 22 € pro Anfrage, 1.750+ Anfragen, 12 % Abschluss | Daten-Aufhänger im Pitch |
+
+## Zielliste (Reihenfolge = Priorität)
+
+1. **SBZ (SHK-Fachmedium)** — Fachredaktion Heizung/Wärmepumpe zuerst; Anzeigenabteilung nur,
+   falls die Antwort „nur bezahlt möglich" lautet. Kontakte vor Versand selbst aus den aktuellen
+   Mediadaten/dem Impressum verifizieren (Redaktionen wechseln; keine Namen aus KI-Antworten
+   übernehmen).
+2. **Weitere SHK-/Haustechnik-Medien** (z. B. Haustec-, TGA-, Gebäudetechnik-Umfeld) — gleicher
+   Gastbeitrag-Winkel, pro Medium leicht angepasst; niemals denselben Text an zwei Redaktionen
+   gleichzeitig (Exklusivität anbieten, Frist setzen, dann weiterreichen).
+3. **Photovoltaikforum & Fach-Communities** — kein Artikel-Pitch, sondern echte Beiträge mit
+   Substanz in passenden Threads (Leadkosten, Portal-Erfahrungen); Profil verlinkt die Domain.
+4. **Solar-/Energie-Newsletter und Blogs** — Daten-Aufhänger („was Leads wirklich kosten")
+   anbieten; kurze Zitate + Link auf die Analyse.
+5. **LinkedIn (eigene Distribution)** — Pillar-Kernthese als eigenständiger Post mit Link;
+   wiederholbar pro neuem Beitrag (Brand-/Referral-Signal laut Playbook Phase 3).
+6. **Regionale Wirtschafts-/Gründermedien Hannover** — Winkel „B2B-Website als Anfrage-System
+   statt Schaufenster" (zahlt auf den lokalen Track im Playbook ein).
+
+## Pitch-Vorlage A — Fachredaktion (Gastbeitrag)
+
+> Betreff: Themenvorschlag: Was gekaufte Wärmepumpen-Leads Betriebe wirklich kosten
+>
+> Hallo [Name],
+>
+> ich arbeite mit Solar-, Wärmepumpen- und Speicher-Anbietern an eigenen Anfrage-Wegen — also
+> Website, Vorprüfung und Nachverfolgung bis zum Auftrag, damit Betriebe weniger von eingekauften
+> Portal-Leads abhängen.
+>
+> Für Ihre Leser hätte ich einen praxisnahen Fachbeitrag: **„Gekaufte Wärmepumpen-Leads: Warum der
+> Preis pro Anfrage Betriebe in die Irre führt."** Kern: Nicht der Leadpreis zählt, sondern was ein
+> gewonnener Auftrag kostet — mit nachvollziehbarer Beispielrechnung, den strukturellen Gründen
+> (Mehrfachverkauf, Beratungstiefe bei der Wärmepumpe) und drei Prüffragen für Betriebe. Kein
+> Werbetext; ein Hinweis auf meine Arbeit in der Autorenzeile genügt mir.
+>
+> Der Beitrag wäre für Sie exklusiv. Eine ausführliche Analyse zum Thema habe ich auf meiner Seite
+> veröffentlicht — der Fachbeitrag ist eine eigenständige Fassung für Ihr Medium.
+>
+> Wäre das grundsätzlich interessant?
+>
+> Beste Grüße, Haşim Üner
+
+## Pitch-Vorlage B — Daten-Aufhänger (Newsletter/Blogs)
+
+> Betreff: Zahlen aus der Praxis: Portal-Lead vs. eigene Anfrage bei Solar & Wärmepumpe
+>
+> Hallo [Name],
+>
+> kurzer Datenpunkt aus einem realen Projekt, falls er in Ihre nächste Ausgabe passt: Ein
+> Energie-Anbieter kam mit gekauften Anfragen auf 150 € pro Kontakt. Nach Aufbau eines eigenen
+> Anfrage-Wegs lagen die eigenen Anfragen bei 22 € — bei 12 % Abschlussquote und über 1.750
+> Anfragen in sechs Monaten. Die vollständige, konservativ gerechnete Analyse (inkl. der
+> Kosten-pro-Auftrag-Logik) steht hier: https://hasimuener.de/solar-leads-kaufen-lohnt-sich/
+>
+> Wenn Sie das Thema aufgreifen, beantworte ich gern Rückfragen oder liefere ein Kurz-Zitat.
+>
+> Beste Grüße, Haşim Üner
+
+## Regeln (No-Gos)
+
+- **Nie** den Website-Pillar 1:1 an ein Medium geben (Duplicate + redaktioneller Anspruch);
+  immer die eigenständige Gastbeitrags-Fassung nutzen.
+- **Redaktion vor Anzeigenverkauf.** Bezahlte Platzierung nur als bewusste zweite Option.
+- **Keine erfundenen Zahlen** — nur die kanonischen E3-Werte und die Beispielrechnungen aus dem
+  Pillar; keine Marktvolumina behaupten.
+- Kontaktdaten und Zuständigkeiten **vor jedem Versand** selbst verifizieren.
+- Kein Massenversand: pro Woche wenige, individuell angepasste Pitches; Antworten dokumentieren.
+- Keine gekauften Linkpakete/PBNs (siehe Playbook Anti-Pattern).
+
+## Messung
+
+Monatlich (nicht wöchentlich, siehe Playbook): verweisende Domains, Position
+„solar leads kaufen"-Cluster in der Search Console, Referral-Traffic der Byline-URL,
+Antwortquote der Pitches (Ziel: 1 redaktionelle Zusage in den ersten 6 Wochen).

--- a/docs/seo/tco-pillar-go-live.md
+++ b/docs/seo/tco-pillar-go-live.md
@@ -13,6 +13,14 @@ Stand: 2026-07-01 (Rewrite auf Handwerker-Klartext, neue Überschrift, Slug-Wech
 > umgeschrieben, die Überschrift auf Such-/Schmerz-Ebene gebracht, der Slug auf `solar-leads-kaufen-lohnt-sich`
 > geändert (301 via `hu_blog_pillar_redirect_legacy_slugs`), und der CPO-Rechner von 18 auf 3 sichtbare
 > Felder pro Seite reduziert. Go-Live läuft über den Seed-Version-Bump (`2026-07-01-1`).
+>
+> **Update 2026-07-01 (Bugfix-Release, Seed `2026-07-01-2`):** Markdown-Konverter-Bug behoben —
+> `$flush_para` flushte Blockquotes und Listen pro Zeile, wodurch CTA-Kästen zerhackt (leere Boxen,
+> Link ohne Button) und Aufzählungen als Ein-Punkt-Listen renderten; per lokalem Test-Harness
+> verifiziert. Zusätzlich: alle `pre/code`-Kästen aus dem Beitrag entfernt (Klartext/Listen statt
+> Monospace), Rechner-Summary-Button gekürzt und zentriert, FAQ um Suchfragen erweitert
+> („Was kosten Solar-Leads?" u. a.). Outreach-Paket: `content/blog-drafts/gastbeitrag-waermepumpe-shk-anfragen.md`
+> + `docs/seo/outreach-plan-2026.md`.
 
 ## 1. Publish-Readiness-Audit (repo-seitig verifiziert)
 


### PR DESCRIPTION
## Was dieser PR behebt (Live-Review-Feedback mit Screenshots)

**1. Zerhackte CTA-Kästen + leere Boxen + Link ohne Button — echter Konverter-Bug, per Test bewiesen.**
`$flush_para` in `blog-pillar-posts.php` flushte bei jeder Zeile auch Blockquotes und Listen. Folge: Die CTA-Blöcke („Stopp…", „Marktcheck-Filter:") zerfielen in Einzel-Boxen mit leeren Blockquotes dazwischen, der Marktcheck-Link bekam nie sein Button-Styling — und Aufzählungen renderten als Ein-Punkt-Listen („1. … 1. … 1. …"). `$flush_para` flusht jetzt nur noch den Absatz; alle Call-Sites flushen Listen/Quotes explizit. Verifiziert mit lokalem PHP-Test-Harness (CTA = genau 1 `aside`, 0 leere Blockquotes, Listen korrekt, Regressionstests für Headings/Code-Fences/Reihenfolge — alle grün). Seed-Version `2026-07-01-2` rendert beide Seed-Beiträge nach Deploy neu.

**2. „Copy-Paste-Kästchen" entfernt.**
Alle 10 `pre/code`-Blöcke im Solar-Leads-Pillar durch Klartext-Sätze mit fetten Ergebnissen und echte Aufzählungen ersetzt — keine Programmierer-Monospace-Optik mehr für die Handwerker-Zielgruppe.

**3. Rechner-Button.**
Summary-Button lief rechts aus der Box (Grid-Überlauf). Jetzt: kürzerer Text („Jetzt Region prüfen"), eigene zentrierte Zeile, Umbruch statt Überlauf. Tracking-Action unverändert.

**4. Sprache & Keywords (Runde 2).**
Kapitel 5/6 weiter vereinfacht (Technik-Liste → vier Klartext-Punkte, Server-Side Tracking in einem Halbsatz erklärt). FAQ um echte Suchfragen erweitert: „Was kosten Solar-Leads?", „Solar-Leads kaufen oder eigene Anfragen aufbauen?", „Woran erkennt man gute Photovoltaik-Leads?". Keyword „Solar-Leads kaufen" jetzt in H1 + H2.

**5. Outreach-Paket für die Plattform-Aktion.**
- `content/blog-drafts/gastbeitrag-waermepumpe-shk-anfragen.md` — ent-marketete, exklusive Gastbeitrags-Fassung (SHK/Wärmepumpe) für Fachmedien; kein CTA, kein Affiliate, Link nur in der Autoren-Byline.
- `docs/seo/outreach-plan-2026.md` — priorisierte Zielliste, zwei Pitch-Vorlagen, No-Gos, Messpunkte.

## Verifikation
- Konverter-Test-Harness: alle Tests bestanden
- `lint-canon-drift`, `check-german-copy`, `lint-e3-canon` gegen `origin/main`: grün
- `php -l` + Pre-Deploy-Smoke: SAFE TO PUSH

## Nach Merge/Deploy manuell prüfen
- Live-Seite: eine CTA-Karte mit Button, keine leeren Boxen, keine Monospace-Kästen, Rechner-Button zentriert
- Alte URL `…/photovoltaik-leads-tco-rechnung/` weiterhin 301 auf `…/solar-leads-kaufen-lohnt-sich/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KBCmz25WJ7siu9ZY7qd38u

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBCmz25WJ7siu9ZY7qd38u)_