### PR TITLE
Anonymize whitelabel-retainer proof section: remove ROAS, fix mandate…

### DIFF
--- a/blocksy-child/assets/css/whitelabel.css
+++ b/blocksy-child/assets/css/whitelabel.css
@@ -650,7 +650,7 @@
 
 .wl-proof__grid {
 	display: grid;
-	grid-template-columns: repeat(4, 1fr);
+	grid-template-columns: repeat(3, 1fr);
 	gap: 0;
 	border: 1px solid hsl(30 10% 100% / 0.08);
 	border-radius: 14px;
@@ -658,8 +658,7 @@
 	background: linear-gradient(180deg, hsl(30 5% 9% / 0.6), hsl(28 8% 6% / 0.7));
 }
 
-@media (max-width: 960px) { .wl-proof__grid { grid-template-columns: repeat(2, 1fr); } }
-@media (max-width: 540px) { .wl-proof__grid { grid-template-columns: 1fr; } }
+@media (max-width: 720px) { .wl-proof__grid { grid-template-columns: 1fr; } }
 
 .wl-proof__item {
 	padding: clamp(1.5rem, 2.4vw, 2rem) clamp(1rem, 2vw, 1.5rem);
@@ -669,13 +668,7 @@
 
 .wl-proof__item:last-child { border-right: 0; }
 
-@media (max-width: 960px) {
-	.wl-proof__item:nth-child(2n) { border-right: 0; }
-	.wl-proof__item:nth-child(1),
-	.wl-proof__item:nth-child(2) { border-bottom: 1px solid hsl(30 10% 100% / 0.06); }
-}
-
-@media (max-width: 540px) {
+@media (max-width: 720px) {
 	.wl-proof__item { border-right: 0; border-bottom: 1px solid hsl(30 10% 100% / 0.06); }
 	.wl-proof__item:last-child { border-bottom: 0; }
 }
@@ -1682,7 +1675,6 @@ thead .wl-compare__col--hl {
 }
 
 .wl-counter--proof-leads { min-width: 6.2ch; }
-.wl-counter--proof-roas  { min-width: 3.4ch; }
 .wl-counter--proof-conv  { min-width: 4.4ch; }
 
 /* Sparkline zeichnet sich beim Laden ein (Hero ist above the fold). */

--- a/blocksy-child/inc/canon/e3-proof-canon.php
+++ b/blocksy-child/inc/canon/e3-proof-canon.php
@@ -18,7 +18,6 @@ define( 'HU_E3_SALES_CONVERSION_PERCENT', 12 );
 define( 'HU_E3_SALES_CONVERSION_BEFORE_LOW', 1 );
 define( 'HU_E3_SALES_CONVERSION_BEFORE_HIGH', 2 );
 define( 'HU_E3_TIMEFRAME_MONTHS', 6 );
-define( 'HU_E3_ROAS', 34 );
 
 /**
  * Return the canonical E3 proof data.
@@ -75,12 +74,6 @@ function hu_e3_canon() {
 				'display' => '1 – 5 % → 12 %',
 				'short'   => '6× bis 12× höhere Abschlussquote',
 				'label'   => 'Anstieg der Abschlussquote durch eigenes System',
-			],
-			'roas'             => [
-				'value'          => HU_E3_ROAS,
-				'display'        => '34×',
-				'counter_target' => '34',
-				'label'          => 'Return on Ad Spend',
 			],
 			'timeframe'        => [
 				'value'          => HU_E3_TIMEFRAME_MONTHS,

--- a/blocksy-child/page-whitelabel-retainer.php
+++ b/blocksy-child/page-whitelabel-retainer.php
@@ -28,12 +28,10 @@ $cpl_reduction  = function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'cpl_reducti
 $lead_count     = function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'lead_count', 'display', '1.750+' )     : '1.750+';
 $sales_conv     = function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'sales_conversion', 'display', '12 %' ) : '12 %';
 $timeframe      = function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'timeframe', 'display_dative', '6 Monaten' ) : '6 Monaten';
-$roas           = function_exists( 'hu_e3_metric' ) ? hu_e3_metric( 'roas', 'display', '34×' )              : '34×';
 
 $cpl_after_int     = function_exists( 'hu_e3_metric' ) ? (int) hu_e3_metric( 'cpl_after',  'counter_target', 22 )  : 22;
 $cpl_reduction_int = function_exists( 'hu_e3_metric' ) ? (int) hu_e3_metric( 'cpl_reduction', 'counter_target', 85 ) : 85;
 $lead_count_int    = function_exists( 'hu_e3_metric' ) ? (int) hu_e3_metric( 'lead_count', 'counter_target', '1750' ) : 1750;
-$roas_int          = function_exists( 'hu_e3_metric' ) ? (int) hu_e3_metric( 'roas', 'counter_target', '34' )         : 34;
 $sales_conv_int    = function_exists( 'hu_e3_metric' ) ? (int) hu_e3_metric( 'sales_conversion', 'counter_target', '12' ) : 12;
 
 $problem_cards = [
@@ -305,7 +303,7 @@ $hero_chips = [ 'GA4', 'GTM', 'Server-Side', 'Consent V2', 'WordPress', 'n8n' ];
 					<header class="wl-dash__head">
 						<span class="wl-dash__head-left">
 							<span class="wl-dash__dot" aria-hidden="true"></span>
-							Live · Whitelabel-Mandat
+							Referenzprojekt · offengelegt
 						</span>
 						<span class="wl-dash__head-right">CPL-Verlauf</span>
 					</header>
@@ -531,8 +529,8 @@ $hero_chips = [ 'GA4', 'GTM', 'Server-Side', 'Consent V2', 'WordPress', 'n8n' ];
 		<div class="nx-container">
 			<div class="wl-section-header nx-reveal">
 				<span class="wl-eyebrow">Beleg · offengelegter Case</span>
-				<h2 class="nx-headline-section">Die meisten Mandate bleiben unter NDA. Eines ist offengelegt.</h2>
-				<p class="wl-section-lede">Genau dafür ist Whitelabel da. Der eine Case, der öffentlich sein darf: ein mittelständischer PV-Installationsbetrieb, erneuerbare Energien — Server-Side-Tracking, Consent Mode V2, CRM-Attribution. Meine Arbeit, offengelegt bis in die Zahlen.</p>
+				<h2 class="nx-headline-section">Ein Referenzprojekt, offengelegt bis in die Zahlen.</h2>
+				<p class="wl-section-lede">Der eine Case, der öffentlich sein darf: ein mittelständischer PV-Installationsbetrieb (erneuerbare Energien) — Server-Side-Tracking, Consent Mode V2, CRM-Attribution. Meine Arbeit, offengelegt bis in die Zahlen.</p>
 			</div>
 
 			<div class="wl-proof__grid reveal-stagger" role="list" aria-label="Proof-Kennzahlen">
@@ -543,10 +541,6 @@ $hero_chips = [ 'GA4', 'GTM', 'Server-Side', 'Consent V2', 'WordPress', 'n8n' ];
 				<div class="wl-proof__item" role="listitem">
 					<div class="wl-proof__value"><span class="wl-counter wl-counter--proof-leads" data-counter-target="<?php echo esc_attr( (string) $lead_count_int ); ?>" data-counter-suffix="+"><?php echo esc_html( $lead_count ); ?></span></div>
 					<div class="wl-proof__label">Qualifizierte Anfragen</div>
-				</div>
-				<div class="wl-proof__item" role="listitem">
-					<div class="wl-proof__value"><span class="wl-counter wl-counter--proof-roas" data-counter-target="<?php echo esc_attr( (string) $roas_int ); ?>" data-counter-suffix="×"><?php echo esc_html( $roas ); ?></span></div>
-					<div class="wl-proof__label">Return on Ad Spend (ROAS)</div>
 				</div>
 				<div class="wl-proof__item" role="listitem">
 					<div class="wl-proof__value"><span class="wl-counter wl-counter--proof-conv" data-counter-target="<?php echo esc_attr( (string) $sales_conv_int ); ?>" data-counter-suffix="&nbsp;%"><?php echo esc_html( $sales_conv ); ?></span></div>


### PR DESCRIPTION
… framing

The disclosed case on /whitelabel-retainer/ was never a white-label mandate. Rewrite the badge/headline/lede to drop the mandate claim, switch the company reference to the canonical parenthetical format, remove the 34x ROAS figure sitewide (tile, counter CSS, canon constant), and collapse the proof grid from 4 to 3 tiles.


Claude-Session: https://claude.ai/code/session_01QVpZJmCMXkZfttTduvKjVp