### PR TITLE
Solar-LP: Hero-H1 auf zwei Zeilen straffen, CPL-Panel nach oben ziehen

### DIFF
--- a/blocksy-child/assets/css/solar-leadgenerierung-solara.css
+++ b/blocksy-child/assets/css/solar-leadgenerierung-solara.css
@@ -38,9 +38,16 @@
   z-index: 1;
 }
 .solara-landing .sol-hero-left { position: relative; }
-.solara-landing .sol-hero-h1 { margin: 18px 0 0; }
-.solara-landing .sol-hero .hu-hero__sub { margin: 18px 0 4px; }
-.solara-landing .sol-hero .hu-hero__stats { margin-top: 24px; }
+.hu-hp.solara-landing .sol-hero-h1 {
+  margin: 14px 0 0;
+  font-size: clamp(34px, 4.2vw, 58px);
+  line-height: 1.05;
+}
+/* Akzentwort inline halten (Basis-Theme setzt display:block → sonst
+   rutscht „mieten." auf eine eigene Zeile und „zu" bleibt als Waise). */
+.hu-hp.solara-landing .sol-hero-h1 .hu-hero__title-2 { display: inline; }
+.solara-landing .sol-hero .hu-hero__sub { margin: 16px 0 4px; }
+.solara-landing .sol-hero .hu-hero__stats { margin-top: 18px; }
 .solara-landing .sol-hero .hu-hero__bullets { margin-top: 16px; }
 
 .solara-landing .sol-hero-callink {
@@ -75,10 +82,10 @@
 /* CPL-Telemetrie-Panel (Balken-Chart im hu-diagram-Rahmen) */
 .solara-landing .sol-cpl {
   min-height: 0;
-  margin: 26px 0 0;
-  padding: 24px 26px 20px;
+  margin: 18px 0 0;
+  padding: 20px 26px 18px;
 }
-.solara-landing .sol-cpl svg { width: 100%; height: auto; margin-top: 16px; }
+.solara-landing .sol-cpl svg { width: 100%; height: auto; margin-top: 12px; }
 .solara-landing .sol-bar {
   transform-box: fill-box;
   transform-origin: bottom;

--- a/blocksy-child/page-solar-waermepumpen-leadgenerierung.php
+++ b/blocksy-child/page-solar-waermepumpen-leadgenerierung.php
@@ -431,7 +431,7 @@ get_header();
 						<span class="hu-mono">Für Solar- &amp; Wärmepumpen-Betriebe · Eigener Vertrieb · DACH</span>
 					</span>
 					<h1 class="hu-display hu-hero__title sol-hero-h1">
-						Hören Sie auf,<br />Anfragen<br />zu&nbsp;<span class="hu-hero__title-2">mieten.</span>
+						Hören Sie auf,<br />Anfragen zu&nbsp;<span class="hu-hero__title-2">mieten.</span>
 					</h1>
 					<p class="hu-hero__sub">
 						Aroundhome, DAA und Wattfox verkaufen jede Anfrage an drei Wettbewerber — Sie bezahlen den Preiskampf.


### PR DESCRIPTION
Die H1 rendert bisher in vier Zeilen: zwei erzwungene <br /> plus der global auf display:block gesetzte Akzent (.hu-hero__title-2) drücken "mieten." auf eine eigene Zeile und lassen "zu" als Waise stehen.

- Ein <br /> entfernt -> "Hören Sie auf," / "Anfragen zu mieten."
- Akzentwort auf dieser Seite inline (display:inline)
- H1-Größe auf max. 58px gecappt, damit die 2. Zeile in der linken Spalte (~565px) sicher passt, Zeilenhöhe 1.05
- Obere Abstände von H1, Sub, Stats und CPL-Panel gestrafft, damit das Diagramm above the fold sichtbar wird


Claude-Session: https://claude.ai/code/session_011eZVoyFrLsSrGGYNPfirXh