### PR TITLE
Solar-LP: dezente Motion-Ebene — Hero-Stagger, Anfrage-Ketten-SVG, Sc…

### DIFF
--- a/blocksy-child/assets/css/solar-leadgenerierung-solara.css
+++ b/blocksy-child/assets/css/solar-leadgenerierung-solara.css
@@ -1033,7 +1033,130 @@
   .solara-landing .sol-sticky-cta { display: none; }
 }
 
-/* ─── 12) Reduced Motion ────────────────────────────────────── */
+/* ─── 11b) Anfrage-Ketten-SVG (direkt unter dem Hero) ───────────
+   Vier Stufen Anzeige → Landingpage → Qualifizierung → CRM als
+   Inline-SVG in zwei Layout-Varianten (horizontal/vertikal), per
+   Breakpoint umgeschaltet. Feste aspect-ratio je Variante → kein CLS.
+   Farben laufen über die Kit-Tokens (Ink + Kupfer). */
+.solara-landing .sol-chain { padding: 6px 0 clamp(30px, 5vw, 54px); }
+.solara-landing .sol-chain-fig { margin: 14px 0 0; }
+.solara-landing .sol-chain-svg { display: block; width: 100%; height: auto; }
+.solara-landing .sol-chain-svg--d { aspect-ratio: 760 / 248; }
+.solara-landing .sol-chain-svg--m {
+  display: none;
+  aspect-ratio: 340 / 644;
+  max-width: 400px;
+  margin: 0 auto;
+}
+@media (max-width: 819px) {
+  .solara-landing .sol-chain-svg--d { display: none; }
+  .solara-landing .sol-chain-svg--m { display: block; }
+}
+
+.solara-landing .sol-chain-rect {
+  fill: rgba(242, 235, 221, .03);
+  stroke: rgba(242, 235, 221, .16);
+  stroke-width: 1;
+}
+.solara-landing .sol-chain-node--final .sol-chain-rect {
+  fill: rgba(224, 138, 60, .07);
+  stroke: rgba(224, 138, 60, .55);
+}
+.solara-landing .sol-chain-k {
+  fill: var(--accent);
+  font: 600 9.5px 'JetBrains Mono', 'Fira Code', ui-monospace, monospace;
+  letter-spacing: 2px;
+}
+.solara-landing .sol-chain-t {
+  fill: var(--fg);
+  font: 700 15.5px 'Satoshi', 'Figtree', sans-serif;
+}
+.solara-landing .sol-chain-s {
+  fill: #8A8478;
+  font: 500 10.5px 'JetBrains Mono', 'Fira Code', ui-monospace, monospace;
+}
+.solara-landing .sol-chain-line {
+  stroke: rgba(224, 138, 60, .6);
+  stroke-width: 1.5;
+  stroke-linecap: round;
+}
+.solara-landing .sol-chain-count {
+  fill: var(--accent);
+  font: 800 30px 'Satoshi', 'Figtree', sans-serif;
+  font-variant-numeric: tabular-nums;
+}
+.solara-landing .sol-chain-count-lbl {
+  fill: #8A8478;
+  font: 500 9.5px 'JetBrains Mono', 'Fira Code', ui-monospace, monospace;
+  letter-spacing: 1px;
+}
+
+/* Zähler-Ziffern laufen ohne Breitensprünge (Guardrail: kein Shift
+   beim Hochzählen — bei SVG-Text ohnehin layoutfrei, bei den
+   HTML-Stats sichert tabular-nums gegen Jitter). */
+.solara-landing .hu-stat-num,
+.solara-landing .hu-proof-stat__num,
+.solara-landing .sol-proofbar-num { font-variant-numeric: tabular-nums; }
+
+.solara-landing .sol-sr {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* ─── 12) Motion Layer ──────────────────────────────────────────
+   Drei Bausteine, ausschließlich transform/opacity (kein Layout):
+   a) Hero-Entry-Stagger: reines CSS (backwards-Fill wie sol-bar),
+      läuft auch ohne JS durch. H1 bleibt komplett unanimiert und
+      die Subline (mobiles LCP-Element) bekommt NUR transform —
+      kein Element des LCP-Pfads startet mit opacity:0.
+   b) Anfrage-Ketten-SVG: Linien zeichnen per stroke-dashoffset,
+      Stufen faden gestaffelt (--sol-d aus dem Template).
+   c) Scroll-Reveal [data-sol-reveal]: 16px/.5s ease-out, einmalig.
+   Versteckte Ausgangszustände (b, c) gelten NUR unter html.sol-anim —
+   die Klasse setzt das deferred JS erst nach Reduced-Motion- und
+   IntersectionObserver-Check. Ohne JS ist alles sofort sichtbar. */
+@media (prefers-reduced-motion: no-preference) {
+  @keyframes sol-rise-fade { from { opacity: 0; transform: translateY(12px); } }
+  @keyframes sol-rise { from { transform: translateY(12px); } }
+  .solara-landing .sol-hero .hu-tag { animation: sol-rise-fade .5s ease-out backwards; }
+  .solara-landing .sol-hero .hu-hero__sub { animation: sol-rise .55s ease-out .1s backwards; }
+  .solara-landing .sol-cta-card { animation: sol-rise-fade .5s ease-out .15s backwards; }
+  .solara-landing .sol-hero .hu-hero__stats { animation: sol-rise-fade .5s ease-out .22s backwards; }
+  .solara-landing .sol-hero .hu-hero__bullets { animation: sol-rise-fade .5s ease-out .3s backwards; }
+  .solara-landing .sol-hero-callink { animation: sol-rise-fade .5s ease-out .38s backwards; }
+}
+
+html.sol-anim .solara-landing [data-sol-reveal] {
+  opacity: 0;
+  transform: translateY(16px);
+  transition: opacity .5s ease-out, transform .5s ease-out;
+}
+html.sol-anim .solara-landing [data-sol-reveal].is-in {
+  opacity: 1;
+  transform: none;
+}
+
+html.sol-anim .solara-landing .sol-chain-node {
+  opacity: 0;
+  transform: translateY(10px);
+  transition: opacity .5s ease-out var(--sol-d, 0s), transform .5s ease-out var(--sol-d, 0s);
+}
+html.sol-anim .solara-landing .sol-chain-line {
+  stroke-dasharray: 1;
+  stroke-dashoffset: 1;
+  transition: stroke-dashoffset .45s ease-out var(--sol-d, 0s);
+}
+html.sol-anim .solara-landing .sol-chain.is-live .sol-chain-node { opacity: 1; transform: none; }
+html.sol-anim .solara-landing .sol-chain.is-live .sol-chain-line { stroke-dashoffset: 0; }
+
+/* ─── 13) Reduced Motion ────────────────────────────────────── */
 @media (prefers-reduced-motion: reduce) {
   .solara-landing .sol-sun-rays,
   .solara-landing .sol-bar,
@@ -1041,4 +1164,19 @@
   .solara-landing .sol-quiz-opt,
   .solara-landing .sol-quiz-progress-shimmer { animation: none; }
   .solara-landing .sol-quiz-progress-fill { transition: none; }
+
+  /* Motion-Layer hart aus: alles sofort sichtbar, Linien gezeichnet.
+     (Greift auch, wenn der Nutzer Reduced Motion nach dem Laden
+     aktiviert und html.sol-anim bereits gesetzt ist.) */
+  html.sol-anim .solara-landing [data-sol-reveal],
+  html.sol-anim .solara-landing .sol-chain-node {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+  html.sol-anim .solara-landing .sol-chain-line {
+    stroke-dasharray: none;
+    stroke-dashoffset: 0;
+    transition: none;
+  }
 }

--- a/blocksy-child/assets/js/solar-leadgenerierung-solara.js
+++ b/blocksy-child/assets/js/solar-leadgenerierung-solara.js
@@ -806,6 +806,90 @@
     } catch (e) { /* Stats bleiben statisch — kein Schaden. */ }
   }
 
+  /* Scroll-Reveal + Anfrage-Ketten-Choreografie.
+     Gate: html.sol-anim kommt erst nach Reduced-Motion- und
+     IntersectionObserver-Check — ohne JS (oder bei Reduced Motion)
+     bleibt jeder Ausgangszustand sichtbar, es gibt keine
+     opacity:0-Zustände ohne Fallback. Bereits sichtbare oder
+     überscrollte Elemente werden vor dem Gate als .is-in markiert,
+     damit ein Reload mitten auf der Seite nicht blinkt. */
+  function setupMotion() {
+    var reduced = false;
+    try { reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches; } catch (e) {}
+    if (reduced || !('IntersectionObserver' in window)) return;
+    var root = document.querySelector(ROOT_SELECTOR);
+    if (!root) return;
+
+    var reveals = [].slice.call(root.querySelectorAll('[data-sol-reveal]'));
+    var chain = root.querySelector('.sol-chain');
+    var vh = window.innerHeight || document.documentElement.clientHeight || 0;
+    var pending = [];
+
+    reveals.forEach(function (el) {
+      if (el.getBoundingClientRect().top < vh * 0.88) el.classList.add('is-in');
+      else pending.push(el);
+    });
+
+    var chainPending = false;
+    if (chain) {
+      if (chain.getBoundingClientRect().top < vh * 0.88) startChain(chain, false);
+      else chainPending = true;
+    }
+
+    document.documentElement.classList.add('sol-anim');
+    if (!pending.length && !chainPending) return;
+
+    try {
+      var io = new IntersectionObserver(function (entries) {
+        entries.forEach(function (entry) {
+          if (!entry.isIntersecting) return;
+          io.unobserve(entry.target);
+          if (entry.target === chain) startChain(chain, true);
+          else entry.target.classList.add('is-in');
+        });
+      }, { rootMargin: '0px 0px -12% 0px' });
+      pending.forEach(function (el) { io.observe(el); });
+      if (chainPending) io.observe(chain);
+    } catch (e) {
+      document.documentElement.classList.remove('sol-anim');
+    }
+  }
+
+  /* Startet den Ketten-Aufbau (CSS übernimmt die Stagger-Delays) und
+     zählt den CPL-Wert am CRM-Ende von Canon-vorher auf Canon-nachher
+     herunter. SSR-Text ist der Endzustand und wird am Schluss exakt
+     wiederhergestellt. */
+  function startChain(chain, viaScroll) {
+    chain.classList.add('is-live');
+    var from = parseInt(chain.getAttribute('data-count-from'), 10);
+    var to = parseInt(chain.getAttribute('data-count-to'), 10);
+    var nodes = chain.querySelectorAll('.sol-chain-count');
+    if (!nodes.length || !isFinite(from) || !isFinite(to) || from <= to) return;
+    if (typeof window.requestAnimationFrame !== 'function') return;
+
+    var originals = [];
+    var i;
+    for (i = 0; i < nodes.length; i++) originals.push(nodes[i].textContent);
+    for (i = 0; i < nodes.length; i++) nodes[i].textContent = from + ' €';
+
+    var duration = 1200;
+    var t0 = null;
+    function tick(now) {
+      if (t0 === null) t0 = now;
+      var p = Math.min(1, (now - t0) / duration);
+      var eased = 1 - Math.pow(1 - p, 3);
+      var j;
+      if (p < 1) {
+        var val = Math.round(from + (to - from) * eased);
+        for (j = 0; j < nodes.length; j++) nodes[j].textContent = val + ' €';
+        window.requestAnimationFrame(tick);
+      } else {
+        for (j = 0; j < nodes.length; j++) nodes[j].textContent = originals[j];
+      }
+    }
+    window.setTimeout(function () { window.requestAnimationFrame(tick); }, viaScroll ? 1500 : 300);
+  }
+
   function setupFaq() {
     var items = document.querySelectorAll(ROOT_SELECTOR + ' .sol-faq-item');
     if (!items.length) return;
@@ -1005,6 +1089,7 @@
   }
 
   ready(function () {
+    setupMotion();
     setupCountUp();
     setupFaq();
     setupStickyCta();

--- a/blocksy-child/page-solar-waermepumpen-leadgenerierung.php
+++ b/blocksy-child/page-solar-waermepumpen-leadgenerierung.php
@@ -588,6 +588,83 @@ get_header();
 		</section>
 
 		<!-- ════════════════════════════════════════════════════════════
+		     ANFRAGE-SYSTEM-KETTE — Anzeige → Landingpage → Qualifizierung → CRM
+		     Inline-SVG in zwei Layout-Varianten (CSS-Breakpoint 820px),
+		     baut sich beim Scroll-Eintritt stufenweise auf; Zähler am
+		     CRM-Ende läuft von CPL-vorher auf CPL-nachher (E3-Canon).
+		     SSR zeigt den Endzustand — ohne JS/bei Reduced Motion statisch.
+		     ════════════════════════════════════════════════════════════ -->
+		<?php
+		$chain_stages = [
+			[ 'k' => '01', 't' => 'Anzeige',        's' => 'Klick mit Kaufabsicht' ],
+			[ 'k' => '02', 't' => 'Landingpage',    's' => 'Eigener Kanal, eigene Daten' ],
+			[ 'k' => '03', 't' => 'Qualifizierung', 's' => 'Region · Dach · Projektwert' ],
+			[ 'k' => '04', 't' => 'CRM',            's' => 'Exklusiv für Ihren Vertrieb' ],
+		];
+		$chain_cx = [ 95, 285, 475, 665 ];
+		$chain_my = [ 24, 166, 308, 450 ];
+		?>
+		<section
+			class="sol-chain"
+			id="anfrage-system"
+			aria-label="Das Anfrage-System im Überblick"
+			data-track-section="request_chain"
+			data-count-from="<?php echo (int) $e3_cpl_before_val; ?>"
+			data-count-to="<?php echo (int) $e3_cpl_after_val; ?>"
+		>
+			<div class="hu-container">
+				<span class="hu-eyebrow">Das Anfrage-System · von der Anzeige bis ins CRM</span>
+				<figure class="sol-chain-fig">
+					<svg class="sol-chain-svg sol-chain-svg--d" viewBox="0 0 760 248" aria-hidden="true" focusable="false">
+						<?php foreach ( $chain_stages as $ci => $stage ) : $cx = $chain_cx[ $ci ]; ?>
+							<g class="sol-chain-node<?php echo 3 === $ci ? ' sol-chain-node--final' : ''; ?>" style="--sol-d:<?php echo esc_attr( (string) ( $ci * 0.35 ) ); ?>s">
+								<rect class="sol-chain-rect" x="<?php echo (int) ( $cx - 75 ); ?>" y="30" width="150" height="78" rx="13" />
+								<text class="sol-chain-k" x="<?php echo (int) $cx; ?>" y="57" text-anchor="middle"><?php echo esc_html( $stage['k'] ); ?></text>
+								<text class="sol-chain-t" x="<?php echo (int) $cx; ?>" y="80" text-anchor="middle"><?php echo esc_html( $stage['t'] ); ?></text>
+								<text class="sol-chain-s" x="<?php echo (int) $cx; ?>" y="130" text-anchor="middle"><?php echo esc_html( $stage['s'] ); ?></text>
+							</g>
+							<?php if ( $ci < 3 ) : ?>
+								<line class="sol-chain-line" pathLength="1" style="--sol-d:<?php echo esc_attr( (string) ( 0.18 + $ci * 0.35 ) ); ?>s"
+									x1="<?php echo (int) ( $cx + 81 ); ?>" y1="69" x2="<?php echo (int) ( $chain_cx[ $ci + 1 ] - 81 ); ?>" y2="69" />
+							<?php endif; ?>
+						<?php endforeach; ?>
+						<line class="sol-chain-line" pathLength="1" style="--sol-d:1.13s" x1="665" y1="140" x2="665" y2="176" />
+						<g class="sol-chain-node" style="--sol-d:1.3s">
+							<text class="sol-chain-count" x="665" y="206" text-anchor="middle"><?php echo esc_html( $e3_cpl_after ); ?></text>
+							<text class="sol-chain-count-lbl" x="665" y="226" text-anchor="middle">pro qualifizierter Anfrage</text>
+							<text class="sol-chain-count-lbl" x="665" y="242" text-anchor="middle">vorher <?php echo esc_html( $e3_cpl_before ); ?></text>
+						</g>
+					</svg>
+					<svg class="sol-chain-svg sol-chain-svg--m" viewBox="0 0 340 644" aria-hidden="true" focusable="false">
+						<?php foreach ( $chain_stages as $ci => $stage ) : $my = $chain_my[ $ci ]; ?>
+							<g class="sol-chain-node<?php echo 3 === $ci ? ' sol-chain-node--final' : ''; ?>" style="--sol-d:<?php echo esc_attr( (string) ( $ci * 0.35 ) ); ?>s">
+								<rect class="sol-chain-rect" x="45" y="<?php echo (int) $my; ?>" width="250" height="84" rx="13" />
+								<text class="sol-chain-k" x="170" y="<?php echo (int) ( $my + 26 ); ?>" text-anchor="middle"><?php echo esc_html( $stage['k'] ); ?></text>
+								<text class="sol-chain-t" x="170" y="<?php echo (int) ( $my + 50 ); ?>" text-anchor="middle"><?php echo esc_html( $stage['t'] ); ?></text>
+								<text class="sol-chain-s" x="170" y="<?php echo (int) ( $my + 70 ); ?>" text-anchor="middle"><?php echo esc_html( $stage['s'] ); ?></text>
+							</g>
+							<?php if ( $ci < 3 ) : ?>
+								<line class="sol-chain-line" pathLength="1" style="--sol-d:<?php echo esc_attr( (string) ( 0.18 + $ci * 0.35 ) ); ?>s"
+									x1="170" y1="<?php echo (int) ( $my + 92 ); ?>" x2="170" y2="<?php echo (int) ( $chain_my[ $ci + 1 ] - 8 ); ?>" />
+							<?php endif; ?>
+						<?php endforeach; ?>
+						<line class="sol-chain-line" pathLength="1" style="--sol-d:1.13s" x1="170" y1="542" x2="170" y2="562" />
+						<g class="sol-chain-node" style="--sol-d:1.3s">
+							<text class="sol-chain-count" x="170" y="596" text-anchor="middle"><?php echo esc_html( $e3_cpl_after ); ?></text>
+							<text class="sol-chain-count-lbl" x="170" y="614" text-anchor="middle">pro qualifizierter Anfrage</text>
+							<text class="sol-chain-count-lbl" x="170" y="630" text-anchor="middle">vorher <?php echo esc_html( $e3_cpl_before ); ?></text>
+						</g>
+					</svg>
+					<figcaption class="sol-sr">
+						Das Anfrage-System in vier Stufen: Anzeige, Landingpage, Qualifizierung, CRM.
+						Kosten pro qualifizierter Anfrage im <?php echo esc_html( $e3_case_label ); ?>-Case:
+						von <?php echo esc_html( $e3_cpl_before ); ?> auf <?php echo esc_html( $e3_cpl_after ); ?> in <?php echo esc_html( $e3_timeframe_dative ); ?>.
+					</figcaption>
+				</figure>
+			</div>
+		</section>
+
+		<!-- ════════════════════════════════════════════════════════════
 		     TRUST STRIP
 		     ════════════════════════════════════════════════════════════ -->
 		<section class="sol-trust" aria-label="Vertrauenssignale" data-track-section="trust_strip">
@@ -607,7 +684,7 @@ get_header();
 		     PROOF-BAR — Case-Study-Kennzahlen früh sichtbar (Teaser → #ergebnisse)
 		     ════════════════════════════════════════════════════════════ -->
 		<section class="sol-proofbar" aria-label="Belegte Ergebnisse aus dem <?php echo esc_attr( $e3_case_label ); ?>-Case" data-track-section="proof_bar">
-			<div class="hu-container">
+			<div class="hu-container" data-sol-reveal>
 				<div class="sol-proofbar-inner">
 					<span class="sol-proofbar-eyebrow sol-mono">Belegt · <?php echo esc_html( $e3_case_label ); ?></span>
 					<ul class="sol-proofbar-stats">
@@ -669,7 +746,7 @@ get_header();
 		     01 / STATUS QUO (Creme)
 		     ════════════════════════════════════════════════════════════ -->
 		<section class="hu-section hu-section--cream" id="problem" data-track-section="problem">
-			<div class="hu-container">
+			<div class="hu-container" data-sol-reveal>
 				<div class="hu-section-head">
 					<span class="hu-eyebrow">01 / Status quo</span>
 					<div>
@@ -693,7 +770,7 @@ get_header();
 		     02 / MARKT VS. EIGENER WEG (Ink)
 		     ════════════════════════════════════════════════════════════ -->
 		<section class="hu-section" id="vergleich" data-track-section="compare">
-			<div class="hu-container">
+			<div class="hu-container" data-sol-reveal>
 				<div class="hu-section-head">
 					<span class="hu-eyebrow">02 / Markt vs. eigener Weg</span>
 					<div>
@@ -737,7 +814,7 @@ get_header();
 		     03 / DAS SYSTEM — Asset-Panel + drei Schritte (Creme)
 		     ════════════════════════════════════════════════════════════ -->
 		<section class="hu-section hu-section--cream" id="system" data-track-section="method">
-			<div class="hu-container">
+			<div class="hu-container" data-sol-reveal>
 				<div class="hu-section-head">
 					<span class="hu-eyebrow">03 / Das System</span>
 					<div>
@@ -792,7 +869,7 @@ get_header();
 		     Interaktiver Zeitraum-Picker (12 · 24 · 36 Monate).
 		     ════════════════════════════════════════════════════════════ -->
 		<section class="hu-section" id="capex" data-track-section="capex_opex">
-			<div class="hu-container">
+			<div class="hu-container" data-sol-reveal>
 				<div class="hu-section-head">
 					<span class="hu-eyebrow">04 / Die Rechnung</span>
 					<div>
@@ -875,7 +952,7 @@ get_header();
 		     05 / SOLAR CASE STUDY — Vorher/Nachher + Stats (Ink)
 		     ════════════════════════════════════════════════════════════ -->
 		<section class="hu-section" id="ergebnisse" data-track-section="results">
-			<div class="hu-container">
+			<div class="hu-container" data-sol-reveal>
 				<div class="hu-proof-headline">
 					<span class="hu-eyebrow">05 / <?php echo esc_html( $e3_case_label ); ?></span>
 					<h2>Vorher. Nachher. Beziffert.</h2>
@@ -904,7 +981,7 @@ get_header();
 				</div>
 				<div class="hu-proof-stats">
 					<div class="hu-proof-stat">
-						<div class="hu-proof-stat__num"><?php echo esc_html( $e3_lead_count ); ?></div>
+						<div class="hu-proof-stat__num" data-sol-countup><?php echo esc_html( $e3_lead_count ); ?></div>
 						<div class="hu-proof-stat__lbl">Qualifizierte Anfragen</div>
 					</div>
 					<div class="hu-proof-stat">
@@ -912,7 +989,7 @@ get_header();
 						<div class="hu-proof-stat__lbl">Abschlussquote · vorher → nachher</div>
 					</div>
 					<div class="hu-proof-stat">
-						<div class="hu-proof-stat__num" style="color:var(--accent);"><?php echo esc_html( $e3_cpl_reduction ); ?></div>
+						<div class="hu-proof-stat__num" style="color:var(--accent);" data-sol-countup><?php echo esc_html( $e3_cpl_reduction ); ?></div>
 						<div class="hu-proof-stat__lbl">Weniger Kosten pro Anfrage</div>
 					</div>
 					<div class="hu-proof-stat">
@@ -944,7 +1021,7 @@ get_header();
 		     06 / WANN ES PASST — ehrliche Vorauswahl (Creme)
 		     ════════════════════════════════════════════════════════════ -->
 		<section class="hu-section hu-section--cream" id="fit" data-track-section="fit_check">
-			<div class="hu-container">
+			<div class="hu-container" data-sol-reveal>
 				<div class="hu-section-head">
 					<span class="hu-eyebrow">06 / Wann es passt</span>
 					<div>
@@ -1011,7 +1088,7 @@ get_header();
 		     07 / RISIKO-UMKEHR (Ink)
 		     ════════════════════════════════════════════════════════════ -->
 		<section class="hu-section" id="garantie" data-track-section="guarantee">
-			<div class="hu-container">
+			<div class="hu-container" data-sol-reveal>
 				<div class="hu-section-head">
 					<span class="hu-eyebrow">07 / Risiko-Umkehr</span>
 					<div>
@@ -1035,7 +1112,7 @@ get_header();
 		     08 / VERTIEFUNG — Themen-Hub für SEO-Sub-Pages (Ink)
 		     ════════════════════════════════════════════════════════════ -->
 		<section class="hu-section" id="deeper" data-track-section="deeper">
-			<div class="hu-container">
+			<div class="hu-container" data-sol-reveal>
 				<div class="hu-section-head">
 					<span class="hu-eyebrow">08 / Vertiefung</span>
 					<div>
@@ -1071,7 +1148,7 @@ get_header();
 		     09 / FAQ (Ink)
 		     ════════════════════════════════════════════════════════════ -->
 		<section class="hu-section" id="faq" data-track-section="faq">
-			<div class="hu-container sol-faq-inner">
+			<div class="hu-container sol-faq-inner" data-sol-reveal>
 				<div class="sol-faq-left">
 					<span class="hu-eyebrow">09 / FAQ</span>
 					<h2 class="sol-faq-h">Bevor Sie fragen.</h2>
@@ -1107,7 +1184,7 @@ get_header();
 		     FOUNDING COHORT 2026 + FINAL CTA — zurück zum Marktcheck
 		     ════════════════════════════════════════════════════════════ -->
 		<section class="hu-section" id="founding" data-track-section="founding_cohort">
-			<div class="hu-container">
+			<div class="hu-container" data-sol-reveal>
 				<div class="hu-final-cta">
 					<span class="hu-tag">
 						<span class="hu-dot hu-dot--live" aria-hidden="true"></span>


### PR DESCRIPTION
…roll-Reveal

- Hero: CSS-only Entry-Stagger (transform/opacity, backwards-Fill) für Tag, Subline, CTA-Card, Stats, Bullets, Cal-Link. H1 bleibt unanimiert; Subline (mobiles LCP-Element) bekommt nur transform, nie opacity:0.
- Neu: Anfrage-System-Kette als Inline-SVG direkt unter dem Hero (Anzeige → Landingpage → Qualifizierung → CRM), zwei Layout-Varianten (Breakpoint 820px) mit fester aspect-ratio. Linien zeichnen per stroke-dashoffset, Stufen faden gestaffelt beim Scroll-Eintritt. CPL-Zähler am CRM-Ende läuft von Canon-vorher (150 €) auf Canon-nachher (22 €) herunter; SSR zeigt den Endzustand.
- Ergebnisse (#ergebnisse): data-sol-countup auf Lead-Count und CPL-Reduktion (bestehende Countup-Logik, einmalig, Canon-Restore).
- Übrige Sektionen: einmaliger Scroll-Reveal (opacity + 16px translateY, .5s ease-out) via IntersectionObserver; Sticky-Section-Nav ausgenommen.
- Progressive Enhancement: versteckte Ausgangszustände nur unter html.sol-anim (Gate nach Reduced-Motion- und IO-Check im deferred JS); ohne JS oder mit prefers-reduced-motion ist alles sofort sichtbar.
- Nur transform/opacity animiert; tabular-nums auf Zähler-Ziffern.

CWV-Nachweis (lokaler Harness, Lighthouse mobil, je 3 Läufe): Perf 80→81/79 (Rauschen), LCP ~3,24s→~3,21s, LCP-Element unverändert (p.hu-hero__sub), keine neue Layout-Shift-Quelle (einzige Quelle vorher wie nachher: Bestands-Font-Swap figtree-600/700 → figure.hu-diagram). Budgets: JS +1,6 KB minifiziert, SVG ~7,1 KB inline.


Claude-Session: https://claude.ai/code/session_01KA4D7qMyy7mgozmbJbSq1k