### PR TITLE
SEO: Portal-Einordnungs-Posts priorisieren Markteinordnung-Kontext vo…

### DIFF
--- a/blocksy-child/single.php
+++ b/blocksy-child/single.php
@@ -67,7 +67,11 @@ get_template_part( 'template-parts/blog-header' );
 			'secondary_url'   => $audit_url,
 		];
 
-		if ( in_array( 'solar-waermepumpen-anfrage-systeme', $post_cat_slugs, true ) ) {
+		// Portal-Einordnungs-Posts (checkfox u. a.) liegen in BEIDEN Kategorien
+		// (solar-waermepumpen-anfrage-systeme + markteinordnung). Für Vergleichsportal-
+		// Intent ("ist X seriös?") ist die Portal-vs-eigenes-System-Einordnung der
+		// treffendere nächste Schritt, daher hat markteinordnung/owned-leads Vorrang.
+		if ( in_array( 'solar-waermepumpen-anfrage-systeme', $post_cat_slugs, true ) && ! array_intersect( [ 'markteinordnung', 'owned-leads' ], $post_cat_slugs ) ) {
 			$article_context = [
 				'eyebrow'         => __( 'Solar-Fokus', 'blocksy-child' ),
 				'title'           => __( 'Teil des Anfrage-Systems für Solar & Wärmepumpe.', 'blocksy-child' ),

--- a/blocksy-child/template-parts/related-content.php
+++ b/blocksy-child/template-parts/related-content.php
@@ -97,9 +97,12 @@ if ( 'post' === $related_type && is_singular( 'post' ) && ! empty( $category_ids
 	];
 
 	$link_priority = [
-		'solar-waermepumpen-anfrage-systeme',
+		// Portal-Einordnungs-Posts liegen in solar-waermepumpen-anfrage-systeme UND
+		// markteinordnung; für Vergleichsportal-Intent hat die Portal-vs-eigenes-
+		// System-Einordnung Vorrang vor der generischen Pillar.
 		'markteinordnung',
 		'owned-leads',
+		'solar-waermepumpen-anfrage-systeme',
 		'sichtbarkeit-daten-conversion',
 		'tracking',
 		'seo',


### PR DESCRIPTION
…r Solar-Pillar

Die fünf Portal-Einordnungs-Posts (checkfox u.a.) liegen in beiden Kategorien solar-waermepumpen-anfrage-systeme + markteinordnung. Bisher gewann die generische Solar-Pillar-Einordnung. Für Vergleichsportal-Intent ("ist X seriös?") ist die wirtschaftliche Portal-vs-eigenes-System-Einordnung der treffendere nächste Schritt und leitet informationalen Portal-Traffic gezielt zu den Money-Pages.

- single.php: Kontext-Bridge + "Nächster Schritt" priorisieren markteinordnung/owned-leads (-> TCO /eigene-leadgenerierung-vs-portale/ + CPL/CPO /cost-per-lead-photovoltaik/).
- related-content.php: Related-Primary-Link analog priorisiert.
- Blast-Radius: exakt die fünf Portal-Posts (nur diese liegen in markteinordnung); Marktcheck-CTA bleibt ueberall erhalten.


Claude-Session: https://claude.ai/code/session_01Vmcmiv8Y4VRC6XAfWGvcPG