### PR TITLE
SEO: Semrush-Audit — eindeutige Meta-Descriptions + interne Link-Hygiene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 2026-07
+
+### Semrush Site-Audit: Meta-Descriptions & interne Link-Hygiene
+
+- **Fehlende/doppelte Meta-Descriptions behoben** (`inc/seo-meta.php`, Forced-SEO-Map): `/stack-solar/` hatte keine Meta-Description; `/owned-leads-statt-ad-miete/` und `/meta-ads-fuer-b2b/` teilten sich eine identische. Jeder Slug bekommt jetzt eine eigene, eindeutige Description (nur `description` gesetzt, Titel bleiben unberührt).
+- **`rel="nofollow"` von internen Impressum-/Datenschutz-Links entfernt** (`template-parts/site-footer.php`, `template-parts/footer-cta.php`): nofollow auf internen Links widerspricht Googles Empfehlung und war Auslöser für ~168 Semrush-Warnungen. Die Seiten bleiben über `noindex`/robots aus dem Index — der nofollow war redundant. Sponsored-/Affiliate-Links (HostPress) bleiben korrekt `sponsored nofollow`.
+- **Nicht im Repo behebbar** (als manuelle WordPress-Admin-Aufgabe dokumentiert): 161 „Broken internal links" mit Zielen `?page_id=13035` / `?page_id=14283` (beide 404) stammen aus Menü/Widgets in der WordPress-DB, nicht aus dem Theme. Ebenso: fehlendes HSTS auf `www.hasimuener.de` (Server/Hosting).
+
 ## 2026-06
 
 ### Über-mich (Editorial) geschärft — person-first, ohne Money-Page-Redundanz

--- a/blocksy-child/inc/seo-meta.php
+++ b/blocksy-child/inc/seo-meta.php
@@ -177,6 +177,18 @@ function hu_get_forced_singular_seo_map() {
 	return (array) apply_filters(
 		'hu_forced_singular_seo_map',
 		[
+			// Eindeutige Meta-Descriptions für Seiten/Beiträge, die sonst ohne
+			// bzw. mit doppelter Description ausgeliefert wurden (Semrush Site
+			// Audit 2026-07-08). Nur 'description' gesetzt: Titel bleiben unberührt.
+			'stack-solar' => [
+				'description' => 'Der Performance-Stack für Solar- und SHK-Anbieter: Frontend, Managed Hosting, Server-Side Tracking, CRM und Marktcheck-Vorqualifizierung in fünf Schichten.',
+			],
+			'owned-leads-statt-ad-miete' => [
+				'description' => 'Von gemieteter Ad-Nachfrage zu eigenen Leads: Warum Owned-Lead-Infrastruktur B2B-Anbieter unabhängiger macht als Dauer-Budget bei Meta und Google Ads.',
+			],
+			'meta-ads-fuer-b2b' => [
+				'description' => 'Meta Ads für B2B: fünf Kampagnenstrukturen für planbare Anfragen statt teurer Reichweite — mit Consent, sauberem Tracking und CRM-Rückführung.',
+			],
 			'kontakt' => [
 				'title'       => 'Kontakt & Projektanfrage | Haşim Üner',
 				'description' => 'Projekt oder Frage kurz einordnen: ein Formular, händisch geprüfte Rückmeldung innerhalb von 48 Stunden. Kein Pflicht-Call, kein Vertriebsteam.',

--- a/blocksy-child/template-parts/footer-cta.php
+++ b/blocksy-child/template-parts/footer-cta.php
@@ -47,9 +47,9 @@ set_query_var( 'nexus_hide_footer_primary_cta', true );
 
 		<p class="nexus-footer-cta__legal">
 			Keine Cookies bei öffentlichen Seitenaufrufen.
-			<a href="<?php echo esc_url( $privacy_url ); ?>" rel="nofollow">Datenschutz</a>
+			<a href="<?php echo esc_url( $privacy_url ); ?>">Datenschutz</a>
 			<span aria-hidden="true">·</span>
-			<a href="<?php echo esc_url( $imprint_url ); ?>" rel="nofollow">Impressum</a>
+			<a href="<?php echo esc_url( $imprint_url ); ?>">Impressum</a>
 		</p>
 
 		<?php get_template_part( 'template-parts/trust-section' ); ?>

--- a/blocksy-child/template-parts/site-footer.php
+++ b/blocksy-child/template-parts/site-footer.php
@@ -59,8 +59,8 @@ if ( $is_whitelabel_context ) {
 		<p class="ft__audit-note"><?php echo esc_html( $audit_footer_note ); ?></p>
 		<nav class="ft__audit-links" aria-label="Marktcheck-Footer-Navigation">
 			<a href="<?php echo esc_url( $request_url ); ?>" data-track-action="cta_audit_footer_analysis" data-track-category="lead_gen">Marktcheck mit Fit-Entscheid starten</a>
-			<a href="<?php echo esc_url( $imprint_url ); ?>" rel="nofollow">Impressum</a>
-			<a href="<?php echo esc_url( $privacy_url ); ?>" rel="nofollow">Datenschutz</a>
+			<a href="<?php echo esc_url( $imprint_url ); ?>">Impressum</a>
+			<a href="<?php echo esc_url( $privacy_url ); ?>">Datenschutz</a>
 		</nav>
 	</div>
 </footer>
@@ -76,9 +76,9 @@ if ( $is_whitelabel_context ) {
 			</div>
 			<a class="ft__cta" href="<?php echo esc_url( $request_url ); ?>" data-track-action="cta_energy_footer_analysis" data-track-category="lead_gen" data-track-section="footer_energy" data-track-funnel-stage="energy_footer">Marktcheck mit Fit-Entscheid starten</a>
 			<nav class="ft__energy-legal" aria-label="Rechtliches">
-			<a href="<?php echo esc_url( $imprint_url ); ?>" rel="nofollow">Impressum</a>
+			<a href="<?php echo esc_url( $imprint_url ); ?>">Impressum</a>
 			<span aria-hidden="true">·</span>
-			<a href="<?php echo esc_url( $privacy_url ); ?>" rel="nofollow">Datenschutz</a>
+			<a href="<?php echo esc_url( $privacy_url ); ?>">Datenschutz</a>
 		</nav>
 		<div class="ft__social ft__social--energy" aria-label="Profile">
 			<a href="https://www.linkedin.com/in/hasim-%C3%BCner/" aria-label="LinkedIn-Profil" rel="me noopener noreferrer" target="_blank">
@@ -137,9 +137,9 @@ if ( $is_whitelabel_context ) {
 				</ul>
 
 				<nav class="ft__legal" aria-label="Rechtliches">
-					<a href="<?php echo esc_url( $imprint_url ); ?>" rel="nofollow">Impressum</a>
+					<a href="<?php echo esc_url( $imprint_url ); ?>">Impressum</a>
 					<span aria-hidden="true">·</span>
-					<a href="<?php echo esc_url( $privacy_url ); ?>" rel="nofollow">Datenschutz</a>
+					<a href="<?php echo esc_url( $privacy_url ); ?>">Datenschutz</a>
 				</nav>
 			</section>
 		</nav>


### PR DESCRIPTION
- seo-meta.php: Forced-SEO-Map um eindeutige Descriptions für /stack-solar/ (fehlte), /owned-leads-statt-ad-miete/ und /meta-ads-fuer-b2b/ (waren identisch) ergänzt; nur description, Titel unberührt.
- site-footer.php + footer-cta.php: rel="nofollow" von internen Impressum-/Datenschutz-Links entfernt (Google-konform, löst ~168 Semrush-Warnungen; Seiten bleiben via noindex/robots aus dem Index).


Claude-Session: https://claude.ai/code/session_01PysuamYfMfsDqBp5EeF59C