### PR TITLE
Anonymize case study: replace company name with generic descriptor

### DIFF
--- a/automations/n8n/data-models/readiness-diagnosis-payload.v1.contract.json
+++ b/automations/n8n/data-models/readiness-diagnosis-payload.v1.contract.json
@@ -521,7 +521,7 @@
       "attribution": {
         "landing_page_url": "https://hasimuener.de/readiness-diagnose/",
         "entry_page_url": "https://hasimuener.de/energie-fahrplan-demo/",
-        "previous_internal_url": "https://hasimuener.de/e3-new-energy/",
+        "previous_internal_url": "https://hasimuener.de/case-study-solar-leadgenerierung/",
         "referrer": null,
         "utm": {
           "source": null,

--- a/blocksy-child/assets/content/blog/photovoltaik-leads-tco-rechnung.md
+++ b/blocksy-child/assets/content/blog/photovoltaik-leads-tco-rechnung.md
@@ -211,7 +211,7 @@ Das Ergebnis wird nicht schöngerechnet. Wenn der eigene Weg bei Ihnen nicht tr�
 
 ## 9. Aus der Praxis: aus 150 € pro Anfrage wurden 22 €
 
-Der Fall E3 New Energy wird oft zu groß erzählt. Das ist gar nicht nötig. Die nackten Zahlen reichen:
+Der Fall eines mittelständischen PV-Installationsbetriebs wird oft zu groß erzählt. Das ist gar nicht nötig. Die nackten Zahlen reichen:
 
 - **Vorher:** 150 € pro gekaufter Anfrage
 - **Nachher:** 22 € pro eigener Anfrage
@@ -225,7 +225,7 @@ Die eigentliche Lehre ist nicht die Prozentzahl. Sie lautet: Der Vertrieb war ni
 
 Viele Betriebe reagieren auf schwache Portal-Leads mit Vertriebstraining. Das kann helfen, löst aber nicht den Kern. Wenn der Kunde schon mit mehreren spricht und auf Preis gepolt ist, arbeitet Ihr Vertrieb gegen die Struktur des Kanals.
 
-Der [E3-Fall](/e3-new-energy/) ist deshalb kein Ergebnisversprechen, sondern ein Beleg für die Mechanik: Wenn Anfragequelle, Nachverfolgen, Vorprüfung und Vertrieb zusammenspielen, ändert sich die Wirtschaftlichkeit.
+Der [Fall dieser Case Study](/case-study-solar-leadgenerierung/) ist deshalb kein Ergebnisversprechen, sondern ein Beleg für die Mechanik: Wenn Anfragequelle, Nachverfolgen, Vorprüfung und Vertrieb zusammenspielen, ändert sich die Wirtschaftlichkeit.
 
 ## 10. Sie müssen das Rad nicht neu erfinden
 

--- a/blocksy-child/assets/content/blog/wordpress-ttfb-google-ads-ladezeit.md
+++ b/blocksy-child/assets/content/blog/wordpress-ttfb-google-ads-ladezeit.md
@@ -100,7 +100,7 @@ Der Aufwand: höher. Die Skalierbarkeit: deutlich besser. Die TTFB-Werte: identi
 
 ## 5. Was TTFB im CPL und CPO konkret bewegt
 
-Im [E3-Case](/e3-new-energy/) hat eine vollständige Anfrage-System-Migration den Cost per Lead von 150 Euro auf 22 Euro gesenkt. Page Speed war einer von mehreren Faktoren — neben Vorqualifizierung, Server-Side Tracking und CRM-Übergabe.
+In der [Solar Case Study](/case-study-solar-leadgenerierung/) hat eine vollständige Anfrage-System-Migration den Cost per Lead von 150 Euro auf 22 Euro gesenkt. Page Speed war einer von mehreren Faktoren — neben Vorqualifizierung, Server-Side Tracking und CRM-Übergabe.
 
 Aber Page Speed wirkt an drei Stellen gleichzeitig:
 

--- a/blocksy-child/assets/css/about-editorial.css
+++ b/blocksy-child/assets/css/about-editorial.css
@@ -462,7 +462,7 @@
 	outline-offset: 3px;
 }
 
-/* Inline-Link im Bio-Fließtext (E3-Case) */
+/* Inline-Link im Bio-Fließtext (Case Study) */
 .about-editorial__inline-link {
 	color: var(--ae-accent-2);
 	text-decoration: underline;

--- a/blocksy-child/assets/css/agentur.css
+++ b/blocksy-child/assets/css/agentur.css
@@ -1102,7 +1102,7 @@
 }
 
 /* ---------------------------------------------------------------------------
-   9. PROOF E3 DEEP DIVE — case study cards
+   9. PROOF CASE STUDY DEEP DIVE — case study cards
    --------------------------------------------------------------------------- */
 #proof {
   background: var(--ag-surface);

--- a/blocksy-child/assets/css/energy-systems.css
+++ b/blocksy-child/assets/css/energy-systems.css
@@ -2560,7 +2560,7 @@
 }
 
 /* ══════════════════════════════════════════════════════════════
-   E3 New Energy Methodik-Case
+   Solar Case Study Methodik-Case
    Uses the same warm monochrome/copper token set as the solar page,
    but keeps layout scoped to .e3-methodology.
    ══════════════════════════════════════════════════════════════ */
@@ -3096,7 +3096,7 @@
 }
 
 /* ══════════════════════════════════════════════════════════════
-   E3 Vertiefungs-Block — Methodik-Sub-Pages-Hub
+   Case Study Vertiefungs-Block — Methodik-Sub-Pages-Hub
    Light-Layout, paper-2 Background, copper Accents.
    ══════════════════════════════════════════════════════════════ */
 .solar-page .e3-section--deeper .e3-section__head {

--- a/blocksy-child/assets/css/homepage-redesign.css
+++ b/blocksy-child/assets/css/homepage-redesign.css
@@ -749,7 +749,7 @@
 .hu-hp .hu-model--b .hu-model__pill { background: rgba(224,138,60,.14); color: var(--accent); border: 1px solid rgba(224,138,60,.4); }
 
 /* =============================================================
-   PROOF (E3)
+   PROOF (Case Study)
    ============================================================= */
 .hu-hp .hu-proof-cards {
   display: grid;

--- a/blocksy-child/assets/css/results.css
+++ b/blocksy-child/assets/css/results.css
@@ -92,7 +92,7 @@
     justify-content: center;
 }
 
-/* Case Cards (E3, DOMDAR, Whitelabel)
+/* Case Cards (Solar Case Study, DOMDAR, Whitelabel)
    ========================================================================== */
 
 .results-case-card {

--- a/blocksy-child/assets/css/single-editorial.css
+++ b/blocksy-child/assets/css/single-editorial.css
@@ -603,7 +603,7 @@
          <div class="casestudy-header">
            <div>
              <div class="casestudy-label">Fallstudie</div>
-             <div class="casestudy-name">E3 New Energy</div>
+             <div class="casestudy-name">Solar Case Study</div>
            </div>
            <div class="casestudy-meta">6 Monate · ...</div>
          </div>

--- a/blocksy-child/assets/css/solar-leadgenerierung-solara.css
+++ b/blocksy-child/assets/css/solar-leadgenerierung-solara.css
@@ -622,7 +622,7 @@
   flex-shrink: 0;
 }
 
-/* ─── 5b) Proof-Bar (E3-Kennzahlen früh, Teaser → #ergebnisse) ─ */
+/* ─── 5b) Proof-Bar (Case-Study-Kennzahlen früh, Teaser → #ergebnisse) ─ */
 .solara-landing .sol-proofbar {
   border-bottom: 1px solid var(--line);
   padding: 22px 0;
@@ -829,7 +829,7 @@
   color: var(--fg-3);
 }
 
-/* Proof-Sektion: Abbinder (Tiefendiagnose + E3-Case-Link) */
+/* Proof-Sektion: Abbinder (Tiefendiagnose + Case-Study-Link) */
 .solara-landing .sol-proof-foot {
   display: flex;
   flex-wrap: wrap;

--- a/blocksy-child/assets/js/solar-leadgenerierung-solara.js
+++ b/blocksy-child/assets/js/solar-leadgenerierung-solara.js
@@ -582,7 +582,7 @@
       var deadlineHuman = qualification.response_deadline_human || '';
       var proof = (!isNurture && qualification.proof && typeof qualification.proof === 'object') ? qualification.proof : null;
       var calcom = buildCalcomUrl(CFG.calcomUrl || 'https://cal.com/hasim-uener/30min', state.answers);
-      var caseUrl = CFG.caseUrl || '/e3-new-energy/';
+      var caseUrl = CFG.caseUrl || '/case-study-solar-leadgenerierung/';
 
       var ctaRow;
       if (isNurture) {
@@ -591,13 +591,13 @@
             href: caseUrl,
             className: 'is-primary',
             dataset: {
-              trackAction: 'cta_solar_success_to_e3_case',
+              trackAction: 'cta_solar_success_to_case_study',
               trackCategory: 'proof',
               trackSection: 'intake_success_nurture',
               trackFunnelStage: 'nurture_resource'
             }
           }, [
-            el('span', null, 'E3 New Energy Case lesen'),
+            el('span', null, 'Case Study lesen'),
             el('span', { 'aria-hidden': 'true', html: ARROW_SVG })
           ])
         ]);
@@ -622,12 +622,12 @@
             href: caseUrl,
             className: 'is-ghost',
             dataset: {
-              trackAction: 'cta_solar_success_to_e3_case',
+              trackAction: 'cta_solar_success_to_case_study',
               trackCategory: 'proof',
               trackSection: 'intake_success'
             }
           }, [
-            el('span', null, 'E3 Case lesen'),
+            el('span', null, 'Case Study lesen'),
             el('span', { 'aria-hidden': 'true', html: ARROW_SVG })
           ])
         ]);

--- a/blocksy-child/front-page.php
+++ b/blocksy-child/front-page.php
@@ -6,7 +6,7 @@
  *   - Hero: Leitmotiv links + animierte SVG-Pipeline (Blueprint) rechts.
  *   - Gateway-Band (3 Weichen) direkt unter dem Hero.
  *   - Sektionen 02–10: Verlust-Raster, Prozess-Kaskade, System-Phasen,
- *     E3-Proof, Portal-Chaos vs. Daten-Integrität, About, FAQ,
+ *     Case-Study-Proof, Portal-Chaos vs. Daten-Integrität, About, FAQ,
  *     Vertiefung, Final Routing.
  *
  * Schema/SEO: Title + Description kommen aus inc/seo-meta.php
@@ -24,7 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /* ── Datenbindungen ────────────────────────────────────── */
 $analysis_url      = function_exists( 'hu_get_request_analysis_url' ) ? hu_get_request_analysis_url() : home_url( '/solar-waermepumpen-leadgenerierung/#marktcheck' );
 $e3_canon          = function_exists( 'hu_e3_canon' ) ? hu_e3_canon() : [];
-$e3_case_url       = isset( $e3_canon['url'] ) ? (string) $e3_canon['url'] : home_url( '/e3-new-energy/' );
+$e3_case_url       = isset( $e3_canon['url'] ) ? (string) $e3_canon['url'] : home_url( '/case-study-solar-leadgenerierung/' );
 $e3_metrics        = isset( $e3_canon['metrics'] ) && is_array( $e3_canon['metrics'] ) ? $e3_canon['metrics'] : [];
 $e3_lead_count     = $e3_metrics['lead_count']['display']        ?? '1.750+';
 $e3_sales_conv     = $e3_metrics['sales_conversion']['display']  ?? '12 %';
@@ -62,16 +62,16 @@ $home_routing_gateways = [
 	'proof' => [
 		'badge'   => 'G3',
 		'kicker'  => 'Zahlen-Validierung',
-		'title'   => 'Die E3-New-Energy-Methodik',
+		'title'   => 'Die Solar-Case-Study-Methodik',
 		'desc'    => sprintf(
 			'Wie ein autarker Nachfrage-Funnel die Cost-per-Lead von %s auf %s gesenkt hat — dokumentiert mit echten Vertriebs-Zahlen.',
 			$e3_cpl_before,
 			$e3_cpl_after
 		),
 		'url'     => $e3_case_url,
-		'label'   => 'E3-Case mit allen Zahlen lesen',
+		'label'   => 'Case Study mit allen Zahlen lesen',
 		'persona' => 'Für skeptische Zahlen-Prüfer',
-		'action'  => 'gateway_e3',
+		'action'  => 'gateway_case_study',
 	],
 ];
 
@@ -150,7 +150,7 @@ get_header();
 					</a>
 					<a href="<?php echo esc_url( $e3_case_url ); ?>" class="hu-btn hu-btn-link"
 					   data-track-action="cta_home_hero_proof" data-track-category="proof" data-track-section="01">
-						E3-Case ansehen
+						Case Study ansehen
 					</a>
 				</div>
 				<p class="hu-hero__cta-note hu-hero__cta-note--trust">Der Marktcheck kostet Sie 60 Sekunden — keine Zahlungsdaten, kein Newsletter, kein Pitch-Deck. Die Rückmeldung kommt persönlich geprüft innerhalb von 48 Stunden.</p>
@@ -159,17 +159,17 @@ get_header();
 				<div class="hu-hero__stats">
 					<div>
 						<div class="hu-stat-num"><?php echo esc_html( $e3_lead_count ); ?></div>
-						<div class="hu-stat-label">Anfragen · E3</div>
+						<div class="hu-stat-label">Anfragen · Case Study</div>
 					</div>
 					<div class="hu-stat-divider"></div>
 					<div>
 						<div class="hu-stat-num"><?php echo esc_html( $e3_sales_conv ); ?></div>
-						<div class="hu-stat-label">Abschlussquote · E3</div>
+						<div class="hu-stat-label">Abschlussquote · Case Study</div>
 					</div>
 					<div class="hu-stat-divider"></div>
 					<div>
 						<div class="hu-stat-num" style="color:var(--accent)"><?php echo esc_html( $e3_cpl_reduction ); ?></div>
-						<div class="hu-stat-label">geringere Kosten/Anfrage · E3</div>
+						<div class="hu-stat-label">geringere Kosten/Anfrage · Case Study</div>
 					</div>
 				</div>
 
@@ -440,13 +440,13 @@ get_header();
 	</section>
 
 	<!-- ═══════════════════════════════════════════════════
-	     05 / E3 PROOF — Validierungsschicht
+	     05 / CASE STUDY PROOF — Validierungsschicht
 	     ═══════════════════════════════════════════════════ -->
 	<section class="hu-section" id="proof" data-track-section="05">
 		<div class="hu-container">
 			<div class="hu-proof-headline hu-reveal">
 				<span class="hu-eyebrow">05 / Validierung</span>
-				<h2>E3 New Energy: von eingekauften Leads zu eigenen qualifizierten Anfragen.</h2>
+				<h2>Ein mittelständischer PV-Installationsbetrieb: von eingekauften Leads zu eigenen qualifizierten Anfragen.</h2>
 				<p>In <?php echo esc_html( $e3_timeframe_dat ); ?> sanken die Kosten pro Anfrage von <?php echo esc_html( $e3_cpl_before ); ?> auf <?php echo esc_html( $e3_cpl_after ); ?> — durch eigene Website-Strecke, Vorqualifizierung und belastbares Tracking.</p>
 			</div>
 
@@ -472,7 +472,7 @@ get_header();
 			<div style="text-align:center;margin-top:48px" class="hu-reveal">
 				<a href="<?php echo esc_url( $e3_case_url ); ?>" class="hu-btn hu-btn-primary"
 				   data-track-action="cta_home_proof_case_study" data-track-category="lead_gen" data-track-section="05">
-					Vollständigen E3-Case analysieren
+					Vollständige Case Study analysieren
 					<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
 				</a>
 			</div>
@@ -569,7 +569,7 @@ get_header();
 			<div class="hu-sf-footer hu-reveal">
 				<div class="hu-sf-footer-l">
 					<div class="hu-eyebrow">ZEITRAUM</div>
-					<div class="hu-sf-footer-t"><?php echo esc_html( $e3_timeframe ); ?> · E3 New Energy</div>
+					<div class="hu-sf-footer-t"><?php echo esc_html( $e3_timeframe ); ?> · Case Study</div>
 				</div>
 				<div class="hu-sf-footer-r">
 					<div class="hu-eyebrow">SETUP</div>
@@ -622,12 +622,12 @@ get_header();
 					</p>
 					<p style="color:var(--ink-2);margin-top:16px">
 						Mein Zugang ist Medienwissenschaft, nicht Webdesign. Ich denke zuerst über Sprache,
-						Entscheidung und Signal — und erst danach über Code. Seit E3 New Energy als erstem
-						Solar-Case ist dokumentiert, wo diese Architektur am stärksten greift.
+						Entscheidung und Signal — und erst danach über Code. Seit dem ersten dokumentierten
+						Solar-Case ist belegt, wo diese Architektur am stärksten greift.
 					</p>
 					<ul class="hu-about-bullets">
 						<li><span class="hu-about-bullet-dot"></span>Medienwissenschaftliche Architektur — Sprache, Signal, System vor Code</li>
-						<li><span class="hu-about-bullet-dot"></span>Fokus Solar &amp; Wärmepumpen — verifizierte Daten-Integrität seit dem E3-Case</li>
+						<li><span class="hu-about-bullet-dot"></span>Fokus Solar &amp; Wärmepumpen — verifizierte Daten-Integrität seit der Case Study</li>
 						<li><span class="hu-about-bullet-dot"></span>Asset-Ownership statt Drittanbieter-Lock-in</li>
 						<li><span class="hu-about-bullet-dot"></span>Gegründet 2026 · Hannover, vor Ort und remote</li>
 						<li><span class="hu-about-bullet-dot"></span>Maximal 3 Founding-Partner pro Jahr</li>
@@ -691,7 +691,7 @@ get_header();
 						<span class="hu-faq-item__icon" aria-hidden="true">+</span>
 					</button>
 					<div class="hu-faq-item__a">
-						<div class="hu-faq-item__a-inner">Bei E3 New Energy: erste qualifizierte Anfragen nach 4–6 Wochen, voller Effekt nach 6 Monaten. Schnellere Versprechen sind unseriös — Abschlussquoten verlangen einen sauberen Trichter, nicht nur ein Logo-Update.</div>
+						<div class="hu-faq-item__a-inner">Bei einem mittelständischen PV-Installationsbetrieb: erste qualifizierte Anfragen nach 4–6 Wochen, voller Effekt nach 6 Monaten. Schnellere Versprechen sind unseriös — Abschlussquoten verlangen einen sauberen Trichter, nicht nur ein Logo-Update.</div>
 					</div>
 				</div>
 
@@ -765,7 +765,7 @@ get_header();
 				<div class="hu-final-routing__head">
 					<span class="hu-eyebrow" style="color:var(--accent)">10 / Nächster Schritt</span>
 					<h2 class="hu-display">Finden Sie heraus, wo Ihr Anfrage-System zuerst Geld verliert.</h2>
-					<p>Starten Sie mit dem Marktcheck, prüfen Sie den E3-Case oder gehen Sie direkt in die technische Umsetzung — je nachdem, wo Sie gerade stehen.</p>
+					<p>Starten Sie mit dem Marktcheck, prüfen Sie die Case Study oder gehen Sie direkt in die technische Umsetzung — je nachdem, wo Sie gerade stehen.</p>
 				</div>
 
 				<div class="hu-gateways hu-gateways--final" data-track-section="10">

--- a/blocksy-child/inc/blog-provider-posts.php
+++ b/blocksy-child/inc/blog-provider-posts.php
@@ -136,7 +136,7 @@ Die Alternative zu gemieteten Portal-Leads ist kein weiteres Tool, sondern eine 
 
 So entsteht ein Betriebs-Asset. Die Anfrage kommt nicht aus einem fremden Portal, sondern aus einer Plattform, die dem Betrieb gehört.
 
-Der [Methodik-Case E3 New Energy](/e3-new-energy/) zeigt diesen Hebel konkret: Der Cost per Lead sank von 150 € auf 22 € bei über 1.750 qualifizierten Anfragen, 12 % Abschlussquote und 6 Monaten Projektlaufzeit. Das ist kein allgemeines Versprechen, aber ein belastbarer Beleg dafür, was möglich wird, wenn Website, Tracking, Vorqualifizierung und Vertrieb zusammengebaut werden.
+Der [Solar Case Study](/case-study-solar-leadgenerierung/) zeigt diesen Hebel konkret: Der Cost per Lead sank von 150 € auf 22 € bei über 1.750 qualifizierten Anfragen, 12 % Abschlussquote und 6 Monaten Projektlaufzeit. Das ist kein allgemeines Versprechen, aber ein belastbarer Beleg dafür, was möglich wird, wenn Website, Tracking, Vorqualifizierung und Vertrieb zusammengebaut werden.
 
 ## Wann das Vergleichsportal-Modell trotzdem Sinn ergibt
 
@@ -229,7 +229,7 @@ Wenn Reichweite, Formular, Datenbasis und Optimierung beim Anbieter liegen, blei
 
 ## Alternative: Eigene Anfrage-Infrastruktur
 
-Eigene Anfrage-Systeme führen per Definition zu exklusiven Anfragen, weil die Strecke dem Betrieb gehört: Money Page, Server-Side-Tracking, Vorqualifizierung, CRM-Übergabe und Datenbasis. Der [Methodik-Case E3 New Energy](/e3-new-energy/) zeigt, dass die Cost per Lead durch ein eigenes System von 150 € auf 22 € gesenkt werden können – bei 12 % Abschlussquote, über 1.750 qualifizierten Anfragen und 6 Monaten Projektlaufzeit.
+Eigene Anfrage-Systeme führen per Definition zu exklusiven Anfragen, weil die Strecke dem Betrieb gehört: Money Page, Server-Side-Tracking, Vorqualifizierung, CRM-Übergabe und Datenbasis. Der [Solar Case Study](/case-study-solar-leadgenerierung/) zeigt, dass die Cost per Lead durch ein eigenes System von 150 € auf 22 € gesenkt werden können – bei 12 % Abschlussquote, über 1.750 qualifizierten Anfragen und 6 Monaten Projektlaufzeit.
 
 Das ist kein allgemeines Versprechen. Es zeigt aber den Unterschied zwischen Lead-Miete und Ownership: Bei einer eigenen Infrastruktur verbessert jeder Lernzyklus das eigene Betriebs-Asset.
 
@@ -320,7 +320,7 @@ Ein spezialisierter Anbieter kann ein guter Kanal sein. Strategisch bleibt aber 
 
 ## Die strategische Alternative: Ownership statt Lead-Miete
 
-Ein eigenes Anfrage-System mit Money Page, Server-Side-Tracking, Vorqualifizierung und CRM-Übergabe erzeugt Anfragen, die per Definition **exklusiv** sind. Der [Methodik-Case E3 New Energy](/e3-new-energy/) zeigt eine CPL-Senkung von 150 € auf 22 € bei 12 % Abschlussquote, über 1.750 qualifizierten Anfragen und 6 Monaten Projektlaufzeit.
+Ein eigenes Anfrage-System mit Money Page, Server-Side-Tracking, Vorqualifizierung und CRM-Übergabe erzeugt Anfragen, die per Definition **exklusiv** sind. Der [Solar Case Study](/case-study-solar-leadgenerierung/) zeigt eine CPL-Senkung von 150 € auf 22 € bei 12 % Abschlussquote, über 1.750 qualifizierten Anfragen und 6 Monaten Projektlaufzeit.
 
 Das ist kein allgemeines Versprechen, sondern ein Beleg für den Unterschied zwischen gemieteter Nachfrage und eigener Anfrage-Infrastruktur: Die Marke, die Daten und die Optimierung bleiben beim Betrieb.
 
@@ -397,7 +397,7 @@ Wie diese Rechnung für Wärmepumpen-Anfragen im Detail aussieht, zeigt die Seit
 
 ## Die strategische Alternative: Eigene Anfrage-Infrastruktur
 
-Ein eigenes Anfrage-System – Money Page, Vorqualifizierung, Server-Side-Tracking, CRM-Übergabe – erzeugt per Definition exklusive Anfragen, weil die Strecke dem Betrieb gehört. Der [Methodik-Case E3 New Energy](/e3-new-energy/) zeigt eine CPL-Senkung von 150 € auf 22 € bei 12 % Abschlussquote, über 1.750 qualifizierten Anfragen und 6 Monaten Projektlaufzeit.
+Ein eigenes Anfrage-System – Money Page, Vorqualifizierung, Server-Side-Tracking, CRM-Übergabe – erzeugt per Definition exklusive Anfragen, weil die Strecke dem Betrieb gehört. Der [Solar Case Study](/case-study-solar-leadgenerierung/) zeigt eine CPL-Senkung von 150 € auf 22 € bei 12 % Abschlussquote, über 1.750 qualifizierten Anfragen und 6 Monaten Projektlaufzeit.
 
 Die vollständige System-Gegenüberstellung über 24 Monate finden Sie im [TCO-Vergleich Portal-Leads vs. eigenes Anfrage-System](/eigene-leadgenerierung-vs-portale/).
 
@@ -481,7 +481,7 @@ Regionale Videokampagnen sind im Volumen durch Region, Angebot und Zielgruppe be
 
 Der nächstgrößere Schritt vom regionalen Videomarketing-Modell ist der Aufbau eines vollständig eigenen Anfrage-Systems: eigene Money Page, eigener Werbe-Account, eigene Tracking-Strecke, eigenes CRM und eigene Vorqualifizierung. Vorteil: Code, Daten und Strecke bleiben dauerhaft im Betrieb.
 
-Der [Methodik-Case E3 New Energy](/e3-new-energy/) demonstriert das mit einer CPL-Senkung von 150 € auf 22 €, über 1.750 qualifizierten Anfragen, 12 % Abschlussquote und 6 Monaten Projektlaufzeit. Das ist kein pauschales Ergebnisversprechen, aber ein belastbarer Beleg für den Wert eigener Anfrage-Infrastruktur.
+Der [Solar Case Study](/case-study-solar-leadgenerierung/) demonstriert das mit einer CPL-Senkung von 150 € auf 22 €, über 1.750 qualifizierten Anfragen, 12 % Abschlussquote und 6 Monaten Projektlaufzeit. Das ist kein pauschales Ergebnisversprechen, aber ein belastbarer Beleg für den Wert eigener Anfrage-Infrastruktur.
 
 ## Wann das Videomarketing-Modell trotzdem Sinn ergibt
 

--- a/blocksy-child/inc/canon/e3-proof-canon.php
+++ b/blocksy-child/inc/canon/e3-proof-canon.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Canonical E3 New Energy proof metrics.
+ * Canonical anonymized case-study proof metrics.
  *
  * @package Blocksy_Child
  */
@@ -9,7 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'HU_E3_CASE_LABEL', 'E3 New Energy' );
+define( 'HU_E3_CASE_LABEL', 'mittelständischer PV-Installationsbetrieb' );
 define( 'HU_E3_CPL_BEFORE', 150 );
 define( 'HU_E3_CPL_AFTER', 22 );
 define( 'HU_E3_CPL_REDUCTION_PERCENT', 85 );
@@ -28,7 +28,7 @@ define( 'HU_E3_ROAS', 34 );
 function hu_e3_canon() {
 	return [
 		'case_label' => HU_E3_CASE_LABEL,
-		'url'        => home_url( '/e3-new-energy/' ),
+		'url'        => home_url( '/case-study-solar-leadgenerierung/' ),
 		'metrics'    => [
 			'cpl_before'       => [
 				'value'   => HU_E3_CPL_BEFORE,
@@ -92,7 +92,7 @@ function hu_e3_canon() {
 		],
 		'summary'    => [
 			'compact'    => '150 € auf 22 € Kosten pro Anfrage, 1.750+ qualifizierte Anfragen, Abschlussquote von 1 – 5 % auf 12 %, 6 Monate.',
-			'proof'      => 'Referenz E3 New Energy: 1.750+ qualifizierte Anfragen, Abschlussquote von 1 – 5 % auf 12 % und über 85 % weniger Kosten pro Anfrage.',
+			'proof'      => 'Referenz mittelständischer PV-Installationsbetrieb: 1.750+ qualifizierte Anfragen, Abschlussquote von 1 – 5 % auf 12 % und über 85 % weniger Kosten pro Anfrage.',
 			'conversion' => 'Die Abschlussquote stieg im selben Zeitraum von 1 – 5 % (gekaufte Portal-Leads) auf 12 % (eigenes Anfrage-System).',
 		],
 	];

--- a/blocksy-child/inc/components/founding-cohort-block.php
+++ b/blocksy-child/inc/components/founding-cohort-block.php
@@ -98,7 +98,7 @@ function hu_render_founding_cohort_block( $args = [] ) {
 			<div class="nx-container">
 				<div class="hu-founding__about-inner">
 					<span class="hu-founding__eyebrow"><?php echo esc_html( $label ); ?></span>
-					<h2 id="<?php echo esc_attr( $section_id . '-title' ); ?>">E3 New Energy war der erste Case, nicht die Grenze.</h2>
+					<h2 id="<?php echo esc_attr( $section_id . '-title' ); ?>">Der mittelständische PV-Installationsbetrieb war der erste Case, nicht die Grenze.</h2>
 					<p>Die Cohort erweitert diese Arbeitsweise auf maximal drei passende Solar- oder Wärmepumpen-Betriebe. Der Einstieg bleibt der Marktcheck, damit vor einer Umsetzung klar ist, ob Markt, Budget und Tracking-Realität zusammenpassen.</p>
 					<div class="hu-founding__about-footer">
 						<span><?php echo esc_html( $slot_line ); ?></span>

--- a/blocksy-child/inc/enqueue.php
+++ b/blocksy-child/inc/enqueue.php
@@ -276,7 +276,7 @@ function hu_enqueue_assets() {
 			'diagnoseUrl'  => function_exists( 'hu_get_request_analysis_url' )
 				? hu_get_request_analysis_url()
 				: home_url( '/solar-waermepumpen-leadgenerierung/#marktcheck' ),
-			'caseUrl'      => home_url( '/e3-new-energy/' ),
+			'caseUrl'      => home_url( '/case-study-solar-leadgenerierung/' ),
 			'privacyUrl'   => home_url( '/datenschutz/' ),
 			'pageUrl'      => function_exists( 'nexus_get_energy_systems_url' )
 				? nexus_get_energy_systems_url()
@@ -321,8 +321,8 @@ function hu_enqueue_assets() {
 		hu_enqueue_css( 'nexus-affiliate-notice-css', 'affiliate-notice.css', [ 'nexus-intercept-solar-leads-css' ] );
 	}
 
-	// ── F1b) Schwester-Templates (E3-Case, Service-Landing) ────────
-	if ( is_page( 'website-fuer-solar-und-waermepumpen-anbieter' ) || is_page( 'e3-new-energy' ) || is_page_template( 'page-website-fuer-solar-und-waermepumpen-anbieter.php' ) || is_page_template( 'page-e3-new-energy.php' ) || is_page_template( 'page-case-e3.php' ) ) {
+	// ── F1b) Schwester-Templates (Solar Case Study, Service-Landing) ────────
+	if ( is_page( 'website-fuer-solar-und-waermepumpen-anbieter' ) || is_page( 'case-study-solar-leadgenerierung' ) || is_page( 'e3-new-energy' ) || is_page_template( 'page-website-fuer-solar-und-waermepumpen-anbieter.php' ) || is_page_template( 'page-e3-new-energy.php' ) || is_page_template( 'page-case-e3.php' ) ) {
 		hu_enqueue_css( 'nexus-review-funnel-css', 'review-funnel.css', [ 'nexus-design-system' ] );
 		hu_enqueue_css( 'nexus-energy-systems-css', 'energy-systems.css', [ 'nexus-review-funnel-css' ] );
 		hu_enqueue_js( 'nexus-solar-hero-js', 'solar-hero.js', [ 'nexus-core-js' ] );
@@ -539,6 +539,7 @@ function hu_disable_core_block_styles_on_custom_templates() {
 		'cost-per-lead-photovoltaik',
 		'qualifizierte-pv-anfragen',
 		'solar-leads-kosten-studie',
+		'case-study-solar-leadgenerierung',
 		'e3-new-energy',
 		'case-e3',
 		'wordpress-agentur',

--- a/blocksy-child/inc/helpers.php
+++ b/blocksy-child/inc/helpers.php
@@ -566,8 +566,8 @@ function nexus_get_primary_public_url_map() {
 			home_url( '/datenschutz/' )
 		),
 		'e3'                   => nexus_get_page_url(
-			[ 'e3-new-energy', 'case-studies/e3-new-energy', 'case-e3' ],
-			home_url( '/e3-new-energy/' )
+			[ 'case-study-solar-leadgenerierung', 'e3-new-energy', 'case-studies/e3-new-energy', 'case-e3' ],
+			home_url( '/case-study-solar-leadgenerierung/' )
 		),
 		'energy'               => function_exists( 'nexus_get_energy_systems_url' ) ? nexus_get_energy_systems_url() : home_url( '/solar-waermepumpen-leadgenerierung/' ),
 		'solar_leads_alternative' => nexus_get_page_url(
@@ -863,6 +863,7 @@ function nexus_is_results_context() {
 	return is_page( 'case-studies-e-commerce' )
 		|| is_page( 'case-studies' )
 		|| is_page( 'ergebnisse' )
+		|| is_page( 'case-study-solar-leadgenerierung' )
 		|| is_page( 'e3-new-energy' )
 		|| is_page( 'case-study-domdar' )
 		|| is_page( 'domdar' )
@@ -1311,6 +1312,7 @@ function nexus_get_legacy_offer_redirect_map() {
 	$request_url = nexus_get_primary_request_url();
 	$energy_url  = nexus_get_energy_systems_url();
 	$portal_url  = home_url( '/eigene-leadgenerierung-vs-portale/' );
+	$case_study_url = nexus_get_primary_public_url( 'e3', home_url( '/case-study-solar-leadgenerierung/' ) );
 
 	return [
 		// High-probability external entry paths. Internal/historical tool,
@@ -1322,6 +1324,9 @@ function nexus_get_legacy_offer_redirect_map() {
 		'/wordpress-tech-audit/'     => $request_url,
 		'/wordpress-agentur/'        => $agentur_url,
 		'/alle-loesungen-im-detail/' => nexus_get_page_url( [ 'alle-loesungen' ], home_url( '/alle-loesungen/' ) ),
+		// Anonymized case study: old company-named slugs redirect to the anonymized slug.
+		'/e3-new-energy/'            => $case_study_url,
+		'/case-e3/'                  => $case_study_url,
 		// Retired (Entwurf) Blog-Slug: 301 auf die Solar-Money-Page, damit
 		// nachlaufende Impressionen/Backlinks das Hub-Signal stützen statt zu
 		// kannibalisieren oder ins Leere (404) zu laufen.
@@ -1574,6 +1579,7 @@ function nexus_should_hide_footer_primary_cta() {
 			'case-studies-e-commerce',
 			'case-studies',
 			'ergebnisse',
+			'case-study-solar-leadgenerierung',
 			'e3-new-energy',
 			'case-study-domdar',
 			'domdar',

--- a/blocksy-child/inc/llms-txt.php
+++ b/blocksy-child/inc/llms-txt.php
@@ -86,14 +86,14 @@ function nexus_get_llms_txt_sections() {
 			'heading' => 'Proof und zitierfähige Quellen',
 			'links'   => [
 				[
-					'label'       => 'E3 New Energy',
-					'url'         => $urls['e3'] ?? home_url( '/e3-new-energy/' ),
+					'label'       => 'Solar Case Study',
+					'url'         => $urls['e3'] ?? home_url( '/case-study-solar-leadgenerierung/' ),
 					'description' => 'Kaufnaher Proof-Case: eigenes Anfrage-System, Vorqualifizierung, Tracking und Conversion statt Portal-Lead-Abhängigkeit.',
 				],
 				[
 					'label'       => 'Was kosten Solar-Leads? (Marktstudie)',
 					'url'         => $urls['solar_leads_cost_study'] ?? home_url( '/solar-leads-kosten-studie/' ),
-					'description' => 'Zitierfähige Marktstudie zu Lead-Kosten im DACH-Raum: Preisspannen je Modell, Cost-per-Order, Methodik und E3-Benchmark.',
+					'description' => 'Zitierfähige Marktstudie zu Lead-Kosten im DACH-Raum: Preisspannen je Modell, Cost-per-Order, Methodik und Case-Study-Benchmark.',
 				],
 				[
 					'label'       => 'Ergebnisse',

--- a/blocksy-child/inc/menu-setup.php
+++ b/blocksy-child/inc/menu-setup.php
@@ -72,6 +72,7 @@ function nexus_is_results_menu_item( $item ) {
 		'/case-studies/',
 		'/case-studies-e-commerce/',
 		'/ergebnisse/',
+		'/case-study-solar-leadgenerierung/',
 		'/e3-new-energy/',
 	];
 
@@ -336,8 +337,9 @@ add_filter( 'nav_menu_link_attributes', function ( $atts, $item ) {
 		'solar & wärmepumpen' => 'solar',
 		'wordpress agentur'   => 'agentur',
 		'ergebnisse'          => 'results',
-		'e3 proof'            => 'e3_proof',
-		'e3 new energy'       => 'e3_proof',
+		'e3 proof'            => 'case_study_proof',
+		'e3 new energy'       => 'case_study_proof',
+		'case study'          => 'case_study_proof',
 		'über mich'           => 'about',
 		'über haşim'          => 'about',
 	];

--- a/blocksy-child/inc/org-schema.php
+++ b/blocksy-child/inc/org-schema.php
@@ -1312,10 +1312,10 @@ function hu_output_schema()
             $e3_article = [
                 '@context'         => 'https://schema.org',
                 '@type'            => 'Article',
-                '@id'              => home_url('/e3-new-energy/#article'),
-                'url'              => home_url('/e3-new-energy/'),
-                'mainEntityOfPage' => home_url('/e3-new-energy/'),
-                'headline'         => function_exists( 'hu_get_e3_methodology_case_title' ) ? hu_get_e3_methodology_case_title() : 'Methodik-Case E3 New Energy',
+                '@id'              => home_url('/case-study-solar-leadgenerierung/#article'),
+                'url'              => home_url('/case-study-solar-leadgenerierung/'),
+                'mainEntityOfPage' => home_url('/case-study-solar-leadgenerierung/'),
+                'headline'         => function_exists( 'hu_get_e3_methodology_case_title' ) ? hu_get_e3_methodology_case_title() : 'Solar Case Study: Cost per Lead von 150 € auf 22 € gesenkt',
                 'description'      => function_exists( 'hu_get_e3_methodology_case_description' ) ? hu_get_e3_methodology_case_description() : '',
                 'inLanguage'       => 'de',
                 'author'           => hu_person_schema_ref( true ),
@@ -1324,10 +1324,6 @@ function hu_output_schema()
                     [
                         '@type' => 'Thing',
                         'name'  => 'Anfrage-Systeme für Solar- und Wärmepumpen-Anbieter',
-                    ],
-                    [
-                        '@type' => 'Organization',
-                        'name'  => 'E3 New Energy',
                     ],
                 ],
             ];
@@ -1362,8 +1358,8 @@ function hu_output_schema()
                 'hasPart' => [
                     [
                         '@type' => 'Article',
-                        'name'  => 'E3 New Energy',
-                        'url'   => home_url('/e3-new-energy/')
+                        'name'  => 'Solar Case Study',
+                        'url'   => home_url('/case-study-solar-leadgenerierung/')
                     ],
                 ],
             ];

--- a/blocksy-child/inc/review-crm.php
+++ b/blocksy-child/inc/review-crm.php
@@ -1040,7 +1040,7 @@ function nexus_build_qualification_screen( $qualification, $validated, $post_id 
 			'response_deadline_human' => $deadline['human'],
 			'proof'                   => [
 				'label' => 'Echte Zahlen aus einem laufenden Setup',
-				'body'  => 'E3 New Energy — CPL von 150 € auf 22 € in 6 Monaten, +12 % Abschlussquote. Gleiche Methode, die für Ihren Betrieb geprüft wird.',
+				'body'  => 'Mittelständischer PV-Installationsbetrieb — CPL von 150 € auf 22 € in 6 Monaten, +12 % Abschlussquote. Gleiche Methode, die für Ihren Betrieb geprüft wird.',
 			],
 		];
 	}

--- a/blocksy-child/inc/seo-cockpit/seo-cockpit-command-center.php
+++ b/blocksy-child/inc/seo-cockpit/seo-cockpit-command-center.php
@@ -184,7 +184,7 @@ function nexus_get_revenue_command_center_funnel_role( $page_role ) {
 function nexus_revenue_command_center_is_e3_adjacent_url( $url ) {
 	$path = (string) wp_parse_url( (string) $url, PHP_URL_PATH );
 
-	return false !== strpos( $path, 'e3' ) || false !== strpos( $path, 'ergebnisse' ) || false !== strpos( $path, 'case' );
+	return false !== strpos( $path, 'case-study-solar-leadgenerierung' ) || false !== strpos( $path, 'e3' ) || false !== strpos( $path, 'ergebnisse' ) || false !== strpos( $path, 'case' );
 }
 
 /**

--- a/blocksy-child/inc/seo-cockpit/seo-cockpit-links.php
+++ b/blocksy-child/inc/seo-cockpit/seo-cockpit-links.php
@@ -245,7 +245,7 @@ function nexus_get_seo_cockpit_template_internal_links( $post_id, $post = null )
 			$links,
 			[
 				$primary_urls['audit'] ?? home_url( '/solar-waermepumpen-leadgenerierung/#marktcheck' ),
-				$primary_urls['e3'] ?? home_url( '/e3-new-energy/' ),
+				$primary_urls['e3'] ?? home_url( '/case-study-solar-leadgenerierung/' ),
 				$primary_urls['agentur'] ?? home_url( '/wordpress-agentur-hannover/' ),
 			],
 			$solar_cluster_urls
@@ -301,7 +301,7 @@ function nexus_get_seo_cockpit_template_internal_links( $post_id, $post = null )
 				$primary_urls['wgos'] ?? home_url( '/wordpress-agentur-hannover/#methode' ),
 				$primary_urls['about'] ?? home_url( '/uber-mich/' ),
 				$contact_url,
-				$primary_urls['e3'] ?? home_url( '/e3-new-energy/' ),
+				$primary_urls['e3'] ?? home_url( '/case-study-solar-leadgenerierung/' ),
 				$primary_urls['seo'] ?? home_url( '/wordpress-agentur-hannover/#technisches-seo' ),
 				$primary_urls['wartung'] ?? home_url( '/wordpress-agentur-hannover/#wordpress-wartung' ),
 				$primary_urls['cro'] ?? home_url( '/wordpress-agentur-hannover/#methode' ),
@@ -315,7 +315,7 @@ function nexus_get_seo_cockpit_template_internal_links( $post_id, $post = null )
 		$links = array_merge(
 			$links,
 			[
-				$primary_urls['e3'] ?? home_url( '/e3-new-energy/' ),
+				$primary_urls['e3'] ?? home_url( '/case-study-solar-leadgenerierung/' ),
 				$primary_urls['agentur'] ?? home_url( '/wordpress-agentur-hannover/' ),
 				$primary_urls['tracking'] ?? home_url( '/ga4-tracking-setup/' ),
 				$primary_urls['cwv'] ?? home_url( '/wgos-assets/cwv-optimierung/' ),
@@ -350,7 +350,7 @@ function nexus_get_seo_cockpit_template_internal_links( $post_id, $post = null )
 				$primary_urls['audit'] ?? home_url( '/solar-waermepumpen-leadgenerierung/#marktcheck' ),
 				$primary_urls['wgos'] ?? home_url( '/wordpress-agentur-hannover/#methode' ),
 				$contact_url,
-				$primary_urls['e3'] ?? home_url( '/e3-new-energy/' ),
+				$primary_urls['e3'] ?? home_url( '/case-study-solar-leadgenerierung/' ),
 				$primary_urls['domdar'] ?? home_url( '/case-study-domdar/' ),
 				$primary_urls['whitelabel'] ?? home_url( '/whitelabel-retainer/' ),
 			]
@@ -496,7 +496,7 @@ function nexus_get_seo_cockpit_sitewide_source_definitions() {
 	$agentur_url      = $primary_urls['agentur'] ?? home_url( '/wordpress-agentur-hannover/' );
 	$wartung_url      = $primary_urls['wartung'] ?? home_url( '/wordpress-agentur-hannover/#wordpress-wartung' );
 	$wgos_url         = $primary_urls['wgos'] ?? home_url( '/wordpress-agentur-hannover/#methode' );
-	$e3_url           = $primary_urls['e3'] ?? home_url( '/e3-new-energy/' );
+	$e3_url           = $primary_urls['e3'] ?? home_url( '/case-study-solar-leadgenerierung/' );
 	$domdar_url       = $primary_urls['domdar'] ?? home_url( '/case-study-domdar/' );
 	$whitelabel_url   = $primary_urls['whitelabel'] ?? home_url( '/whitelabel-retainer/' );
 	$seo_url          = $primary_urls['seo'] ?? home_url( '/wordpress-agentur-hannover/#technisches-seo' );

--- a/blocksy-child/inc/seo-meta.php
+++ b/blocksy-child/inc/seo-meta.php
@@ -45,7 +45,7 @@ function hu_get_homepage_description() {
 
 	return (string) apply_filters(
 		'hu_homepage_seo_description',
-		sprintf( 'Eigene Anfragen statt Portal-Leads: Marktcheck, Vorqualifizierung und Tracking für Solar- und Wärmepumpen-Anbieter. E3-Case: CPL von %s auf %s.', $cpl_before, $cpl_after )
+		sprintf( 'Eigene Anfragen statt Portal-Leads: Marktcheck, Vorqualifizierung und Tracking für Solar- und Wärmepumpen-Anbieter. Case Study: CPL von %s auf %s.', $cpl_before, $cpl_after )
 	);
 }
 
@@ -206,23 +206,27 @@ function hu_get_forced_singular_seo_map() {
 			// daher keine oeffentlichen Meta-Signale mehr.
 			'wordpress-agentur-hannover' => [
 				'title'       => 'WordPress Agentur Hannover: SEO, Tracking & CRO',
-				'description' => sprintf( 'WordPress Agentur Hannover für messbare B2B-Anfragen: technisches SEO, Server-Side Tracking und CRO. Erst Projektprüfung, dann Umsetzung — E3: CPL %s → %s.', $e3_cpl_before, $e3_cpl_after ),
+				'description' => sprintf( 'WordPress Agentur Hannover für messbare B2B-Anfragen: technisches SEO, Server-Side Tracking und CRO. Erst Projektprüfung, dann Umsetzung — Case Study: CPL %s → %s.', $e3_cpl_before, $e3_cpl_after ),
 			],
 			'wordpress-agentur' => [
 				'title'       => 'WordPress Agentur Hannover: SEO, Tracking & CRO',
-				'description' => sprintf( 'WordPress Agentur Hannover für messbare B2B-Anfragen: technisches SEO, Server-Side Tracking und CRO. Erst Projektprüfung, dann Umsetzung — E3: CPL %s → %s.', $e3_cpl_before, $e3_cpl_after ),
+				'description' => sprintf( 'WordPress Agentur Hannover für messbare B2B-Anfragen: technisches SEO, Server-Side Tracking und CRO. Erst Projektprüfung, dann Umsetzung — Case Study: CPL %s → %s.', $e3_cpl_before, $e3_cpl_after ),
 			],
 			'ergebnisse' => [
 				'title'       => 'Ergebnisse & Case Studies | WordPress, SEO, CRO',
-				'description' => 'Ergebnisse aus öffentlich sichtbaren WordPress-, SEO-, Tracking- und CRO-Projekten: E3 New Energy, Systemlogik und konkrete nächste Schritte.',
+				'description' => 'Ergebnisse aus öffentlich sichtbaren WordPress-, SEO-, Tracking- und CRO-Projekten: Case Study mittelständischer PV-Installationsbetrieb, Systemlogik und konkrete nächste Schritte.',
 			],
 			'case-studies-e-commerce' => [
 				'title'       => 'Ergebnisse & Case Studies | WordPress, SEO, CRO',
-				'description' => 'Ergebnisse aus öffentlich sichtbaren WordPress-, SEO-, Tracking- und CRO-Projekten: E3 New Energy, Systemlogik und konkrete nächste Schritte.',
+				'description' => 'Ergebnisse aus öffentlich sichtbaren WordPress-, SEO-, Tracking- und CRO-Projekten: Case Study mittelständischer PV-Installationsbetrieb, Systemlogik und konkrete nächste Schritte.',
 			],
 			'case-studies' => [
 				'title'       => 'Ergebnisse & Case Studies | WordPress, SEO, CRO',
-				'description' => 'Ergebnisse aus öffentlich sichtbaren WordPress-, SEO-, Tracking- und CRO-Projekten: E3 New Energy, Systemlogik und konkrete nächste Schritte.',
+				'description' => 'Ergebnisse aus öffentlich sichtbaren WordPress-, SEO-, Tracking- und CRO-Projekten: Case Study mittelständischer PV-Installationsbetrieb, Systemlogik und konkrete nächste Schritte.',
+			],
+			'case-study-solar-leadgenerierung' => [
+				'title'       => hu_get_e3_methodology_case_title(),
+				'description' => hu_get_e3_methodology_case_description(),
 			],
 			'e3-new-energy' => [
 				'title'       => hu_get_e3_methodology_case_title(),
@@ -237,19 +241,19 @@ function hu_get_forced_singular_seo_map() {
 			// /ki-integration-wordpress/ ist noindex. Keine eigenstaendigen SEO-Signale mehr noetig.
 			'solar-waermepumpen-leadgenerierung' => [
 				'title'       => 'Leadgenerierung Photovoltaik & Wärmepumpe ohne Portale',
-				'description' => sprintf( 'Leadgenerierung für Photovoltaik, Solar und Wärmepumpe: eigene qualifizierte Anfragen statt geteilter Portal-Leads. Marktcheck plus E3-Beleg: %s niedrigerer CPL.', $e3_cpl_reduction ),
+				'description' => sprintf( 'Leadgenerierung für Photovoltaik, Solar und Wärmepumpe: eigene qualifizierte Anfragen statt geteilter Portal-Leads. Marktcheck plus Case-Study-Beleg: %s niedrigerer CPL.', $e3_cpl_reduction ),
 			],
 			'website-fuer-solar-und-waermepumpen-anbieter' => [
 				'title'       => 'Leadgenerierung Photovoltaik & Wärmepumpe ohne Portale',
-				'description' => sprintf( 'Leadgenerierung für Photovoltaik, Solar und Wärmepumpe: eigene qualifizierte Anfragen statt geteilter Portal-Leads. Marktcheck plus E3-Beleg: %s niedrigerer CPL.', $e3_cpl_reduction ),
+				'description' => sprintf( 'Leadgenerierung für Photovoltaik, Solar und Wärmepumpe: eigene qualifizierte Anfragen statt geteilter Portal-Leads. Marktcheck plus Case-Study-Beleg: %s niedrigerer CPL.', $e3_cpl_reduction ),
 			],
 			'solar-leads-kaufen-alternative' => [
 				'title'       => 'Photovoltaik & Solar Leads kaufen? Alternative ohne Portale',
-				'description' => sprintf( 'Photovoltaik-, PV- oder Solar-Leads kaufen — oder eigene Anfragen aufbauen? Portal-Leads werden mehrfach verkauft. Der Vergleich pro Anfrage — E3-Case: %s niedrigerer CPL.', $e3_cpl_reduction ),
+				'description' => sprintf( 'Photovoltaik-, PV- oder Solar-Leads kaufen — oder eigene Anfragen aufbauen? Portal-Leads werden mehrfach verkauft. Der Vergleich pro Anfrage — Case Study: %s niedrigerer CPL.', $e3_cpl_reduction ),
 			],
 			'waermepumpen-leads' => [
 				'title'       => 'Wärmepumpen Leads kaufen? Alternative ohne Portale',
-				'description' => sprintf( 'Wärmepumpen-Leads kaufen oder eigene Anfragen aufbauen? Portal-Leads werden mehrfach verkauft und schließen selten ab. Der Vergleich pro Anfrage — E3-Case: %s niedrigerer CPL.', $e3_cpl_reduction ),
+				'description' => sprintf( 'Wärmepumpen-Leads kaufen oder eigene Anfragen aufbauen? Portal-Leads werden mehrfach verkauft und schließen selten ab. Der Vergleich pro Anfrage — Case Study: %s niedrigerer CPL.', $e3_cpl_reduction ),
 			],
 			'server-side-tracking-b2b' => [
 				'title'       => 'Server-Side Tracking Agentur: DSGVO, GA4 & CAPI',
@@ -261,7 +265,7 @@ function hu_get_forced_singular_seo_map() {
 			],
 			'eigene-leadgenerierung-vs-portale' => [
 				'title'       => 'Portal-Leads vs. eigenes System: TCO-Vergleich Solar/SHK',
-				'description' => sprintf( '24-Monats-TCO: Portal-Leads (DAA, Aroundhome, Check24) vs. eigenes Anfrage-System. E3: %s niedrigerer CPL in 6 Monaten.', $e3_cpl_reduction ),
+				'description' => sprintf( '24-Monats-TCO: Portal-Leads (DAA, Aroundhome, Check24) vs. eigenes Anfrage-System. Case Study: %s niedrigerer CPL in 6 Monaten.', $e3_cpl_reduction ),
 			],
 			'lead-funnel-solar' => [
 				'title'       => 'Lead-Funnel Solar & Wärmepumpe – Aufbau für B2B-Marketing',
@@ -269,19 +273,19 @@ function hu_get_forced_singular_seo_map() {
 			],
 			'kunden-gewinnen-solarteure' => [
 				'title'       => 'Kunden gewinnen für Solarteure – ohne Portal-Leads',
-				'description' => sprintf( 'Wie Solarteure & Wärmepumpen-Anbieter systematisch Kunden gewinnen – ohne DAA, Aroundhome oder Check24. E3: %s niedrigerer CPL.', $e3_cpl_reduction ),
+				'description' => sprintf( 'Wie Solarteure & Wärmepumpen-Anbieter systematisch Kunden gewinnen – ohne DAA, Aroundhome oder Check24. Case Study: %s niedrigerer CPL.', $e3_cpl_reduction ),
 			],
 			'cost-per-lead-photovoltaik' => [
 				'title'       => 'Cost per Lead Photovoltaik: Was Solar-Anfragen wirklich kosten',
-				'description' => sprintf( 'CPL-Rechnung für Photovoltaik- und Wärmepumpen-Anbieter: Portal-Leads vs. eigenes System. E3-Referenz: %s niedrigere Kosten pro Anfrage in 6 Monaten.', $e3_cpl_reduction ),
+				'description' => sprintf( 'CPL-Rechnung für Photovoltaik- und Wärmepumpen-Anbieter: Portal-Leads vs. eigenes System. Case-Study-Referenz: %s niedrigere Kosten pro Anfrage in 6 Monaten.', $e3_cpl_reduction ),
 			],
 			'qualifizierte-pv-anfragen' => [
 				'title'       => 'Qualifizierte PV-Anfragen: 4 Merkmale guter Solar-Leads',
-				'description' => 'Vier Merkmale einer qualifizierten Photovoltaik-Anfrage: Intent, Exklusivität, Vorqualifizierung, Echtzeit. Mit Praxisbezug E3 New Energy.',
+				'description' => 'Vier Merkmale einer qualifizierten Photovoltaik-Anfrage: Intent, Exklusivität, Vorqualifizierung, Echtzeit. Mit Praxisbezug zur Case Study eines mittelständischen PV-Installationsbetriebs.',
 			],
 			'solar-leads-kosten-studie' => [
 				'title'       => 'Solar-Leads Kosten 2026: CPL, CPO & Portal-Vergleich',
-				'description' => 'Was kosten Solar-Leads wirklich? Marktstudie mit Photovoltaik- und Wärmepumpen-CPL, Cost-per-Order, Portal-Modellen, Methodik und E3-Benchmark.',
+				'description' => 'Was kosten Solar-Leads wirklich? Marktstudie mit Photovoltaik- und Wärmepumpen-CPL, Cost-per-Order, Portal-Modellen, Methodik und Case-Study-Benchmark.',
 			],
 		]
 	);
@@ -594,7 +598,7 @@ function hu_is_e3_methodology_case_post( $post_id = 0 ) {
 	$slug     = (string) get_post_field( 'post_name', $post_id );
 	$template = (string) get_page_template_slug( $post_id );
 
-	return in_array( $slug, [ 'e3-new-energy', 'case-e3' ], true )
+	return in_array( $slug, [ 'case-study-solar-leadgenerierung', 'e3-new-energy', 'case-e3' ], true )
 		|| in_array( $template, [ 'page-e3-new-energy.php', 'page-case-e3.php' ], true );
 }
 
@@ -736,6 +740,11 @@ function hu_get_noindex_follow_slugs() {
 		'audit-linkedin',
 		'case-studies',
 		'case-studies-e-commerce',
+		// Anonymization hold: noindex pending settlement resolution.
+		// Remove once the anonymized case study is cleared for public reindexing.
+		'e3-new-energy',
+		'case-e3',
+		'case-study-solar-leadgenerierung',
 		'conversion-rate-optimization',
 		'core-web-vitals',
 		'danke',
@@ -864,21 +873,21 @@ function hu_get_subpage_last_updated_label( $template_path ) {
 }
 
 /**
- * Get the SEO title for the E3 methodology case.
+ * Get the SEO title for the anonymized solar methodology case.
  *
  * @return string
  */
 function hu_get_e3_methodology_case_title() {
-	return 'E3 New Energy: Cost per Lead von 150 € auf 22 € – Solar-Case';
+	return 'Solar Case Study: Cost per Lead von 150 € auf 22 € gesenkt';
 }
 
 /**
- * Get the SEO description for the E3 methodology case.
+ * Get the SEO description for the anonymized solar methodology case.
  *
  * @return string
  */
 function hu_get_e3_methodology_case_description() {
-	return 'E3 New Energy senkte den CPL mit eigenem Anfrage-System statt Portal-Leads um über 85 %: 1.750+ qualifizierte PV- & Wärmepumpen-Anfragen, 12 % Abschluss.';
+	return 'Ein mittelständischer PV-Installationsbetrieb senkte den CPL mit eigenem Anfrage-System statt Portal-Leads um über 85 %: 1.750+ qualifizierte PV- & Wärmepumpen-Anfragen, 12 % Abschluss.';
 }
 
 /**
@@ -1078,7 +1087,7 @@ function hu_get_singular_post_seo_context( $post_id ) {
 	}
 
 	$robots_context       = hu_get_singular_robots_context( $post_id );
-	$canonical            = hu_is_e3_methodology_case_post( $post_id ) ? home_url( '/e3-new-energy/' ) : (string) get_permalink( $post_id );
+	$canonical            = hu_is_e3_methodology_case_post( $post_id ) ? home_url( '/case-study-solar-leadgenerierung/' ) : (string) get_permalink( $post_id );
 
 	return [
 		'title'              => trim( wp_strip_all_tags( (string) $title ) ),
@@ -1340,7 +1349,7 @@ function hu_get_seo_meta() {
 		if ( hu_is_e3_methodology_case_post( $post_id ) ) {
 			$meta['og_title']    = hu_get_e3_methodology_case_title();
 			$meta['description'] = hu_get_e3_methodology_case_description();
-			$meta['canonical']   = home_url( '/e3-new-energy/' );
+			$meta['canonical']   = home_url( '/case-study-solar-leadgenerierung/' );
 			$meta['og_type']     = 'article';
 		}
 

--- a/blocksy-child/inc/shortcodes.php
+++ b/blocksy-child/inc/shortcodes.php
@@ -144,7 +144,7 @@ function hu_home_urls() {
 		'cro'         => nexus_get_primary_public_url( 'cro', home_url( '/wordpress-agentur-hannover/#methode' ) ),
 		'about'       => nexus_get_primary_public_url( 'about', home_url( '/uber-mich/' ) ),
 		'blog'        => nexus_get_primary_public_url( 'blog', home_url( '/blog/' ) ),
-		'e3'          => nexus_get_primary_public_url( 'e3', home_url( '/e3-new-energy/' ) ),
+		'e3'          => nexus_get_primary_public_url( 'e3', home_url( '/case-study-solar-leadgenerierung/' ) ),
 		'contact'     => nexus_get_primary_public_url( 'contact', home_url( '/kontakt/' ) ),
 		'github_repo' => 'https://github.com/Hasim-Uner/meine-wordpress-site-2fe6f514',
 		'linkedin'    => 'https://www.linkedin.com/in/hasim-%C3%BCner/',
@@ -670,13 +670,13 @@ function hu_erfolge_section_shortcode() {
 			<div class="nx-reveal" style="text-align:center; margin-bottom:3rem;">
 				<span class="nx-badge nx-badge--gold">Proof</span>
 				<h2 id="cases-heading" style="font-size:clamp(1.8rem,3vw,2.4rem); margin:1rem 0 0.5rem; color:#fff;">Beispielhafte Wirkung des Systems.</h2>
-				<p style="color:var(--nx-text-muted);">E3 New Energy zeigt die Logik im sichtbaren Ausschnitt. Der Hebel liegt selten in einer einzelnen Maßnahme, sondern fast immer in besserer Reihenfolge.</p>
+				<p style="color:var(--nx-text-muted);">Ein mittelständischer PV-Installationsbetrieb zeigt die Logik im sichtbaren Ausschnitt. Der Hebel liegt selten in einer einzelnen Maßnahme, sondern fast immer in besserer Reihenfolge.</p>
 			</div>
 
 			<div class="homepage-proof-grid">
 				<article class="nx-card nx-reveal homepage-proof-card" style="border-top:3px solid var(--nx-success);">
 					<p class="nx-card__subtitle"><?php echo esc_html( sprintf( 'Beispielhafte Wirkung des Systems · B2B Leadgen · WordPress System · %s', $e3_timeframe ) ); ?></p>
-					<h3 class="nx-card__title">E3 New Energy</h3>
+					<h3 class="nx-card__title">Solar Case Study</h3>
 					<p style="color:var(--nx-text-muted); margin:0.8rem 0 0;">Eingekaufte Leads, keine saubere Datenlage, hohe Reibung nach dem Klick. Nach systematischer Neuordnung von Positionierung, Tracking und Conversion-Pfad:</p>
 					<div class="nx-metrics" style="margin-top:1.5rem; display:grid; grid-template-columns:1fr 1fr; gap:1.25rem;">
 						<?php foreach ( $canonical_metrics as $metric ) : ?>

--- a/blocksy-child/inc/wgos/wgos-cluster-pages.php
+++ b/blocksy-child/inc/wgos/wgos-cluster-pages.php
@@ -279,7 +279,7 @@ function nexus_get_wgos_cluster_page_proof_metrics() {
 		],
 		[
 			'value' => '3 Proof-Routen',
-			'label' => 'E3, DOMDAR und Ergebnisse sind oeffentlich einsehbar',
+			'label' => 'Case Study, DOMDAR und Ergebnisse sind oeffentlich einsehbar',
 		],
 	];
 }

--- a/blocksy-child/page-b2b-solar-leads.php
+++ b/blocksy-child/page-b2b-solar-leads.php
@@ -19,12 +19,12 @@ $solar_money_url = function_exists( 'nexus_get_energy_systems_url' )
 	? nexus_get_energy_systems_url()
 	: home_url( '/solar-waermepumpen-leadgenerierung/' );
 $marktcheck_url  = trailingslashit( $solar_money_url ) . '#marktcheck';
-$e3_url          = home_url( '/e3-new-energy/' );
+$e3_url          = home_url( '/case-study-solar-leadgenerierung/' );
 
 // ── E3-Canon ──────────────────────────────────────────────────
 $e3_canon            = function_exists( 'hu_e3_canon' ) ? hu_e3_canon() : [];
 $e3_metrics          = isset( $e3_canon['metrics'] ) && is_array( $e3_canon['metrics'] ) ? $e3_canon['metrics'] : [];
-$e3_case_label       = isset( $e3_canon['case_label'] ) ? (string) $e3_canon['case_label'] : 'E3 New Energy';
+$e3_case_label       = isset( $e3_canon['case_label'] ) ? (string) $e3_canon['case_label'] : 'mittelständischer PV-Installationsbetrieb';
 $e3_cpl_reduction    = $e3_metrics['cpl_reduction']['display'] ?? 'über 85 %';
 $e3_lead_count       = $e3_metrics['lead_count']['display'] ?? '1.750+';
 $e3_sales_conversion = $e3_metrics['sales_conversion']['display'] ?? '12 %';
@@ -107,8 +107,8 @@ $faq = [
 		'answer'   => 'Typischerweise drei bis sechs: Energie-Manager (technische Erstprüfung), Geschäftsführung (strategische Freigabe), CFO (Finanzierung), Einkauf (Vertragsbedingungen), ggf. Facility Management und Nachhaltigkeitsbeauftragte. Jeder Stakeholder bekommt seinen eigenen Funnel-Schritt – nicht alles wird auf eine Person abgewälzt.',
 	],
 	[
-		'question' => sprintf( 'Funktioniert die E3-Referenz auch im B2B-Gewerbe?', $e3_case_label ),
-		'answer'   => sprintf( 'Die E3-Referenz (%1$s qualifizierte Anfragen, %2$s Abschlussquote, %3$s niedrigere Cost per Lead in %4$s) deckt B2C-Wärmepumpen und B2C/B2B-Photovoltaik ab. Im reinen Gewerbe-PV sind die Ticketgrößen größer, die Abschlussquoten ähnlich, die Sales-Zyklen länger – die System-Logik bleibt identisch.', $e3_lead_count, $e3_sales_conversion, $e3_cpl_reduction, $e3_timeframe ),
+		'question' => 'Funktioniert die Case-Study-Referenz auch im B2B-Gewerbe?',
+		'answer'   => sprintf( 'Die Case-Study-Referenz (%1$s qualifizierte Anfragen, %2$s Abschlussquote, %3$s niedrigere Cost per Lead in %4$s) deckt B2C-Wärmepumpen und B2C/B2B-Photovoltaik ab. Im reinen Gewerbe-PV sind die Ticketgrößen größer, die Abschlussquoten ähnlich, die Sales-Zyklen länger – die System-Logik bleibt identisch.', $e3_lead_count, $e3_sales_conversion, $e3_cpl_reduction, $e3_timeframe ),
 	],
 	[
 		'question' => 'Wie passt das mit DAA, Aroundhome oder Check24 zusammen?',
@@ -194,7 +194,7 @@ get_header();
 				   data-track-action="cta_e3_case"
 				   data-track-category="b2b_solar_leads"
 				   data-track-section="hero">
-					E3-Case lesen (<?php echo esc_html( $e3_lead_count ); ?> Anfragen, <?php echo esc_html( $e3_sales_conversion ); ?> Abschlussquote)
+					Case Study lesen (<?php echo esc_html( $e3_lead_count ); ?> Anfragen, <?php echo esc_html( $e3_sales_conversion ); ?> Abschlussquote)
 				</a>
 			</div>
 		</div>

--- a/blocksy-child/page-case-e3.php
+++ b/blocksy-child/page-case-e3.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Template Name: Case Study – E3 New Energy
- * Description: Legacy template alias for the E3 New Energy methodology case.
+ * Template Name: Case Study – Solar Leadgenerierung
+ * Description: Legacy template alias for the anonymized solar methodology case.
  *
  * @package Blocksy_Child
  */

--- a/blocksy-child/page-case-studies-e-commerce.php
+++ b/blocksy-child/page-case-studies-e-commerce.php
@@ -14,7 +14,7 @@ get_header();
 
 $request_url    = function_exists( 'nexus_get_primary_request_url' ) ? nexus_get_primary_request_url() : home_url( '/solar-waermepumpen-leadgenerierung/#marktcheck' );
 $request_cta    = function_exists( 'nexus_get_primary_request_cta_label' ) ? nexus_get_primary_request_cta_label() : 'Anfrage stellen';
-$e3_url         = function_exists( 'nexus_get_primary_public_url' ) ? nexus_get_primary_public_url( 'e3', home_url( '/e3-new-energy/' ) ) : home_url( '/e3-new-energy/' );
+$e3_url         = function_exists( 'nexus_get_primary_public_url' ) ? nexus_get_primary_public_url( 'e3', home_url( '/case-study-solar-leadgenerierung/' ) ) : home_url( '/case-study-solar-leadgenerierung/' );
 $agentur_url    = function_exists( 'nexus_get_primary_public_url' ) ? nexus_get_primary_public_url( 'agentur', home_url( '/wordpress-agentur-hannover/' ) ) : home_url( '/wordpress-agentur-hannover/' );
 $e3_cpl_before  = function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'cpl_before', 'display', '150 €' ) : '150 €';
 $e3_cpl_after   = function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'cpl_after', 'display', '22 €' ) : '22 €';
@@ -59,13 +59,13 @@ $e3_sales_rate  = function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'sales_conve
 		</div>
 	</section>
 
-	<!-- 2. E3 New Energy -->
+	<!-- 2. Solar Case Study -->
 	<section class="nx-section results-case">
 		<div class="nx-container">
 			<article class="results-case-card results-case-card--success">
 				<div class="results-case-card__content">
 					<span class="results-case-card__kicker">Öffentlicher Methodik-Case · Solar &amp; Wärmepumpe</span>
-					<h2 class="results-case-card__title">E3 New Energy</h2>
+					<h2 class="results-case-card__title">Solar Case Study</h2>
 					<p class="results-case-card__context">
 						Zwei parallele Anfrage-Quellen: Portal-Leads und Viessmann-Partner-Anfragen. Die Methodik im Detail.
 					</p>
@@ -83,7 +83,7 @@ $e3_sales_rate  = function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'sales_conve
 						<li>Drei Monate Implementierung, drei Monate Optimierung</li>
 					</ul>
 
-					<a href="<?php echo esc_url( $e3_url ); ?>" class="nx-btn nx-btn--primary" data-track-action="cta_results_e3_methodology" data-track-category="trust">
+					<a href="<?php echo esc_url( $e3_url ); ?>" class="nx-btn nx-btn--primary" data-track-action="cta_results_case_study_methodology" data-track-category="trust">
 						Methodik-Case lesen
 					</a>
 				</div>
@@ -126,7 +126,7 @@ $e3_sales_rate  = function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'sales_conve
 					<span class="results-case-card__kicker">Sekundärer Einstieg · WordPress Agentur Hannover</span>
 					<h2 class="results-case-card__title">Wenn es nicht um Solar geht, aber um ein erklärungsbedürftiges B2B-Angebot.</h2>
 					<p class="results-case-card__context">
-						Die Methodik hinter E3 ist nicht „mehr Leads kaufen", sondern WordPress, Tracking, SEO und Conversion als Anfrage-System zu ordnen. Für B2B-Websites außerhalb des Solar-Fokus ist die Agentur-Seite der passendere Einstieg.
+						Die Methodik hinter dieser Case Study ist nicht „mehr Leads kaufen", sondern WordPress, Tracking, SEO und Conversion als Anfrage-System zu ordnen. Für B2B-Websites außerhalb des Solar-Fokus ist die Agentur-Seite der passendere Einstieg.
 					</p>
 					<div class="results-case-card__actions">
 						<a href="<?php echo esc_url( $agentur_url ); ?>" class="nx-btn nx-btn--ghost" data-track-action="cta_results_to_agentur" data-track-category="navigation" data-track-section="results_b2b_bridge">

--- a/blocksy-child/page-cost-per-lead-photovoltaik.php
+++ b/blocksy-child/page-cost-per-lead-photovoltaik.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Template Name: Cost per Lead Photovoltaik – Was Solar-Anfragen wirklich kosten
- * Description: CPL-Rechnung fuer Solar/SHK. Bezug zur E3-Referenz.
+ * Description: CPL-Rechnung fuer Solar/SHK. Bezug zur Case-Study-Referenz.
  *              Primaerer CTA: Marktcheck.
  *
  * @package Blocksy_Child
@@ -16,14 +16,14 @@ $solar_money_url = function_exists( 'nexus_get_energy_systems_url' )
 	? nexus_get_energy_systems_url()
 	: home_url( '/solar-waermepumpen-leadgenerierung/' );
 $marktcheck_url  = trailingslashit( $solar_money_url ) . '#marktcheck';
-$e3_url          = home_url( '/e3-new-energy/' );
+$e3_url          = home_url( '/case-study-solar-leadgenerierung/' );
 $quality_url     = home_url( '/qualifizierte-pv-anfragen/' );
 $vs_url          = home_url( '/eigene-leadgenerierung-vs-portale/' );
 $intercept_url   = home_url( '/solar-leads-kaufen-alternative/' );
 
 $e3_canon            = function_exists( 'hu_e3_canon' ) ? hu_e3_canon() : [];
 $e3_metrics          = isset( $e3_canon['metrics'] ) && is_array( $e3_canon['metrics'] ) ? $e3_canon['metrics'] : [];
-$e3_case_label       = isset( $e3_canon['case_label'] ) ? (string) $e3_canon['case_label'] : 'E3 New Energy';
+$e3_case_label       = isset( $e3_canon['case_label'] ) ? (string) $e3_canon['case_label'] : 'mittelständischer PV-Installationsbetrieb';
 $e3_cpl_before       = $e3_metrics['cpl_before']['display'] ?? '150 €';
 $e3_cpl_after        = $e3_metrics['cpl_after']['display'] ?? '22 €';
 $e3_cpl_reduction    = $e3_metrics['cpl_reduction']['display'] ?? 'über 85 %';
@@ -87,7 +87,7 @@ $linked_assets = [
 	[ 't' => 'Qualifizierte PV-Anfragen – 4 Merkmale', 's' => 'Wie man hochwertige von schlechten Leads unterscheidet.', 'url' => $quality_url ],
 	[ 't' => 'TCO 24/36 Monate: Portal vs. eigenes System', 's' => 'Strategischer 8-Kriterien-Vergleich mit Asset-Eigentum-Logik.', 'url' => $vs_url ],
 	[ 't' => 'Solar Leads kaufen? CPL-Rechnung pro Anfrage', 's' => 'Markteinordnung und konkrete Kosten pro Anfrage im Lead-Markt.', 'url' => $intercept_url ],
-	[ 't' => 'E3 New Energy – Methodik-Case', 's' => sprintf( '%1$s, %2$s Abschlussquote, %3$s.', $e3_lead_count, $e3_sales_conversion, $e3_timeframe ), 'url' => $e3_url ],
+	[ 't' => 'Solar Case Study – Methodik-Case', 's' => sprintf( '%1$s, %2$s Abschlussquote, %3$s.', $e3_lead_count, $e3_sales_conversion, $e3_timeframe ), 'url' => $e3_url ],
 ];
 
 $faq = [
@@ -171,10 +171,10 @@ get_header();
 				</a>
 				<a class="hu-intercept__cta-secondary"
 				   href="<?php echo esc_url( $e3_url ); ?>"
-				   data-track-action="cta_e3_case"
+				   data-track-action="cta_case_study"
 				   data-track-category="cost_per_lead_photovoltaik"
 				   data-track-section="hero">
-					E3-Case lesen (<?php echo esc_html( $e3_lead_count ); ?> Anfragen, <?php echo esc_html( $e3_sales_conversion ); ?> Abschlussquote)
+					Case Study lesen (<?php echo esc_html( $e3_lead_count ); ?> Anfragen, <?php echo esc_html( $e3_sales_conversion ); ?> Abschlussquote)
 				</a>
 			</div>
 		</div>
@@ -198,7 +198,7 @@ get_header();
 		<div class="hu-intercept__container">
 			<h2 class="hu-intercept__h2" id="hu-cpl-scenarios-title">Drei Szenarien: Portal-Standard, Portal-Exklusiv, Eigenes System</h2>
 			<p class="hu-intercept__section-lead">
-				Vergleichsrechnung auf identischer Annahme-Basis (10 Anfragen pro Monat, B2C-Mittelstand). Werte beruhen auf marktüblichen Spannen und der E3-Referenz.
+				Vergleichsrechnung auf identischer Annahme-Basis (10 Anfragen pro Monat, B2C-Mittelstand). Werte beruhen auf marktüblichen Spannen und der Case-Study-Referenz.
 			</p>
 			<ol class="hu-intercept__layers">
 				<?php foreach ( $scenarios as $i => $s ) : ?>

--- a/blocksy-child/page-e3-new-energy.php
+++ b/blocksy-child/page-e3-new-energy.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Template Name: E3 New Energy Methodik-Case
- * Description: Methodik-Case fuer /e3-new-energy/.
+ * Template Name: Solar Case Study Methodik-Case
+ * Description: Methodik-Case fuer /case-study-solar-leadgenerierung/.
  *
  * @package Blocksy_Child
  */
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 $diagnostic_url = function_exists( 'hu_get_request_analysis_url' ) ? hu_get_request_analysis_url() : home_url( '/solar-waermepumpen-leadgenerierung/#marktcheck' );
 $agentur_url    = function_exists( 'nexus_get_primary_public_url' ) ? nexus_get_primary_public_url( 'agentur', home_url( '/wordpress-agentur-hannover/' ) ) : home_url( '/wordpress-agentur-hannover/' );
 
-$tracking_attrs = 'data-track-section="case_e3_methodology" data-track-funnel-stage="proof"';
+$tracking_attrs = 'data-track-section="case_solar_methodology" data-track-funnel-stage="proof"';
 
 $e3_cpl_before  = function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'cpl_before', 'display', '150 €' ) : '150 €';
 $e3_cpl_after   = function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'cpl_after', 'display', '22 €' ) : '22 €';
@@ -60,7 +60,7 @@ $implementation_blocks = [
 	[
 		'label' => 'Block B',
 		'title' => 'Exklusivität nachbauen',
-		'body'  => 'Eigene Domain, eigenes Formular, eigene Datenbank. Jede Anfrage ging exklusiv an E3, nicht an drei andere Anbieter gleichzeitig. Zusätzlich: CRM-Webhook direkt aus dem Formular, damit der Erstkontakt in Minuten erfolgte, nicht in Stunden — der gleiche Speed-Vorteil, den Viessmann-Anfragen strukturell hatten.',
+		'body'  => 'Eigene Domain, eigenes Formular, eigene Datenbank. Jede Anfrage ging exklusiv an den Betrieb, nicht an drei andere Anbieter gleichzeitig. Zusätzlich: CRM-Webhook direkt aus dem Formular, damit der Erstkontakt in Minuten erfolgte, nicht in Stunden — der gleiche Speed-Vorteil, den Viessmann-Anfragen strukturell hatten.',
 	],
 	[
 		'label' => 'Block C',
@@ -93,7 +93,7 @@ $transferable = [
 	'Die Vier-Eigenschaften-Logik (Intent, Exklusivität, Vorqualifizierung, Echtzeit) gilt für jeden Solar- oder SHK-Betrieb mit eigenem Vertrieb.',
 	'Tracking-Fundament ist Voraussetzung, kein optionales Add-on. Ohne sauberes Attribution-Setup wird Optimierung zum Ratespiel.',
 	'Drei Monate Implementierung sind realistisch — wer "in zwei Wochen Leads" verspricht, übersieht entweder das Tracking-Fundament oder die CRM-Integration oder beides.',
-	'Vertriebs-Schulung wird oft als erste Maßnahme verkauft. Bei E3 war der Vertrieb nie das Problem. Das ist häufiger der Fall als die Branche zugibt.',
+	'Vertriebs-Schulung wird oft als erste Maßnahme verkauft. Bei diesem Betrieb war der Vertrieb nie das Problem. Das ist häufiger der Fall als die Branche zugibt.',
 ];
 
 $specific = [
@@ -147,7 +147,7 @@ $e3_deeper = [
 	],
 	[
 		't'   => 'Lead-Funnel Solar',
-		's'   => 'Die fünf Funnel-Stufen vom Suchbegriff bis zum Auftrag – die Architektur hinter dem E3-Setup.',
+		's'   => 'Die fünf Funnel-Stufen vom Suchbegriff bis zum Auftrag – die Architektur hinter diesem Setup.',
 		'url' => home_url( '/lead-funnel-solar/' ),
 	],
 	[
@@ -166,11 +166,11 @@ get_header();
 			<div class="e3-section__inner e3-hero__inner">
 				<div class="e3-hero__content" data-reveal>
 					<p class="e3-kicker">Methodik-Case · Solar &amp; Wärmepumpe</p>
-					<h1 class="e3-hero__headline" id="e3-hero-title">Warum gekaufte Leads bei E3 nicht funktionierten — und was wir stattdessen gebaut haben.</h1>
-					<p class="e3-hero__subline">E3 New Energy hatte zwei parallele Anfrage-Quellen: Portal-Leads für 150 € pro Stück und kostenlose Viessmann-Partner-Anfragen. Die kostenlosen konvertierten deutlich besser. Die Diagnose dieses Widerspruchs wurde zur Grundlage für ein eigenes Anfrage-System.</p>
+					<h1 class="e3-hero__headline" id="e3-hero-title">Warum gekaufte Leads bei einem mittelständischen PV-Installationsbetrieb nicht funktionierten — und was wir stattdessen gebaut haben.</h1>
+					<p class="e3-hero__subline">Ein mittelständischer PV-Installationsbetrieb hatte zwei parallele Anfrage-Quellen: Portal-Leads für 150 € pro Stück und kostenlose Viessmann-Partner-Anfragen. Die kostenlosen konvertierten deutlich besser. Die Diagnose dieses Widerspruchs wurde zur Grundlage für ein eigenes Anfrage-System.</p>
 				</div>
 
-				<div class="e3-metric-grid" role="list" aria-label="E3 New Energy Kennzahlen">
+				<div class="e3-metric-grid" role="list" aria-label="Kennzahlen des mittelständischen PV-Installationsbetriebs">
 					<?php foreach ( $metrics as $metric ) : ?>
 						<div class="e3-metric-card" role="listitem" data-reveal>
 							<strong><?php echo esc_html( $metric ); ?></strong>
@@ -178,7 +178,7 @@ get_header();
 					<?php endforeach; ?>
 				</div>
 
-				<p class="e3-hero__micro" data-reveal>Mandat E3 New Energy. Implementierungsphase 3 Monate, Optimierung 3 Monate.</p>
+				<p class="e3-hero__micro" data-reveal>Mandat mittelständischer PV-Installationsbetrieb. Implementierungsphase 3 Monate, Optimierung 3 Monate.</p>
 			</div>
 		</section>
 
@@ -190,8 +190,8 @@ get_header();
 				</div>
 
 				<div class="e3-prose e3-prose--wide" data-reveal>
-					<p>E3 New Energy kaufte 2024 Solar- und Wärmepumpen-Anfragen über Portale wie Aroundhome, Check24 und DAA — rund 150 € pro Lead. Die Conversion schwankte zwischen 1 % und 5 % je nach Monat. Bei 150 € Einkauf und 3 % Durchschnitt heißt das rechnerisch 5.000 € reine Lead-Kosten pro Abschluss, bevor irgendein Cent Marge entsteht.</p>
-					<p>Parallel dazu erhielt E3 als Premium-Partner von Viessmann Anfragen — kostenlos, direkt vom Interessenten ausgelöst, der aktiv nach einem Viessmann-Fachbetrieb in seiner Region gesucht hatte. Dieselbe Vertriebsmannschaft. Derselbe Außendienst. Dieselben Produkte. Diese Anfragen konvertierten deutlich besser.</p>
+					<p>Der mittelständische PV-Installationsbetrieb kaufte 2024 Solar- und Wärmepumpen-Anfragen über Portale wie Aroundhome, Check24 und DAA — rund 150 € pro Lead. Die Conversion schwankte zwischen 1 % und 5 % je nach Monat. Bei 150 € Einkauf und 3 % Durchschnitt heißt das rechnerisch 5.000 € reine Lead-Kosten pro Abschluss, bevor irgendein Cent Marge entsteht.</p>
+					<p>Parallel dazu erhielt der Betrieb als Premium-Partner von Viessmann Anfragen — kostenlos, direkt vom Interessenten ausgelöst, der aktiv nach einem Viessmann-Fachbetrieb in seiner Region gesucht hatte. Dieselbe Vertriebsmannschaft. Derselbe Außendienst. Dieselben Produkte. Diese Anfragen konvertierten deutlich besser.</p>
 					<p>Damit war die übliche Erklärung — "der Vertrieb müsste schneller anrufen", "die Margen müssten höher sein", "das Telefonscript müsste besser werden" — sofort entkräftet. Gleicher Vertrieb, anderes Resultat. Der Unterschied lag nicht im Haus. Er lag in der Anfrage.</p>
 				</div>
 
@@ -320,7 +320,7 @@ get_header();
 			<div class="e3-section__inner">
 				<div class="e3-section__head" data-reveal>
 					<p class="e3-kicker">Kernerkenntnis</p>
-					<h2 class="e3-section__title" id="insight-title">Die fundamentale Erkenntnis aus <?php echo esc_html( function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'timeframe', 'display_dative' ) : '6 Monaten' ); ?> E3.</h2>
+					<h2 class="e3-section__title" id="insight-title">Die fundamentale Erkenntnis aus <?php echo esc_html( function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'timeframe', 'display_dative' ) : '6 Monaten' ); ?> Praxis.</h2>
 				</div>
 
 				<aside class="e3-pullquote" data-reveal>
@@ -333,7 +333,7 @@ get_header();
 			<div class="e3-section__inner">
 				<div class="e3-section__head" data-reveal>
 					<p class="e3-kicker">Methodik im Detail</p>
-					<h2 class="e3-section__title" id="vertiefung-title">Vier Bausteine, die das E3-Ergebnis möglich gemacht haben.</h2>
+					<h2 class="e3-section__title" id="vertiefung-title">Vier Bausteine, die dieses Ergebnis möglich gemacht haben.</h2>
 					<p class="e3-section__lead">
 						Wer den Case fachlich vertiefen will: hier die thematischen Seiten zu CPL-Rechnung, Tracking-Architektur, Funnel-Stufen und der TCO-Logik gegenüber Lead-Portalen.
 					</p>
@@ -344,7 +344,7 @@ get_header();
 						<li class="e3-deeper-item" data-reveal>
 							<a class="e3-deeper-link"
 							   href="<?php echo esc_url( $deeper_item['url'] ); ?>"
-							   data-track-action="cta_e3_deeper_link"
+							   data-track-action="cta_case_study_deeper_link"
 							   data-track-category="navigation"
 							   data-track-section="vertiefung">
 								<span class="e3-deeper-link__t"><?php echo esc_html( $deeper_item['t'] ); ?></span>
@@ -356,7 +356,7 @@ get_header();
 
 				<p class="e3-coda e3-coda--agentur" data-reveal>
 					Wenn es nicht um Solar oder Wärmepumpe geht, sondern um ein erklärungsbedürftiges B2B-Angebot auf WordPress, ist der passendere Einstieg die
-					<a href="<?php echo esc_url( $agentur_url ); ?>" data-track-action="cta_e3_to_agentur" data-track-category="navigation" data-track-section="vertiefung">WordPress Agentur Hannover</a>.
+					<a href="<?php echo esc_url( $agentur_url ); ?>" data-track-action="cta_case_study_to_agentur" data-track-category="navigation" data-track-section="vertiefung">WordPress Agentur Hannover</a>.
 				</p>
 			</div>
 		</section>
@@ -374,7 +374,7 @@ get_header();
 				</ul>
 
 				<div class="e3-cta__actions">
-					<a class="e3-btn" href="<?php echo esc_url( $diagnostic_url ); ?>" data-track-action="cta_e3_to_diagnostic_request" data-track-category="lead_gen" data-track-section="case_e3_methodology">
+					<a class="e3-btn" href="<?php echo esc_url( $diagnostic_url ); ?>" data-track-action="cta_case_study_to_diagnostic_request" data-track-category="lead_gen" data-track-section="case_solar_methodology">
 						<span>Marktcheck mit Fit-Entscheid starten</span>
 						<span class="e3-btn__arrow" aria-hidden="true">→</span>
 					</a>

--- a/blocksy-child/page-eigene-leadgenerierung-vs-portale.php
+++ b/blocksy-child/page-eigene-leadgenerierung-vs-portale.php
@@ -20,12 +20,12 @@ $solar_money_url = function_exists( 'nexus_get_energy_systems_url' )
 	? nexus_get_energy_systems_url()
 	: home_url( '/solar-waermepumpen-leadgenerierung/' );
 $marktcheck_url  = trailingslashit( $solar_money_url ) . '#marktcheck';
-$e3_url          = home_url( '/e3-new-energy/' );
+$e3_url          = home_url( '/case-study-solar-leadgenerierung/' );
 
 $linked_assets = [
 	[
 		't'   => 'CPL pro Anfrage: Solar Leads kaufen oder eigenes System?',
-		's'   => 'Die konkrete Kosten-pro-Anfrage-Rechnung mit E3-Benchmark und Portal-Preisspannen.',
+		's'   => 'Die konkrete Kosten-pro-Anfrage-Rechnung mit Case-Study-Benchmark und Portal-Preisspannen.',
 		'url' => home_url( '/solar-leads-kaufen-alternative/' ),
 	],
 	[
@@ -48,7 +48,7 @@ $linked_assets = [
 // ── E3-Canon ──────────────────────────────────────────────────
 $e3_canon            = function_exists( 'hu_e3_canon' ) ? hu_e3_canon() : [];
 $e3_metrics          = isset( $e3_canon['metrics'] ) && is_array( $e3_canon['metrics'] ) ? $e3_canon['metrics'] : [];
-$e3_case_label       = isset( $e3_canon['case_label'] ) ? (string) $e3_canon['case_label'] : 'E3 New Energy';
+$e3_case_label       = isset( $e3_canon['case_label'] ) ? (string) $e3_canon['case_label'] : 'mittelständischer PV-Installationsbetrieb';
 $e3_cpl_before       = $e3_metrics['cpl_before']['display'] ?? '150 €';
 $e3_cpl_after        = $e3_metrics['cpl_after']['display'] ?? '22 €';
 $e3_cpl_reduction    = $e3_metrics['cpl_reduction']['display'] ?? 'über 85 %';
@@ -67,9 +67,9 @@ $rent_facts = [
 ];
 
 $own_facts = [
-	[ 'k' => $e3_cpl_after, 'l' => 'Cost per Lead im eigenen System (E3-Referenz)' ],
+	[ 'k' => $e3_cpl_after, 'l' => 'Cost per Lead im eigenen System (Case-Study-Referenz)' ],
 	[ 'k' => '1× exklusiv', 'l' => 'jede Anfrage gehört nur Ihrem Betrieb' ],
-	[ 'k' => $e3_sales_conversion, 'l' => 'Abschlussquote bei eigenen Anfragen (E3)' ],
+	[ 'k' => $e3_sales_conversion, 'l' => 'Abschlussquote bei eigenen Anfragen (Case Study)' ],
 	[ 'k' => 'CAPEX', 'l' => 'investiv in Eigentum, bilanzierbar und planbar' ],
 ];
 
@@ -102,7 +102,7 @@ $comparison_rows = [
 	[
 		'criterion' => 'Abschlussquote',
 		'rent'      => sprintf( 'typisch %s — Endkunde wurde parallel an Wettbewerber verkauft', $e3_conv_before ),
-		'own'       => sprintf( '%s bei E3 — Faktor 6× bis 12× durch Exklusivität und Vorqualifizierung', $e3_sales_conversion ),
+		'own'       => sprintf( '%s bei diesem Betrieb — Faktor 6× bis 12× durch Exklusivität und Vorqualifizierung', $e3_sales_conversion ),
 	],
 	[
 		'criterion' => 'Attribution',
@@ -154,7 +154,7 @@ $when_rent_makes_sense = [
 $faq = [
 	[
 		'question' => 'Wann lohnt sich der Umstieg vom Portal auf das eigene System?',
-		'answer'   => sprintf( 'Faustregel: ab einem monatlichen Portal-Budget von 800 – 1.000 € amortisiert sich der Aufbau eines eigenen Anfrage-Systems im B2B-Mittelstand binnen 12 – 24 Monaten. Bei E3 New Energy lag die Amortisation in %1$s; gleichzeitig sank der CPL %2$s.', $e3_timeframe, $e3_cpl_reduction ),
+		'answer'   => sprintf( 'Faustregel: ab einem monatlichen Portal-Budget von 800 – 1.000 € amortisiert sich der Aufbau eines eigenen Anfrage-Systems im B2B-Mittelstand binnen 12 – 24 Monaten. Bei einem mittelständischen PV-Installationsbetrieb lag die Amortisation in %1$s; gleichzeitig sank der CPL %2$s.', $e3_timeframe, $e3_cpl_reduction ),
 	],
 	[
 		'question' => 'Kann ich beide Wege parallel fahren?',
@@ -241,10 +241,10 @@ get_header();
 				</a>
 				<a class="hu-intercept__cta-secondary"
 				   href="<?php echo esc_url( $e3_url ); ?>"
-				   data-track-action="cta_e3_case"
+				   data-track-action="cta_case_study"
 				   data-track-category="vergleich_portale"
 				   data-track-section="hero">
-					E3-Case lesen (<?php echo esc_html( $e3_lead_count ); ?> Anfragen, <?php echo esc_html( $e3_sales_conversion ); ?> Abschlussquote)
+					Case Study lesen (<?php echo esc_html( $e3_lead_count ); ?> Anfragen, <?php echo esc_html( $e3_sales_conversion ); ?> Abschlussquote)
 				</a>
 			</div>
 			<p class="hu-intercept__hero-related" style="margin-top:18px;font-size:13.5px;opacity:.75;">
@@ -311,7 +311,7 @@ get_header();
 		<div class="hu-intercept__container">
 			<h2 class="hu-intercept__h2" id="hu-vs-tco-title">TCO-Überschlag: 24 und 36 Monate</h2>
 			<p class="hu-intercept__section-lead">
-				Beispielrechnung für einen mittelständischen Solar-/Wärmepumpen-Betrieb mit etwa ~ 20 zusätzlichen Anfragen pro Monat. Werte beruhen auf typischen Marktdaten und der E3-Referenz.
+				Beispielrechnung für einen mittelständischen Solar-/Wärmepumpen-Betrieb mit etwa ~ 20 zusätzlichen Anfragen pro Monat. Werte beruhen auf typischen Marktdaten und der Case-Study-Referenz.
 			</p>
 			<div class="hu-intercept__grid hu-intercept__grid--two">
 				<?php foreach ( $tco_scenarios as $scenario ) : ?>

--- a/blocksy-child/page-kunden-gewinnen-solarteure.php
+++ b/blocksy-child/page-kunden-gewinnen-solarteure.php
@@ -19,13 +19,13 @@ $solar_money_url = function_exists( 'nexus_get_energy_systems_url' )
 	? nexus_get_energy_systems_url()
 	: home_url( '/solar-waermepumpen-leadgenerierung/' );
 $marktcheck_url  = trailingslashit( $solar_money_url ) . '#marktcheck';
-$e3_url          = home_url( '/e3-new-energy/' );
+$e3_url          = home_url( '/case-study-solar-leadgenerierung/' );
 $intercept_url   = home_url( '/solar-leads-kaufen-alternative/' );
 $vs_url          = home_url( '/eigene-leadgenerierung-vs-portale/' );
 
 $e3_canon            = function_exists( 'hu_e3_canon' ) ? hu_e3_canon() : [];
 $e3_metrics          = isset( $e3_canon['metrics'] ) && is_array( $e3_canon['metrics'] ) ? $e3_canon['metrics'] : [];
-$e3_case_label       = isset( $e3_canon['case_label'] ) ? (string) $e3_canon['case_label'] : 'E3 New Energy';
+$e3_case_label       = isset( $e3_canon['case_label'] ) ? (string) $e3_canon['case_label'] : 'mittelständischer PV-Installationsbetrieb';
 $e3_cpl_reduction    = $e3_metrics['cpl_reduction']['display'] ?? 'über 85 %';
 $e3_lead_count       = $e3_metrics['lead_count']['display'] ?? '1.750+';
 $e3_sales_conversion = $e3_metrics['sales_conversion']['display'] ?? '12 %';
@@ -90,7 +90,7 @@ $linked_assets = [
 	[ 't' => 'Lead-Funnel Solar (Pillar)', 's' => 'Die 5 Funnel-Stufen und die häufigsten Fehler.', 'url' => home_url( '/lead-funnel-solar/' ) ],
 	[ 't' => 'TCO über 24 Monate: Portal-Leads vs. eigenes System', 's' => 'Strategische Vergleichsmatrix mit Asset-Eigentum-Logik.', 'url' => $vs_url ],
 	[ 't' => 'Solar Leads kaufen? CPL-Rechnung pro Anfrage', 's' => 'Warum Portal-Leads das Wachstum bremsen — Kosten pro Anfrage im Detail.', 'url' => $intercept_url ],
-	[ 't' => 'E3-Methodik-Case', 's' => sprintf( '%1$s Anfragen, %2$s Abschlussquote.', $e3_lead_count, $e3_sales_conversion ), 'url' => $e3_url ],
+	[ 't' => 'Solar-Methodik-Case', 's' => sprintf( '%1$s Anfragen, %2$s Abschlussquote.', $e3_lead_count, $e3_sales_conversion ), 'url' => $e3_url ],
 ];
 
 $faq = [
@@ -104,7 +104,7 @@ $faq = [
 	],
 	[
 		'question' => 'Wie viele neue Kunden sind realistisch pro Monat?',
-		'answer'   => 'Das hängt von Region, Projektwert und Ad-Budget ab. Im DACH-Mittelstand sind 8–25 zusätzliche qualifizierte Anfragen pro Monat realistisch, bei Abschlussquoten von 8–15 % – siehe E3-Referenz mit 12 % Abschlussquote.',
+		'answer'   => 'Das hängt von Region, Projektwert und Ad-Budget ab. Im DACH-Mittelstand sind 8–25 zusätzliche qualifizierte Anfragen pro Monat realistisch, bei Abschlussquoten von 8–15 % – siehe Case-Study-Referenz mit 12 % Abschlussquote.',
 	],
 	[
 		'question' => 'Brauche ich dafür eine neue Website?',
@@ -174,10 +174,10 @@ get_header();
 				</a>
 				<a class="hu-intercept__cta-secondary"
 				   href="<?php echo esc_url( $e3_url ); ?>"
-				   data-track-action="cta_e3_case"
+				   data-track-action="cta_case_study"
 				   data-track-category="kunden_gewinnen_solarteure"
 				   data-track-section="hero">
-					E3-Case lesen (<?php echo esc_html( $e3_lead_count ); ?> Anfragen, <?php echo esc_html( $e3_sales_conversion ); ?> Abschlussquote)
+					Case Study lesen (<?php echo esc_html( $e3_lead_count ); ?> Anfragen, <?php echo esc_html( $e3_sales_conversion ); ?> Abschlussquote)
 				</a>
 			</div>
 		</div>

--- a/blocksy-child/page-lead-funnel-solar.php
+++ b/blocksy-child/page-lead-funnel-solar.php
@@ -18,13 +18,13 @@ $solar_money_url = function_exists( 'nexus_get_energy_systems_url' )
 	? nexus_get_energy_systems_url()
 	: home_url( '/solar-waermepumpen-leadgenerierung/' );
 $marktcheck_url  = trailingslashit( $solar_money_url ) . '#marktcheck';
-$e3_url          = home_url( '/e3-new-energy/' );
+$e3_url          = home_url( '/case-study-solar-leadgenerierung/' );
 $sst_url         = home_url( '/server-side-tracking-b2b/' );
 $vs_url          = home_url( '/eigene-leadgenerierung-vs-portale/' );
 
 $e3_canon            = function_exists( 'hu_e3_canon' ) ? hu_e3_canon() : [];
 $e3_metrics          = isset( $e3_canon['metrics'] ) && is_array( $e3_canon['metrics'] ) ? $e3_canon['metrics'] : [];
-$e3_case_label       = isset( $e3_canon['case_label'] ) ? (string) $e3_canon['case_label'] : 'E3 New Energy';
+$e3_case_label       = isset( $e3_canon['case_label'] ) ? (string) $e3_canon['case_label'] : 'mittelständischer PV-Installationsbetrieb';
 $e3_cpl_reduction    = $e3_metrics['cpl_reduction']['display'] ?? 'über 85 %';
 $e3_lead_count       = $e3_metrics['lead_count']['display'] ?? '1.750+';
 $e3_sales_conversion = $e3_metrics['sales_conversion']['display'] ?? '12 %';
@@ -75,7 +75,7 @@ $funnel_pitfalls = [
 $linked_assets = [
 	[ 't' => 'Server-Side Tracking für B2B', 's' => 'GA4, Meta CAPI, Consent Mode v2 – die Daten-Schicht unter dem Funnel.', 'url' => $sst_url ],
 	[ 't' => 'TCO über 24 Monate: Portal-Leads vs. eigenes System', 's' => 'Strategischer 8-Kriterien-Vergleich mit Asset-Eigentum-Logik.', 'url' => $vs_url ],
-	[ 't' => 'E3-Methodik-Case', 's' => sprintf( '%1$s qualifizierte Anfragen, %2$s Abschlussquote, %3$s niedrigere Cost per Lead.', $e3_lead_count, $e3_sales_conversion, $e3_cpl_reduction ), 'url' => $e3_url ],
+	[ 't' => 'Solar-Methodik-Case', 's' => sprintf( '%1$s qualifizierte Anfragen, %2$s Abschlussquote, %3$s niedrigere Cost per Lead.', $e3_lead_count, $e3_sales_conversion, $e3_cpl_reduction ), 'url' => $e3_url ],
 ];
 
 $faq = [
@@ -155,10 +155,10 @@ get_header();
 				</a>
 				<a class="hu-intercept__cta-secondary"
 				   href="<?php echo esc_url( $e3_url ); ?>"
-				   data-track-action="cta_e3_case"
+				   data-track-action="cta_case_study"
 				   data-track-category="lead_funnel_solar"
 				   data-track-section="hero">
-					E3-Case lesen (<?php echo esc_html( $e3_lead_count ); ?> Anfragen, <?php echo esc_html( $e3_sales_conversion ); ?> Abschlussquote)
+					Case Study lesen (<?php echo esc_html( $e3_lead_count ); ?> Anfragen, <?php echo esc_html( $e3_sales_conversion ); ?> Abschlussquote)
 				</a>
 			</div>
 		</div>

--- a/blocksy-child/page-qualifizierte-pv-anfragen.php
+++ b/blocksy-child/page-qualifizierte-pv-anfragen.php
@@ -17,14 +17,14 @@ $solar_money_url = function_exists( 'nexus_get_energy_systems_url' )
 	? nexus_get_energy_systems_url()
 	: home_url( '/solar-waermepumpen-leadgenerierung/' );
 $marktcheck_url  = trailingslashit( $solar_money_url ) . '#marktcheck';
-$e3_url          = home_url( '/e3-new-energy/' );
+$e3_url          = home_url( '/case-study-solar-leadgenerierung/' );
 $cpl_url         = home_url( '/cost-per-lead-photovoltaik/' );
 $sst_url         = home_url( '/server-side-tracking-b2b/' );
 $intercept_url   = home_url( '/solar-leads-kaufen-alternative/' );
 
 $e3_canon            = function_exists( 'hu_e3_canon' ) ? hu_e3_canon() : [];
 $e3_metrics          = isset( $e3_canon['metrics'] ) && is_array( $e3_canon['metrics'] ) ? $e3_canon['metrics'] : [];
-$e3_case_label       = isset( $e3_canon['case_label'] ) ? (string) $e3_canon['case_label'] : 'E3 New Energy';
+$e3_case_label       = isset( $e3_canon['case_label'] ) ? (string) $e3_canon['case_label'] : 'mittelständischer PV-Installationsbetrieb';
 $e3_cpl_reduction    = $e3_metrics['cpl_reduction']['display'] ?? 'über 85 %';
 $e3_sales_conversion = $e3_metrics['sales_conversion']['display'] ?? '12 %';
 $e3_lead_count       = $e3_metrics['lead_count']['display'] ?? '1.750+';
@@ -91,7 +91,7 @@ $linked_assets = [
 	[ 't' => 'Cost per Lead Photovoltaik', 's' => 'Drei Szenarien im CPL-Vergleich und versteckte Kostentreiber.', 'url' => $cpl_url ],
 	[ 't' => 'Server-Side Tracking für B2B', 's' => 'Wie man Quelle-zu-Auftrag-Attribution sauber misst.', 'url' => $sst_url ],
 	[ 't' => 'Solar Leads kaufen? CPL-Rechnung pro Anfrage', 's' => 'Markteinordnung der Lead-Anbieter und konkrete Kosten pro Anfrage.', 'url' => $intercept_url ],
-	[ 't' => 'E3 New Energy – Methodik-Case', 's' => sprintf( '%1$s, %2$s Abschlussquote in %3$s.', $e3_lead_count, $e3_sales_conversion, $e3_timeframe ), 'url' => $e3_url ],
+	[ 't' => 'Solar Case Study – Methodik-Case', 's' => sprintf( '%1$s, %2$s Abschlussquote in %3$s.', $e3_lead_count, $e3_sales_conversion, $e3_timeframe ), 'url' => $e3_url ],
 ];
 
 $faq = [
@@ -113,7 +113,7 @@ $faq = [
 	],
 	[
 		'question' => sprintf( 'Welche Abschlussquote ist im Solar-Bereich realistisch?', $e3_case_label ),
-		'answer'   => sprintf( 'Im B2C-PV-Markt liegen Abschlussquoten bei Portal-Leads typischerweise zwischen 2 %% und 5 %%. Bei eigenen, qualifizierten Anfragen sind 8 %% bis 15 %% realistisch – die E3-Referenz liegt bei %s über alle Anfragen hinweg.', $e3_sales_conversion ),
+		'answer'   => sprintf( 'Im B2C-PV-Markt liegen Abschlussquoten bei Portal-Leads typischerweise zwischen 2 %% und 5 %%. Bei eigenen, qualifizierten Anfragen sind 8 %% bis 15 %% realistisch – die Case-Study-Referenz liegt bei %s über alle Anfragen hinweg.', $e3_sales_conversion ),
 	],
 ];
 
@@ -175,10 +175,10 @@ get_header();
 				</a>
 				<a class="hu-intercept__cta-secondary"
 				   href="<?php echo esc_url( $e3_url ); ?>"
-				   data-track-action="cta_e3_case"
+				   data-track-action="cta_case_study"
 				   data-track-category="qualifizierte_pv_anfragen"
 				   data-track-section="hero">
-					E3-Case ansehen
+					Case Study ansehen
 				</a>
 			</div>
 		</div>

--- a/blocksy-child/page-server-side-tracking-b2b.php
+++ b/blocksy-child/page-server-side-tracking-b2b.php
@@ -18,12 +18,12 @@ $solar_money_url = function_exists( 'nexus_get_energy_systems_url' )
 	? nexus_get_energy_systems_url()
 	: home_url( '/solar-waermepumpen-leadgenerierung/' );
 $marktcheck_url  = trailingslashit( $solar_money_url ) . '#marktcheck';
-$e3_url          = home_url( '/e3-new-energy/' );
+$e3_url          = home_url( '/case-study-solar-leadgenerierung/' );
 
 // ── E3-Canon ──────────────────────────────────────────────────
 $e3_canon            = function_exists( 'hu_e3_canon' ) ? hu_e3_canon() : [];
 $e3_metrics          = isset( $e3_canon['metrics'] ) && is_array( $e3_canon['metrics'] ) ? $e3_canon['metrics'] : [];
-$e3_case_label       = isset( $e3_canon['case_label'] ) ? (string) $e3_canon['case_label'] : 'E3 New Energy';
+$e3_case_label       = isset( $e3_canon['case_label'] ) ? (string) $e3_canon['case_label'] : 'mittelständischer PV-Installationsbetrieb';
 $e3_cpl_reduction    = $e3_metrics['cpl_reduction']['display'] ?? 'über 85 %';
 $e3_lead_count       = $e3_metrics['lead_count']['display'] ?? '1.750+';
 $e3_sales_conversion = $e3_metrics['sales_conversion']['display'] ?? '12 %';
@@ -193,10 +193,10 @@ get_header();
 				</a>
 				<a class="hu-intercept__cta-secondary"
 				   href="<?php echo esc_url( $e3_url ); ?>"
-				   data-track-action="cta_e3_case"
+				   data-track-action="cta_case_study"
 				   data-track-category="server_side_tracking_b2b"
 				   data-track-section="hero">
-					E3-Case ansehen (<?php echo esc_html( $e3_cpl_reduction ); ?> CPL-Senkung)
+					Case Study ansehen (<?php echo esc_html( $e3_cpl_reduction ); ?> CPL-Senkung)
 				</a>
 			</div>
 		</div>

--- a/blocksy-child/page-solar-leads-kaufen-alternative.php
+++ b/blocksy-child/page-solar-leads-kaufen-alternative.php
@@ -19,7 +19,7 @@ $solar_money_url = function_exists( 'nexus_get_energy_systems_url' )
 	? nexus_get_energy_systems_url()
 	: home_url( '/solar-waermepumpen-leadgenerierung/' );
 $marktcheck_url  = trailingslashit( $solar_money_url ) . '#marktcheck';
-$e3_url          = home_url( '/e3-new-energy/' );
+$e3_url          = home_url( '/case-study-solar-leadgenerierung/' );
 $contact_url     = home_url( '/kontakt/' );
 
 $linked_assets = [
@@ -48,7 +48,7 @@ $linked_assets = [
 // ── E3-Proof-Canon ─────────────────────────────────────────────
 $e3_canon            = function_exists( 'hu_e3_canon' ) ? hu_e3_canon() : [];
 $e3_metrics          = isset( $e3_canon['metrics'] ) && is_array( $e3_canon['metrics'] ) ? $e3_canon['metrics'] : [];
-$e3_case_label       = isset( $e3_canon['case_label'] ) ? (string) $e3_canon['case_label'] : 'E3 New Energy';
+$e3_case_label       = isset( $e3_canon['case_label'] ) ? (string) $e3_canon['case_label'] : 'mittelständischer PV-Installationsbetrieb';
 $e3_lead_count       = $e3_metrics['lead_count']['display'] ?? '1.750+';
 $e3_sales_conversion = $e3_metrics['sales_conversion']['display'] ?? '12 %';
 $e3_conv_uplift      = $e3_metrics['sales_conversion_uplift']['display'] ?? '1 – 5 % → 12 %';
@@ -81,7 +81,7 @@ $portal_facts = [
 $own_facts = [
 	[
 		'k' => $e3_cpl_after,
-		'l' => 'Cost per Lead im eigenen Anfrage-System (E3-Referenz)',
+		'l' => 'Cost per Lead im eigenen Anfrage-System (Case-Study-Referenz)',
 	],
 	[
 		'k' => '100 %',
@@ -89,7 +89,7 @@ $own_facts = [
 	],
 	[
 		'k' => $e3_conv_uplift,
-		'l' => 'Sprung der Abschlussquote — von Portal-Leads zu eigenem System (E3)',
+		'l' => 'Sprung der Abschlussquote — von Portal-Leads zu eigenem System (Case Study)',
 	],
 	[
 		'k' => '100 % Asset',
@@ -131,7 +131,7 @@ $market_models = [
 	],
 	[
 		't' => 'Eigene Anfrage-Infrastruktur',
-		's' => 'Money Page, Server-Side-Tracking und Vorqualifizierung im eigenen Eigentum. Anfragen sind per Definition exklusiv. Setup einmalig, Asset im Betrieb. Vergleich: siehe E3-Referenz.',
+		's' => 'Money Page, Server-Side-Tracking und Vorqualifizierung im eigenen Eigentum. Anfragen sind per Definition exklusiv. Setup einmalig, Asset im Betrieb. Vergleich: siehe Case-Study-Referenz.',
 	],
 ];
 
@@ -192,7 +192,7 @@ $objections = [
 	],
 	[
 		'question' => 'Wie lange dauert es, bis sich das rechnet?',
-		'answer'   => sprintf( 'Bei E3 New Energy hat sich das System nach %1$s amortisiert: %2$s qualifizierte Anfragen, %3$s Abschlussquote und der CPL fiel von %4$s auf %5$s.', $e3_timeframe, $e3_lead_count, $e3_sales_conversion, $e3_cpl_before, $e3_cpl_after ),
+		'answer'   => sprintf( 'Bei einem mittelständischen PV-Installationsbetrieb hat sich das System nach %1$s amortisiert: %2$s qualifizierte Anfragen, %3$s Abschlussquote und der CPL fiel von %4$s auf %5$s.', $e3_timeframe, $e3_lead_count, $e3_sales_conversion, $e3_cpl_before, $e3_cpl_after ),
 	],
 	[
 		'question' => 'Verkaufen Sie selbst Leads?',
@@ -275,10 +275,10 @@ get_header();
 				</a>
 				<a class="hu-intercept__cta-secondary"
 				   href="<?php echo esc_url( $e3_url ); ?>"
-				   data-track-action="cta_e3_case"
+				   data-track-action="cta_case_study"
 				   data-track-category="intercept_solar_leads"
 				   data-track-section="hero">
-					E3-Case lesen (<?php echo esc_html( $e3_lead_count ); ?> Anfragen, <?php echo esc_html( $e3_sales_conversion ); ?> Abschlussquote)
+					Case Study lesen (<?php echo esc_html( $e3_lead_count ); ?> Anfragen, <?php echo esc_html( $e3_sales_conversion ); ?> Abschlussquote)
 				</a>
 			</div>
 			<p class="hu-intercept__hero-related" style="margin-top:18px;font-size:13.5px;opacity:.75;">

--- a/blocksy-child/page-solar-leads-kosten-studie.php
+++ b/blocksy-child/page-solar-leads-kosten-studie.php
@@ -4,7 +4,7 @@
  * Description: Zitierfähige Marktstudie zu den tatsächlichen Kosten von Solar-,
  *              Wärmepumpen- und Speicher-Leads im DACH-Raum. Kernthese:
  *              Cost-per-Order statt Cost-per-Lead. Methodik transparent,
- *              eigene Fallzahl (E3) als Referenz-Benchmark.
+ *              eigene Fallzahl (Case Study) als Referenz-Benchmark.
  *              Primärer Pfad: Marktcheck auf /solar-waermepumpen-leadgenerierung/#marktcheck.
  *
  * @package Blocksy_Child
@@ -20,12 +20,12 @@ $solar_money_url = function_exists( 'nexus_get_energy_systems_url' )
 	? nexus_get_energy_systems_url()
 	: home_url( '/solar-waermepumpen-leadgenerierung/' );
 $marktcheck_url  = trailingslashit( $solar_money_url ) . '#marktcheck';
-$e3_url          = home_url( '/e3-new-energy/' );
+$e3_url          = home_url( '/case-study-solar-leadgenerierung/' );
 
 // ── E3-Proof-Canon (Referenz-Benchmark) ───────────────────────
 $e3_canon         = function_exists( 'hu_e3_canon' ) ? hu_e3_canon() : [];
 $e3_metrics       = isset( $e3_canon['metrics'] ) && is_array( $e3_canon['metrics'] ) ? $e3_canon['metrics'] : [];
-$e3_case_label    = isset( $e3_canon['case_label'] ) ? (string) $e3_canon['case_label'] : 'E3 New Energy';
+$e3_case_label    = isset( $e3_canon['case_label'] ) ? (string) $e3_canon['case_label'] : 'mittelständischer PV-Installationsbetrieb';
 $e3_cpl_after     = $e3_metrics['cpl_after']['display'] ?? '22 €';
 $e3_conv_after    = $e3_metrics['sales_conversion']['display'] ?? '12 %';
 $e3_timeframe     = $e3_metrics['timeframe']['display'] ?? '6 Monate';
@@ -97,7 +97,7 @@ $cpo_rows = [
 		'cpo'    => '3.000 €',
 	],
 	[
-		'modell' => 'Eigenes Anfrage-System (E3-Referenz)',
+		'modell' => 'Eigenes Anfrage-System (Case-Study-Referenz)',
 		'cpl'    => $e3_cpl_after,
 		'conv'   => $e3_conv_after,
 		'cpo'    => '≈ 183 €',
@@ -136,11 +136,11 @@ $faqs = [
 	],
 	[
 		'question' => 'Wie wird der Cost-per-Order berechnet?',
-		'answer'   => 'CPO = Cost-per-Lead geteilt durch die Abschlussquote. Beispiel: 70 € Lead-Preis bei 2 % Abschlussquote ergibt 3.500 € pro Abschluss. Ein eigenes System mit 22 € pro Anfrage und 12 % Abschlussquote ergibt rund 183 € pro Abschluss (Referenzwerte E3 New Energy).',
+		'answer'   => 'CPO = Cost-per-Lead geteilt durch die Abschlussquote. Beispiel: 70 € Lead-Preis bei 2 % Abschlussquote ergibt 3.500 € pro Abschluss. Ein eigenes System mit 22 € pro Anfrage und 12 % Abschlussquote ergibt rund 183 € pro Abschluss (Referenzwerte Case Study).',
 	],
 	[
 		'question' => 'Sind die Zahlen dieser Studie repräsentativ?',
-		'answer'   => 'Die Preisspannen basieren auf öffentlich beobachtbaren Marktpreispunkten und Brancheneinordnung. Die Abschluss- und CPO-Werte des eigenen Systems sind ein dokumentierter Einzelfall (E3 New Energy) und ausdrücklich als Referenz, nicht als Garantie zu lesen. Die CPO-Tabelle ist eine transparente Modellrechnung, keine Erhebung.',
+		'answer'   => 'Die Preisspannen basieren auf öffentlich beobachtbaren Marktpreispunkten und Brancheneinordnung. Die Abschluss- und CPO-Werte des eigenen Systems sind ein dokumentierter Einzelfall (mittelständischer PV-Installationsbetrieb) und ausdrücklich als Referenz, nicht als Garantie zu lesen. Die CPO-Tabelle ist eine transparente Modellrechnung, keine Erhebung.',
 	],
 	[
 		'question' => 'Lohnt sich ein eigenes Anfrage-System gegenüber Lead-Kauf?',

--- a/blocksy-child/page-solar-waermepumpen-leadgenerierung.php
+++ b/blocksy-child/page-solar-waermepumpen-leadgenerierung.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 // ── URLs ───────────────────────────────────────────────────────
 $page_url     = function_exists( 'nexus_get_energy_systems_url' ) ? nexus_get_energy_systems_url() : home_url( '/solar-waermepumpen-leadgenerierung/' );
-$e3_url       = home_url( '/e3-new-energy/' );
+$e3_url       = home_url( '/case-study-solar-leadgenerierung/' );
 $privacy_url  = home_url( '/datenschutz/' );
 $primary_urls = function_exists( 'nexus_get_primary_public_url_map' ) ? nexus_get_primary_public_url_map() : [];
 $tracking_url = $primary_urls['tracking'] ?? home_url( '/ga4-tracking-setup/' );
@@ -33,7 +33,7 @@ $cal_url      = function_exists( 'hu_get_analysis_calcom_base_url' )
 // ── E3-Proof-Metriken (Canon) ──────────────────────────────────
 $e3_canon            = function_exists( 'hu_e3_canon' ) ? hu_e3_canon() : [];
 $e3_metrics          = isset( $e3_canon['metrics'] ) && is_array( $e3_canon['metrics'] ) ? $e3_canon['metrics'] : [];
-$e3_case_label       = isset( $e3_canon['case_label'] ) ? (string) $e3_canon['case_label'] : 'E3 New Energy';
+$e3_case_label       = isset( $e3_canon['case_label'] ) ? (string) $e3_canon['case_label'] : 'mittelständischer PV-Installationsbetrieb';
 $e3_lead_count       = $e3_metrics['lead_count']['display'] ?? '1.750+';
 $e3_sales_conversion = $e3_metrics['sales_conversion']['display'] ?? '12 %';
 $e3_conv_before      = $e3_metrics['sales_conversion_before']['display'] ?? '1 – 5 %';
@@ -604,7 +604,7 @@ get_header();
 		</section>
 
 		<!-- ════════════════════════════════════════════════════════════
-		     PROOF-BAR — E3-Kennzahlen früh sichtbar (Teaser → #ergebnisse)
+		     PROOF-BAR — Case-Study-Kennzahlen früh sichtbar (Teaser → #ergebnisse)
 		     ════════════════════════════════════════════════════════════ -->
 		<section class="sol-proofbar" aria-label="Belegte Ergebnisse aus dem <?php echo esc_attr( $e3_case_label ); ?>-Case" data-track-section="proof_bar">
 			<div class="hu-container">
@@ -872,7 +872,7 @@ get_header();
 		</section>
 
 		<!-- ════════════════════════════════════════════════════════════
-		     05 / E3 NEW ENERGY — Vorher/Nachher + Stats (Ink)
+		     05 / SOLAR CASE STUDY — Vorher/Nachher + Stats (Ink)
 		     ════════════════════════════════════════════════════════════ -->
 		<section class="hu-section" id="ergebnisse" data-track-section="results">
 			<div class="hu-container">

--- a/blocksy-child/page-startseite-wow.php
+++ b/blocksy-child/page-startseite-wow.php
@@ -13,7 +13,7 @@ $analysis_url     = function_exists( 'hu_get_request_analysis_url' ) ? hu_get_re
 $contact_url      = function_exists( 'nexus_get_contact_url' ) ? nexus_get_contact_url() : home_url( '/kontakt/' );
 $energy_url       = function_exists( 'nexus_get_energy_systems_url' ) ? nexus_get_energy_systems_url() : home_url( '/solar-waermepumpen-leadgenerierung/' );
 $e3_canon         = function_exists( 'hu_e3_canon' ) ? hu_e3_canon() : [];
-$e3_case_url      = isset( $e3_canon['url'] ) ? (string) $e3_canon['url'] : home_url( '/e3-new-energy/' );
+$e3_case_url      = isset( $e3_canon['url'] ) ? (string) $e3_canon['url'] : home_url( '/case-study-solar-leadgenerierung/' );
 $e3_metrics       = isset( $e3_canon['metrics'] ) && is_array( $e3_canon['metrics'] ) ? $e3_canon['metrics'] : [];
 $e3_lead_count    = $e3_metrics['lead_count']['display']       ?? '1.750+';
 $e3_sales_conv    = $e3_metrics['sales_conversion']['display'] ?? '12 %';
@@ -57,7 +57,7 @@ $loss_markers = [
 ];
 
 $proof_metrics = [
-	[ 'value' => $e3_lead_count, 'label' => 'qualifizierte Anfragen', 'detail' => 'E3-System' ],
+	[ 'value' => $e3_lead_count, 'label' => 'qualifizierte Anfragen', 'detail' => 'eigenes System' ],
 	[ 'value' => $e3_sales_conv, 'label' => 'Abschlussquote', 'detail' => 'vom Lead zum Auftrag' ],
 	[ 'value' => $e3_cpl_before . ' auf ' . $e3_cpl_after, 'label' => 'Kosten pro Anfrage', 'detail' => 'vorher/nachher' ],
 	[ 'value' => $e3_timeframe, 'label' => 'Validierungszeitraum', 'detail' => 'Implementierung und Optimierung' ],
@@ -108,15 +108,15 @@ get_header();
 						<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
 					</a>
 					<a href="<?php echo esc_url( $e3_case_url ); ?>" class="hu-btn hu-btn-ghost"
-						data-track-action="cta_wow_hero_e3" data-track-category="proof" data-track-section="wow_hero">
-						E3-Case prüfen
+						data-track-action="cta_wow_hero_case_study" data-track-category="proof" data-track-section="wow_hero">
+						Case Study prüfen
 					</a>
 				</div>
 
 				<p class="hu-wow-hero__note">Erst Diagnose, dann Entscheidung. Kein Relaunch auf Verdacht.</p>
 			</div>
 
-			<div class="hu-wow-kpi-strip" aria-label="E3 Proof Kennzahlen" data-wow-reveal>
+			<div class="hu-wow-kpi-strip" aria-label="Case Study Proof Kennzahlen" data-wow-reveal>
 				<?php foreach ( $proof_metrics as $metric ) : ?>
 					<div class="hu-wow-kpi">
 						<strong><?php echo esc_html( $metric['value'] ); ?></strong>
@@ -192,14 +192,14 @@ get_header();
 			<div class="hu-wow-proof">
 				<div class="hu-wow-proof__copy" data-wow-reveal>
 					<span class="hu-eyebrow">03 / Beweis-Schicht</span>
-					<h2>E3 zeigt den Mechanismus: eigene Strecke statt Lead-Einkauf.</h2>
+					<h2>Diese Case Study zeigt den Mechanismus: eigene Strecke statt Lead-Einkauf.</h2>
 					<p>
 						Der Case ist kein Versprechen für jeden Markt. Er zeigt, welche Mechanik funktioniert,
 						wenn Projektwert, Vertrieb und Region zur eigenen Nachfrage-Infrastruktur passen.
 					</p>
 					<a href="<?php echo esc_url( $e3_case_url ); ?>" class="hu-btn hu-btn-link"
-						data-track-action="cta_wow_proof_e3" data-track-category="proof" data-track-section="wow_proof">
-						E3-Methodik mit Zahlen lesen
+						data-track-action="cta_wow_proof_case_study" data-track-category="proof" data-track-section="wow_proof">
+						Methodik mit Zahlen lesen
 					</a>
 				</div>
 
@@ -219,7 +219,7 @@ get_header();
 					<div class="hu-wow-proof__result">
 						<span class="hu-mono">VALIDIERUNG</span>
 						<strong><?php echo esc_html( $e3_lead_count ); ?> Anfragen · <?php echo esc_html( $e3_sales_conv ); ?> Abschluss</strong>
-						<small><?php echo esc_html( $e3_timeframe ); ?> E3 New Energy</small>
+						<small><?php echo esc_html( $e3_timeframe ); ?> Case Study</small>
 					</div>
 				</div>
 			</div>

--- a/blocksy-child/page-waermepumpen-leads.php
+++ b/blocksy-child/page-waermepumpen-leads.php
@@ -21,7 +21,7 @@ $solar_money_url = function_exists( 'nexus_get_energy_systems_url' )
 	? nexus_get_energy_systems_url()
 	: home_url( '/solar-waermepumpen-leadgenerierung/' );
 $marktcheck_url  = trailingslashit( $solar_money_url ) . '#marktcheck';
-$e3_url          = home_url( '/e3-new-energy/' );
+$e3_url          = home_url( '/case-study-solar-leadgenerierung/' );
 
 $linked_assets = [
 	[
@@ -49,7 +49,7 @@ $linked_assets = [
 // ── E3-Proof-Canon ─────────────────────────────────────────────
 $e3_canon            = function_exists( 'hu_e3_canon' ) ? hu_e3_canon() : [];
 $e3_metrics          = isset( $e3_canon['metrics'] ) && is_array( $e3_canon['metrics'] ) ? $e3_canon['metrics'] : [];
-$e3_case_label       = isset( $e3_canon['case_label'] ) ? (string) $e3_canon['case_label'] : 'E3 New Energy';
+$e3_case_label       = isset( $e3_canon['case_label'] ) ? (string) $e3_canon['case_label'] : 'mittelständischer PV-Installationsbetrieb';
 $e3_lead_count       = $e3_metrics['lead_count']['display'] ?? '1.750+';
 $e3_sales_conversion = $e3_metrics['sales_conversion']['display'] ?? '12 %';
 $e3_conv_uplift      = $e3_metrics['sales_conversion_uplift']['display'] ?? '1 – 5 % → 12 %';
@@ -82,7 +82,7 @@ $portal_facts = [
 $own_facts = [
 	[
 		'k' => $e3_cpl_after,
-		'l' => 'Cost per Lead im eigenen Anfrage-System (E3-Referenz)',
+		'l' => 'Cost per Lead im eigenen Anfrage-System (Case-Study-Referenz)',
 	],
 	[
 		'k' => '100 %',
@@ -90,7 +90,7 @@ $own_facts = [
 	],
 	[
 		'k' => $e3_conv_uplift,
-		'l' => 'Sprung der Abschlussquote — von Portal-Leads zu eigenem System (E3)',
+		'l' => 'Sprung der Abschlussquote — von Portal-Leads zu eigenem System (Case Study)',
 	],
 	[
 		'k' => '100 % Asset',
@@ -132,7 +132,7 @@ $market_models = [
 	],
 	[
 		't' => 'Eigene Anfrage-Infrastruktur',
-		's' => 'Money Page, Server-Side-Tracking und Vorqualifizierung im eigenen Eigentum. Anfragen sind per Definition exklusiv. Setup einmalig, Asset im Betrieb. Vergleich: siehe E3-Referenz.',
+		's' => 'Money Page, Server-Side-Tracking und Vorqualifizierung im eigenen Eigentum. Anfragen sind per Definition exklusiv. Setup einmalig, Asset im Betrieb. Vergleich: siehe Case-Study-Referenz.',
 	],
 ];
 
@@ -185,7 +185,7 @@ $objections = [
 	],
 	[
 		'question' => 'Warum schließen gekaufte Wärmepumpen-Leads so selten ab?',
-		'answer'   => 'Weil der Heizungstausch beratungsintensiv ist und der Datensatz mehrfach verkauft wird: Der Endkunde spricht parallel mit drei Betrieben, während Bestandsheizung, Sanierungsstand und Fördersituation ungeklärt sind. Typische Abschlussquoten liegen bei 1 – 5 %. Im eigenen System stieg die Quote bei E3 New Energy auf 12 %, weil die Vorqualifizierung vor dem ersten Anruf passiert.',
+		'answer'   => 'Weil der Heizungstausch beratungsintensiv ist und der Datensatz mehrfach verkauft wird: Der Endkunde spricht parallel mit drei Betrieben, während Bestandsheizung, Sanierungsstand und Fördersituation ungeklärt sind. Typische Abschlussquoten liegen bei 1 – 5 %. Im eigenen System stieg die Quote bei einem mittelständischen PV-Installationsbetrieb auf 12 %, weil die Vorqualifizierung vor dem ersten Anruf passiert.',
 	],
 	[
 		'question' => 'Funktioniert ein eigenes Anfrage-System für Wärmepumpe und Photovoltaik zusammen?',
@@ -268,10 +268,10 @@ get_header();
 				</a>
 				<a class="hu-intercept__cta-secondary"
 				   href="<?php echo esc_url( $e3_url ); ?>"
-				   data-track-action="cta_e3_case"
+				   data-track-action="cta_case_study"
 				   data-track-category="intercept_waermepumpen_leads"
 				   data-track-section="hero">
-					E3-Case lesen (<?php echo esc_html( $e3_lead_count ); ?> Anfragen, <?php echo esc_html( $e3_sales_conversion ); ?> Abschlussquote)
+					Case Study lesen (<?php echo esc_html( $e3_lead_count ); ?> Anfragen, <?php echo esc_html( $e3_sales_conversion ); ?> Abschlussquote)
 				</a>
 			</div>
 			<p class="hu-intercept__hero-related" style="margin-top:18px;font-size:13.5px;opacity:.75;">

--- a/blocksy-child/page-whitelabel-retainer.php
+++ b/blocksy-child/page-whitelabel-retainer.php
@@ -17,7 +17,7 @@ $whitelabel_fit_url = function_exists( 'nexus_get_whitelabel_calendar_url' )
 	: 'https://cal.com/hasim-uener/whitelabel-fit-gesprach?overlayCalendar=true';
 $mailto_url = 'mailto:hallo@hasimuener.de';
 
-$e3_case_url  = function_exists( 'hu_e3_canon' ) ? (string) ( hu_e3_canon()['url'] ?? home_url( '/e3-new-energy/' ) ) : home_url( '/e3-new-energy/' );
+$e3_case_url  = function_exists( 'hu_e3_canon' ) ? (string) ( hu_e3_canon()['url'] ?? home_url( '/case-study-solar-leadgenerierung/' ) ) : home_url( '/case-study-solar-leadgenerierung/' );
 $portrait_url = function_exists( 'hu_get_portrait_image_url' )
 	? hu_get_portrait_image_url()
 	: home_url( '/wp-content/uploads/2026/01/Hasim-Uener-Prtraeit_Startseite.webp' );
@@ -532,7 +532,7 @@ $hero_chips = [ 'GA4', 'GTM', 'Server-Side', 'Consent V2', 'WordPress', 'n8n' ];
 			<div class="wl-section-header nx-reveal">
 				<span class="wl-eyebrow">Beleg · offengelegter Case</span>
 				<h2 class="nx-headline-section">Die meisten Mandate bleiben unter NDA. Eines ist offengelegt.</h2>
-				<p class="wl-section-lede">Genau dafür ist Whitelabel da. Der eine Case, der öffentlich sein darf: E3 New Energy, erneuerbare Energien — Server-Side-Tracking, Consent Mode V2, CRM-Attribution. Meine Arbeit, offengelegt bis in die Zahlen.</p>
+				<p class="wl-section-lede">Genau dafür ist Whitelabel da. Der eine Case, der öffentlich sein darf: ein mittelständischer PV-Installationsbetrieb, erneuerbare Energien — Server-Side-Tracking, Consent Mode V2, CRM-Attribution. Meine Arbeit, offengelegt bis in die Zahlen.</p>
 			</div>
 
 			<div class="wl-proof__grid reveal-stagger" role="list" aria-label="Proof-Kennzahlen">

--- a/blocksy-child/page-wordpress-agentur.php
+++ b/blocksy-child/page-wordpress-agentur.php
@@ -21,7 +21,7 @@ $contact_url    = add_query_arg(
 	],
 	home_url( '/kontakt/' )
 );
-$e3_url         = home_url( '/e3-new-energy/' );
+$e3_url         = home_url( '/case-study-solar-leadgenerierung/' );
 $marktcheck_url = home_url( '/solar-waermepumpen-leadgenerierung/#marktcheck' );
 
 // ═══ Vertiefungs-Links für Fokusmarkt-Solar-Brücke ═══
@@ -203,8 +203,8 @@ get_header();
 								<path d="M7 4L13 10L7 16" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 							</svg>
 						</a>
-						<a href="#proof" class="ag-btn ag-btn--ghost" data-track-action="cta_hero_e3_case" data-track-category="navigation" data-track-section="hero">
-							E3-Case ansehen
+						<a href="#proof" class="ag-btn ag-btn--ghost" data-track-action="cta_hero_case_study" data-track-category="navigation" data-track-section="hero">
+							Case Study ansehen
 						</a>
 					</div>
 
@@ -213,11 +213,11 @@ get_header();
 					</p>
 				</div>
 
-				<aside class="ag-hero-viz" aria-label="Referenzfall E3 New Energy – Kosten pro qualifizierter Anfrage">
+				<aside class="ag-hero-viz" aria-label="Referenzfall mittelständischer PV-Installationsbetrieb – Kosten pro qualifizierter Anfrage">
 					<header class="ag-hero-viz__head">
 						<span class="ag-hero-viz__live">
 							<span class="ag-hero-viz__live-dot" aria-hidden="true"></span>
-							Verifizierter Referenzfall · E3 New Energy
+							Verifizierter Referenzfall · Solar Case Study
 						</span>
 						<h2 class="ag-hero-viz__title">CPL-Senkung in <?php echo esc_html( $e3_timeframe_dat ); ?></h2>
 						<p class="ag-hero-viz__sub">Kosten pro qualifizierter B2B-Anfrage — vor und nach dem eigenen Anfrage-System.</p>
@@ -247,7 +247,7 @@ get_header();
 						</div>
 					</div>
 
-					<dl class="ag-hero-viz__foot" aria-label="Kennzahlen aus dem E3-Case">
+					<dl class="ag-hero-viz__foot" aria-label="Kennzahlen aus der Case Study">
 						<div>
 							<dt><span class="ag-counter" data-counter-target="<?php echo esc_attr( $e3_lead_counter ); ?>" data-counter-suffix="+">0</span></dt>
 							<dd>Qualifizierte Anfragen</dd>
@@ -273,9 +273,9 @@ get_header();
 <section class="nx-section wp-agentur-proof" data-nx-theme="light" id="zahlen">
 	<div class="nx-container">
 		<div class="wp-agentur-proof-header">
-			<p class="wp-agentur-eyebrow">Proof · E3 New Energy</p>
+			<p class="wp-agentur-eyebrow">Proof · Solar Case Study</p>
 			<h2 class="nx-headline-section">Keine leeren Versprechen.</h2>
-			<p>Der E3-Case ist Referenz, keine pauschale Übertragbarkeitsgarantie. Er zeigt, warum Reihenfolge, Datenqualität und eigene Anfragepfade wichtiger sind als ein weiterer Relaunch.</p>
+			<p>Diese Case Study ist Referenz, keine pauschale Übertragbarkeitsgarantie. Sie zeigt, warum Reihenfolge, Datenqualität und eigene Anfragepfade wichtiger sind als ein weiterer Relaunch.</p>
 		</div>
 
 		<div class="wp-agentur-proof-grid">
@@ -299,8 +299,8 @@ get_header();
 
 		<div class="wp-agentur-proof-cta">
 			<p><?php echo esc_html( sprintf( '%s, %s qualifizierte Anfragen, %s niedrigere Kosten pro Anfrage.', $e3_timeframe, $e3_lead_count, $e3_cpl_reduction ) ); ?></p>
-			<a href="<?php echo esc_url( $e3_url ); ?>" class="nx-btn nx-btn--ghost" data-track-action="cta_proof_strip_e3" data-track-category="navigation" data-track-section="proof_strip">
-				E3-Case im Detail ansehen
+			<a href="<?php echo esc_url( $e3_url ); ?>" class="nx-btn nx-btn--ghost" data-track-action="cta_proof_strip_case_study" data-track-category="navigation" data-track-section="proof_strip">
+				Case Study im Detail ansehen
 			</a>
 		</div>
 	</div>
@@ -332,7 +332,7 @@ get_header();
 			</div>
 			<div class="wp-agentur-segment-card">
 				<span class="wp-agentur-segment-card__tag">Womit</span>
-				<h3>Mit einer Anfrage-System-Methode, validiert am E3-Case</h3>
+				<h3>Mit einer Anfrage-System-Methode, validiert an der Case Study</h3>
 				<p><?php echo esc_html( sprintf( 'CPL von %s auf %s gesenkt, %s qualifizierte Anfragen in %s und %s Abschlussquote.', $e3_cpl_before, $e3_cpl_after, $e3_lead_count, $e3_timeframe_dat, $e3_sales_conv ) ); ?></p>
 			</div>
 		</div>
@@ -657,19 +657,19 @@ get_header();
 </section>
 
 <!-- ═══════════════════════════════════════════════
-     SECTION 08 — PROOF E3 DEEP DIVE
+     SECTION 08 — PROOF CASE STUDY DEEP DIVE
      ═══════════════════════════════════════════════ -->
 <section class="nx-section" data-nx-theme="light" id="proof">
 	<div class="nx-container">
 		<div class="nx-section-header">
-			<p class="wp-agentur-eyebrow">Proof · E3 New Energy</p>
+			<p class="wp-agentur-eyebrow">Proof · Solar Case Study</p>
 			<h2 class="nx-headline-section">Was passiert, wenn WordPress, Tracking und Anfrageführung zusammenarbeiten.</h2>
 		</div>
 
 		<div class="wp-agentur-case-grid">
 			<div class="wp-agentur-case-card">
 				<span class="wp-agentur-case-card__eyebrow">Referenz</span>
-				<h3>E3 New Energy</h3>
+				<h3>Mittelständischer PV-Installationsbetrieb</h3>
 				<p>Ein Energie-Anbieter, der von eingekauften Portal-Leads auf ein eigenes Anfrage-System umgestellt hat — WordPress, Server-Side Tracking und Vorqualifizierung als ein zusammenhängendes System statt als Einzelmaßnahmen.</p>
 			</div>
 			<div class="wp-agentur-case-card wp-agentur-case-card--result">
@@ -886,8 +886,8 @@ get_header();
 						<path d="M7 4L13 10L7 16" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 					</svg>
 				</a>
-				<a href="<?php echo esc_url( $e3_url ); ?>" class="ag-close__textlink" data-track-action="cta_final_e3_case" data-track-category="navigation" data-track-section="cta">
-					E3-Case im Detail ansehen →
+				<a href="<?php echo esc_url( $e3_url ); ?>" class="ag-close__textlink" data-track-action="cta_final_case_study" data-track-category="navigation" data-track-section="cta">
+					Case Study im Detail ansehen →
 				</a>
 			</div>
 

--- a/blocksy-child/template-about-editorial.php
+++ b/blocksy-child/template-about-editorial.php
@@ -5,7 +5,7 @@
  *              Outcome-Hero mit ruhigem Textlink (kein Button), Biografie als
  *              Kompetenz-Beleg, Manifest, Fit-Standards, interner Experten-Cluster
  *              (E-E-A-T). Proof/CTA-Last bewusst bei den Money-Pages, hier nur EIN
- *              primärer CTA am Seitenende. E3 erscheint einmal im Text + Link zum Case.
+ *              primärer CTA am Seitenende. Die Case Study erscheint einmal im Text + Link zum Case.
  *
  * Parallel zu template-about.php. Auswahl pro Page im WP-Admin.
  *
@@ -20,7 +20,7 @@ $request_url   = function_exists( 'nexus_get_primary_request_url' ) ? nexus_get_
 $request_cta   = function_exists( 'nexus_get_primary_request_cta_label' ) ? nexus_get_primary_request_cta_label() : 'Marktcheck mit Fit-Entscheid starten';
 $portrait_url  = function_exists( 'hu_get_profile_image_url' ) ? hu_get_profile_image_url() : get_stylesheet_directory_uri() . '/assets/img/hasim-portrait.png';
 $portrait_path = get_stylesheet_directory() . '/assets/img/hasim-portrait.png';
-$e3_case_url   = home_url( '/e3-new-energy/' );
+$e3_case_url   = home_url( '/case-study-solar-leadgenerierung/' );
 
 // ── E3-Canon: nur die eine, korrekte Erwähnung im Bio-Text (kein Zahlen-Band) ──
 $e3_canon     = function_exists( 'hu_e3_canon' ) ? hu_e3_canon() : [];
@@ -42,7 +42,7 @@ $about_hero_path = [
 	],
 	[
 		't' => 'Der eigene Beweis',
-		's' => 'Eigenen Shop von Null aufgebaut und am eigenen Geld gespürt, was Plattform-Abhängigkeit kostet. Dieselbe Logik auf Energie skaliert – und bei E3 New Energy belegt.',
+		's' => 'Eigenen Shop von Null aufgebaut und am eigenen Geld gespürt, was Plattform-Abhängigkeit kostet. Dieselbe Logik auf Energie skaliert – und bei einem mittelständischen PV-Installationsbetrieb belegt.',
 	],
 ];
 
@@ -218,7 +218,7 @@ get_header();
 					<p>Vertrieb habe ich danach nicht in Seminaren gelernt, sondern in acht Jahren B2B-Beratung: Bedarf strukturiert aufnehmen, mit Entscheidern verbindlich kommunizieren, langfristige Beziehungen über zuverlässige Follow-ups halten.</p>
 					<p>Dann habe ich selbst gegründet — einen eigenen Online-Shop, von der ersten Zeile Code bis zur letzten Conversion. Dort habe ich am eigenen Geld erlebt, was es bedeutet, seine Nachfrage selbst zu erzeugen, statt sie von Plattformen zu mieten. Genau diese Erfahrung ist der Kern dessen, was ich heute baue.</p>
 					<p>Mein Studium der Medienwissenschaft an der Universität Paderborn war dabei der analytische Werkzeugkasten: Ich schaue nicht darauf, was auf einer Website schön aussieht, sondern wie Daten fließen, wo Aufmerksamkeit versickert und welche Signale zwischen Oberfläche und B2B-Entscheider übertragen werden müssen, damit Vertrauen entsteht.</p>
-					<p>Die meisten WordPress-Websites scheitern, weil sie von Designern gebaut wurden, die nie ein echtes Verkaufsgespräch geführt haben. Sie informieren den Nutzer zu Tode, statt Entscheidungen zu provozieren. Ich verbinde acht Jahre Vertriebs-Pragmatismus mit analytischer Präzision — und seit dem Case bei <a class="about-editorial__inline-link" href="<?php echo esc_url( $e3_case_url ); ?>" data-track-action="link_about_editorial_e3" data-track-category="navigation" data-track-section="about_editorial_bio">E3 New Energy</a> (<?php echo esc_html( $e3_bio_line ); ?>) wende ich diese Methode exklusiv auf den Solar- und Wärmepumpen-Mittelstand an.</p>
+					<p>Die meisten WordPress-Websites scheitern, weil sie von Designern gebaut wurden, die nie ein echtes Verkaufsgespräch geführt haben. Sie informieren den Nutzer zu Tode, statt Entscheidungen zu provozieren. Ich verbinde acht Jahre Vertriebs-Pragmatismus mit analytischer Präzision — und seit dem Case bei einem <a class="about-editorial__inline-link" href="<?php echo esc_url( $e3_case_url ); ?>" data-track-action="link_about_editorial_case_study" data-track-category="navigation" data-track-section="about_editorial_bio">mittelständischen PV-Installationsbetrieb</a> (<?php echo esc_html( $e3_bio_line ); ?>) wende ich diese Methode exklusiv auf den Solar- und Wärmepumpen-Mittelstand an.</p>
 				</div>
 			</section>
 
@@ -247,7 +247,7 @@ get_header();
 			<section class="about-editorial__expertise" aria-labelledby="about-editorial-expertise-title">
 				<div class="about-editorial__expertise-head">
 					<h2 id="about-editorial-expertise-title" class="about-editorial__section-kicker">Fachliche Schwerpunkte</h2>
-					<p class="about-editorial__fit-intro">Sechs Felder entlang der drei System-Ebenen — jedes als eigene Seite mit Methode, Beispielen und Bezug zum E3-Case.</p>
+					<p class="about-editorial__fit-intro">Sechs Felder entlang der drei System-Ebenen — jedes als eigene Seite mit Methode, Beispielen und Bezug zur Case Study.</p>
 				</div>
 				<div class="about-editorial__expertise-cluster">
 					<?php foreach ( $about_expertise_structured as $expertise_category => $expertise_items ) : ?>

--- a/blocksy-child/template-about.php
+++ b/blocksy-child/template-about.php
@@ -77,7 +77,7 @@ $about_evidence = [
 	],
 	[
 		'k' => $e3_cpl_reduction,
-		'l' => sprintf( 'CPL-Senkung in %s bei E3 New Energy.', $e3_timeframe ),
+		'l' => sprintf( 'CPL-Senkung in %s bei einem mittelständischen PV-Installationsbetrieb.', $e3_timeframe ),
 	],
 	[
 		'k' => '100 %',
@@ -299,9 +299,9 @@ get_header();
 					<div class="about-evidence-band__intro">
 						<p class="about-evidence-band__eyebrow">Beleg, nicht Aufhänger</p>
 						<h3 class="about-evidence-band__title">Die Zahlen kommen nach der Diagnose.</h3>
-						<p>Beim E3-Case sieht man, warum diese Reihenfolge wichtig ist. Die Kennzahlen sind kein Versprechen für jeden Betrieb, sondern ein Beleg dafür, was möglich wird, wenn Nachfrage, Qualifizierung und Vertriebsanschluss zusammenpassen.</p>
+						<p>Bei dieser Case Study sieht man, warum diese Reihenfolge wichtig ist. Die Kennzahlen sind kein Versprechen für jeden Betrieb, sondern ein Beleg dafür, was möglich wird, wenn Nachfrage, Qualifizierung und Vertriebsanschluss zusammenpassen.</p>
 					</div>
-					<ul class="about-evidence-band__list" role="list" aria-label="Ausgewählte E3-Belege">
+					<ul class="about-evidence-band__list" role="list" aria-label="Ausgewählte Case-Study-Belege">
 						<?php foreach ( $about_evidence as $proof_item ) : ?>
 							<li class="about-evidence-band__item">
 								<span class="about-evidence-band__k"><?php echo esc_html( $proof_item['k'] ); ?></span>
@@ -440,13 +440,13 @@ get_header();
 
 				<div class="about-cohort-card" data-reveal>
 					<p class="about-cohort-card__eyebrow">FOUNDING COHORT 2026</p>
-					<h3 class="about-cohort-card__title">E3 New Energy war der erste Case, nicht die Grenze.</h3>
+					<h3 class="about-cohort-card__title">Der mittelständische PV-Installationsbetrieb war der erste Case, nicht die Grenze.</h3>
 					<p class="about-cohort-card__status">
 						<span class="about-cohort-card__dot" aria-hidden="true"></span>
 						3 von 3 Plätzen offen
 					</p>
 					<p class="about-cohort-card__text">
-						Ein einzelner dokumentierter Case ist eine bewusste Entscheidung gegen die anonyme Logo-Wand — dafür liegt dieser eine vollständig offen, von der Lead-Quelle bis zur Abschlussquote. Was bei E3 funktioniert hat, war Methode, kein Zufall: dieselbe Vier-Eigenschaften-Logik lässt sich auf jeden Solar- oder Wärmepumpen-Betrieb mit eigenem Vertrieb übertragen. Genau diese Arbeitsweise öffnet die Cohort für maximal drei passende Betriebe. Der Einstieg bleibt der Marktcheck, damit vor einer Umsetzung klar ist, ob Markt, Budget und Tracking-Realität zusammenpassen.
+						Ein einzelner dokumentierter Case ist eine bewusste Entscheidung gegen die anonyme Logo-Wand — dafür liegt dieser eine vollständig offen, von der Lead-Quelle bis zur Abschlussquote. Was bei diesem Betrieb funktioniert hat, war Methode, kein Zufall: dieselbe Vier-Eigenschaften-Logik lässt sich auf jeden Solar- oder Wärmepumpen-Betrieb mit eigenem Vertrieb übertragen. Genau diese Arbeitsweise öffnet die Cohort für maximal drei passende Betriebe. Der Einstieg bleibt der Marktcheck, damit vor einer Umsetzung klar ist, ob Markt, Budget und Tracking-Realität zusammenpassen.
 					</p>
 					<a href="<?php echo esc_url( $request_url ); ?>"
 					   class="about-cta-primary"
@@ -471,7 +471,7 @@ get_header();
 					<p class="about-section__number">05 / Fachliche Schwerpunkte</p>
 					<div class="about-section__head-body">
 						<h2 class="about-h2" id="about-expertise-title">Sechs Felder. Drei System-Ebenen.</h2>
-						<p class="about-section__lead">Jedes Feld ist als eigene Seite mit Methode, Beispielen und Bezug zum E3-Case aufgeschrieben — gruppiert entlang der Architektur, in der sie wirken.</p>
+						<p class="about-section__lead">Jedes Feld ist als eigene Seite mit Methode, Beispielen und Bezug zur Case Study aufgeschrieben — gruppiert entlang der Architektur, in der sie wirken.</p>
 					</div>
 				</header>
 

--- a/blocksy-child/template-parts/audit-page-shell.php
+++ b/blocksy-child/template-parts/audit-page-shell.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 $request_url     = function_exists( 'nexus_get_primary_request_url' ) ? nexus_get_primary_request_url() : home_url( '/solar-waermepumpen-leadgenerierung/#marktcheck' );
 $privacy_url     = nexus_get_page_url( [ 'datenschutz' ], home_url( '/datenschutz/' ) );
 $audit_cta_label = 'Marktcheck mit Fit-Entscheid starten';
-$e3_summary      = function_exists( 'hu_e3_summary' ) ? hu_e3_summary( 'proof' ) : 'E3 New Energy: eigene Anfragen, Abschlussquote und niedrigere Kosten pro Anfrage.';
+$e3_summary      = function_exists( 'hu_e3_summary' ) ? hu_e3_summary( 'proof' ) : 'Mittelständischer PV-Installationsbetrieb: eigene Anfragen, Abschlussquote und niedrigere Kosten pro Anfrage.';
 ?>
 
 <div class="audit-wrapper" id="audit-main-wrapper">

--- a/blocksy-child/template-parts/site-footer.php
+++ b/blocksy-child/template-parts/site-footer.php
@@ -17,7 +17,7 @@ $primary_urls = function_exists( 'nexus_get_primary_public_url_map' ) ? nexus_ge
 $home_url     = $primary_urls['home'] ?? home_url( '/' );
 $analysis_url = function_exists( 'hu_get_request_analysis_url' ) ? hu_get_request_analysis_url() : home_url( '/solar-waermepumpen-leadgenerierung/#marktcheck' );
 $request_url  = $analysis_url;
-$e3_url       = $primary_urls['e3'] ?? home_url( '/e3-new-energy/' );
+$e3_url       = $primary_urls['e3'] ?? home_url( '/case-study-solar-leadgenerierung/' );
 $results_url  = $primary_urls['results'] ?? home_url( '/ergebnisse/' );
 $blog_url     = $primary_urls['blog'] ?? home_url( '/blog/' );
 $agentur_url  = $primary_urls['agentur'] ?? home_url( '/wordpress-agentur-hannover/' );
@@ -115,7 +115,7 @@ if ( $is_whitelabel_context ) {
 				<h3 id="ft-ergebnisse">Ergebnisse</h3>
 				<ul class="ft__list">
 					<li><a class="ft__link-strong" href="<?php echo esc_url( $results_url ); ?>" data-track-action="cta_footer_nav_results" data-track-category="trust" data-track-section="footer">Referenzen ansehen</a></li>
-					<li><a href="<?php echo esc_url( $e3_url ); ?>" data-track-action="cta_footer_nav_e3_proof" data-track-category="trust" data-track-section="footer">Fallstudie: E3 New Energy</a></li>
+					<li><a href="<?php echo esc_url( $e3_url ); ?>" data-track-action="cta_footer_nav_case_study_proof" data-track-category="trust" data-track-section="footer">Fallstudie: Solar Leadgenerierung</a></li>
 				</ul>
 			</section>
 

--- a/content/blog-drafts/aroundhome-solar-einordnung.md
+++ b/content/blog-drafts/aroundhome-solar-einordnung.md
@@ -97,7 +97,7 @@ Die Alternative zu gemieteten Portal-Leads ist kein weiteres Tool, sondern eine 
 
 So entsteht ein Betriebs-Asset. Die Anfrage kommt nicht aus einem fremden Portal, sondern aus einer Plattform, die dem Betrieb gehört.
 
-Der [Methodik-Case E3 New Energy](https://hasimuener.de/e3-new-energy/) zeigt diesen Hebel konkret: Der Cost per Lead sank von 150 € auf 22 € bei über 1.750 qualifizierten Anfragen, 12 % Abschlussquote und 6 Monaten Projektlaufzeit. Das ist kein allgemeines Versprechen, aber ein belastbarer Beleg dafür, was möglich wird, wenn Website, Tracking, Vorqualifizierung und Vertrieb zusammengebaut werden.
+Der [Solar Case Study](https://hasimuener.de/case-study-solar-leadgenerierung/) zeigt diesen Hebel konkret: Der Cost per Lead sank von 150 € auf 22 € bei über 1.750 qualifizierten Anfragen, 12 % Abschlussquote und 6 Monaten Projektlaufzeit. Das ist kein allgemeines Versprechen, aber ein belastbarer Beleg dafür, was möglich wird, wenn Website, Tracking, Vorqualifizierung und Vertrieb zusammengebaut werden.
 
 ## Wann das Vergleichsportal-Modell trotzdem Sinn ergibt
 

--- a/content/blog-drafts/daa-photovoltaik-leads-einordnung.md
+++ b/content/blog-drafts/daa-photovoltaik-leads-einordnung.md
@@ -73,7 +73,7 @@ Ein spezialisierter Anbieter kann ein guter Kanal sein. Strategisch bleibt aber 
 
 ## Die strategische Alternative: Ownership statt Lead-Miete
 
-Ein eigenes Anfrage-System mit Money Page, Server-Side-Tracking, Vorqualifizierung und CRM-Übergabe erzeugt Anfragen, die per Definition **exklusiv** sind. Der [Methodik-Case E3 New Energy](https://hasimuener.de/e3-new-energy/) zeigt eine CPL-Senkung von 150 € auf 22 € bei 12 % Abschlussquote, über 1.750 qualifizierten Anfragen und 6 Monaten Projektlaufzeit.
+Ein eigenes Anfrage-System mit Money Page, Server-Side-Tracking, Vorqualifizierung und CRM-Übergabe erzeugt Anfragen, die per Definition **exklusiv** sind. Der [Solar Case Study](https://hasimuener.de/case-study-solar-leadgenerierung/) zeigt eine CPL-Senkung von 150 € auf 22 € bei 12 % Abschlussquote, über 1.750 qualifizierten Anfragen und 6 Monaten Projektlaufzeit.
 
 Das ist kein allgemeines Versprechen, sondern ein Beleg für den Unterschied zwischen gemieteter Nachfrage und eigener Anfrage-Infrastruktur: Die Marke, die Daten und die Optimierung bleiben beim Betrieb.
 

--- a/content/blog-drafts/leadfluss-pv-leads-einordnung.md
+++ b/content/blog-drafts/leadfluss-pv-leads-einordnung.md
@@ -68,7 +68,7 @@ Regionale Videokampagnen sind im Volumen durch Region, Angebot und Zielgruppe be
 
 Der nächstgrößere Schritt vom regionalen Videomarketing-Modell ist der Aufbau eines vollständig eigenen Anfrage-Systems: eigene Money Page, eigener Werbe-Account, eigene Tracking-Strecke, eigenes CRM und eigene Vorqualifizierung. Vorteil: Code, Daten und Strecke bleiben dauerhaft im Betrieb.
 
-Der [Methodik-Case E3 New Energy](https://hasimuener.de/e3-new-energy/) demonstriert das mit einer CPL-Senkung von 150 € auf 22 €, über 1.750 qualifizierten Anfragen, 12 % Abschlussquote und 6 Monaten Projektlaufzeit. Das ist kein pauschales Ergebnisversprechen, aber ein belastbarer Beleg für den Wert eigener Anfrage-Infrastruktur.
+Der [Solar Case Study](https://hasimuener.de/case-study-solar-leadgenerierung/) demonstriert das mit einer CPL-Senkung von 150 € auf 22 €, über 1.750 qualifizierten Anfragen, 12 % Abschlussquote und 6 Monaten Projektlaufzeit. Das ist kein pauschales Ergebnisversprechen, aber ein belastbarer Beleg für den Wert eigener Anfrage-Infrastruktur.
 
 ## Wann das Videomarketing-Modell trotzdem Sinn ergibt
 

--- a/content/blog-drafts/photovoltaik-leads-tco-rechnung.md
+++ b/content/blog-drafts/photovoltaik-leads-tco-rechnung.md
@@ -380,9 +380,9 @@ Das Ergebnis darf nicht weichgespült werden. Wenn die eigene Strecke bei einem 
 
 Ein Anfrage-System ist keine Glaubensfrage. Es ist eine Rechenfrage.
 
-## 9. Case Study E3: 71 Prozent CPO-Reduktion, konservativ gerechnet
+## 9. Case Study: 71 Prozent CPO-Reduktion, konservativ gerechnet
 
-Der E3-Case wird oft zu aggressiv erzählt. Das ist unnötig.
+Dieser Case wird oft zu aggressiv erzählt. Das ist unnötig.
 
 Die kanonischen Fakten reichen:
 
@@ -419,7 +419,7 @@ Das ist die Zahl, die in den Artikel gehört: 71 Prozent CPO-Reduktion.
 
 Nicht, weil die schön klingt. Sondern weil sie belastbarer ist als die maximale Werberechnung aus CPL-Senkung und Abschlussquotensprung. Wer hohe Ticketpreise verkauft, braucht keine überzogene Proof-Zahl. Er braucht eine Zahl, die ein Geschäftsführer im Kopf nicht sofort zerlegt.
 
-Die eigentliche E3-Lektion ist ohnehin nicht die Prozentzahl.
+Die eigentliche Lektion aus dieser Case Study ist ohnehin nicht die Prozentzahl.
 
 Die Lektion ist: Der Vertrieb war nicht das Hauptproblem. Die Anfragequelle war das Problem. Dieselben Verkäufer konnten bessere Ergebnisse erzielen, sobald Anfragekontext, Exklusivität, Geschwindigkeit, Tracking und Vorqualifizierung sauberer wurden.
 
@@ -437,7 +437,7 @@ Beim eigenen Anfrage-System verschiebt sich diese Ausgangslage:
 
 Das ist kein einzelner Trick. Es ist Systemarbeit.
 
-Der [E3 New Energy Methodik-Case](/e3-new-energy/) ist deshalb nicht als Ergebnisversprechen zu lesen. Er ist ein Beleg für die Mechanik: Wenn Anfragequelle, Tracking, Vorqualifizierung und Vertrieb zusammenarbeiten, verändert sich die Wirtschaftlichkeit.
+Der [Solar Case Study Methodik-Case](/case-study-solar-leadgenerierung/) ist deshalb nicht als Ergebnisversprechen zu lesen. Er ist ein Beleg für die Mechanik: Wenn Anfragequelle, Tracking, Vorqualifizierung und Vertrieb zusammenarbeiten, verändert sich die Wirtschaftlichkeit.
 
 ## 10. Replikation heißt nicht Kopieren. Es heißt: keine Lernkurve zweimal bezahlen.
 

--- a/content/blog-drafts/wattfox-solar-leads-einordnung.md
+++ b/content/blog-drafts/wattfox-solar-leads-einordnung.md
@@ -65,7 +65,7 @@ Wenn Reichweite, Formular, Datenbasis und Optimierung beim Anbieter liegen, blei
 
 ## Alternative: Eigene Anfrage-Infrastruktur
 
-Eigene Anfrage-Systeme führen per Definition zu exklusiven Anfragen, weil die Strecke dem Betrieb gehört: Money Page, Server-Side-Tracking, Vorqualifizierung, CRM-Übergabe und Datenbasis. Der [Methodik-Case E3 New Energy](https://hasimuener.de/e3-new-energy/) zeigt, dass die Cost per Lead durch ein eigenes System von 150 € auf 22 € gesenkt werden können – bei 12 % Abschlussquote, über 1.750 qualifizierten Anfragen und 6 Monaten Projektlaufzeit.
+Eigene Anfrage-Systeme führen per Definition zu exklusiven Anfragen, weil die Strecke dem Betrieb gehört: Money Page, Server-Side-Tracking, Vorqualifizierung, CRM-Übergabe und Datenbasis. Der [Solar Case Study](https://hasimuener.de/case-study-solar-leadgenerierung/) zeigt, dass die Cost per Lead durch ein eigenes System von 150 € auf 22 € gesenkt werden können – bei 12 % Abschlussquote, über 1.750 qualifizierten Anfragen und 6 Monaten Projektlaufzeit.
 
 Das ist kein allgemeines Versprechen. Es zeigt aber den Unterschied zwischen Lead-Miete und Ownership: Bei einer eigenen Infrastruktur verbessert jeder Lernzyklus das eigene Betriebs-Asset.
 

--- a/content/blog-drafts/wordpress-ttfb-google-ads-ladezeit.md
+++ b/content/blog-drafts/wordpress-ttfb-google-ads-ladezeit.md
@@ -100,7 +100,7 @@ Der Aufwand: höher. Die Skalierbarkeit: deutlich besser. Die TTFB-Werte: identi
 
 ## 5. Was TTFB im CPL und CPO konkret bewegt
 
-Im [E3-Case](/e3-new-energy/) hat eine vollständige Anfrage-System-Migration den Cost per Lead von 150 Euro auf 22 Euro gesenkt. Page Speed war einer von mehreren Faktoren — neben Vorqualifizierung, Server-Side Tracking und CRM-Übergabe.
+In der [Solar Case Study](/case-study-solar-leadgenerierung/) hat eine vollständige Anfrage-System-Migration den Cost per Lead von 150 Euro auf 22 Euro gesenkt. Page Speed war einer von mehreren Faktoren — neben Vorqualifizierung, Server-Side Tracking und CRM-Übergabe.
 
 Aber Page Speed wirkt an drei Stellen gleichzeitig:
 

--- a/llms.txt
+++ b/llms.txt
@@ -9,8 +9,8 @@
 - [Kontakt](/kontakt/) - Anfragepfad für Analyse, Umsetzung und Weiterentwicklung nach Marktcheck-Fit.
 
 ## Proof und zitierfähige Quellen
-- [E3 New Energy](/e3-new-energy/) - kaufnaher Proof-Case für Nachfrageaufbau, Vorqualifizierung, Tracking und Conversion.
-- [Was kosten Solar-Leads? Marktstudie](/solar-leads-kosten-studie/) - zitierfähige Marktstudie zu Lead-Kosten im DACH-Raum: Preisspannen, Cost-per-Order, Methodik und E3-Benchmark.
+- [Solar Case Study](/case-study-solar-leadgenerierung/) - kaufnaher Proof-Case für Nachfrageaufbau, Vorqualifizierung, Tracking und Conversion.
+- [Was kosten Solar-Leads? Marktstudie](/solar-leads-kosten-studie/) - zitierfähige Marktstudie zu Lead-Kosten im DACH-Raum: Preisspannen, Cost-per-Order, Methodik und Case-Study-Benchmark.
 - [Ergebnisse](/ergebnisse/) - kuratierter Proof-Hub mit Cases, Kennzahlen und Kontext.
 - [Über Haşim Üner](/uber-mich/) - Personenprofil des Autors und Betreibers.
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -106,11 +106,6 @@ parameters:
 			path: blocksy-child/inc/seo-cockpit/seo-cockpit-ui.php
 
 		-
-			message: "#^Call to sprintf contains 0 placeholders, 1 value given\\.$#"
-			count: 1
-			path: blocksy-child/page-b2b-solar-leads.php
-
-		-
 			message: "#^Offset 'description' on array\\{label\\: 'Marktcheck', description\\: 'Klarheit vor…'\\}\\|array\\{label\\: 'Projektprüfung', description\\: 'B2B\\-Projekt sauber…'\\}\\|array\\{label\\: 'Umsetzung', description\\: 'Konkreter Bau oder…'\\}\\|array\\{label\\: 'Website\\-Analyse', description\\: 'Klarheit vor…'\\}\\|array\\{label\\: 'Weiterentwicklung', description\\: 'Planbare…'\\} in isset\\(\\) always exists and is not nullable\\.$#"
 			count: 1
 			path: blocksy-child/page-kontakt.php


### PR DESCRIPTION
Case-study page moved to /case-study-solar-leadgenerierung/ with a 301 from the old company-named slug, set to noindex,follow pending review, and dropped from the results/proof menu detection. All sitewide references (money pages, homepage, about pages, footer, blog posts, JSON-LD schema, meta titles/descriptions, llms.txt, tracking action names) now use the anonymized case label sourced from the central proof canon. Metrics unchanged.


Claude-Session: https://claude.ai/code/session_01HPbWhukFn55HuKGV4pGyTY