### PR TITLE
Hero: Copy verdichten und Grafik/Zahlen nach oben ziehen

### DIFF
--- a/blocksy-child/assets/css/homepage-redesign.css
+++ b/blocksy-child/assets/css/homepage-redesign.css
@@ -219,7 +219,7 @@
    HERO
    ============================================================= */
 .hu-hp .hu-hero {
-  padding: clamp(56px,6vw,72px) 0 clamp(28px,3.5vw,44px);
+  padding: clamp(40px,4.5vw,56px) 0 clamp(28px,3.5vw,44px);
   position: relative;
   overflow: hidden;
 }
@@ -235,13 +235,13 @@
   display: grid;
   grid-template-columns: 1.05fr 1fr;
   gap: 64px;
-  align-items: center;
+  align-items: start;
   position: relative;
 }
 @media (max-width: 1080px) {
   .hu-hp .hu-hero__container { grid-template-columns: 1fr; gap: 48px; }
 }
-.hu-hp .hu-hero__eyebrow { margin-bottom: 16px; }
+.hu-hp .hu-hero__eyebrow { margin-bottom: 14px; }
 .hu-hp .hu-hero__title {
   font-size: clamp(36px,4.6vw,62px);
   font-weight: 700;
@@ -265,7 +265,7 @@
   color: var(--fg-2);
   font-size: clamp(16px,1.3vw,19px);
   max-width: 54ch;
-  margin: 16px 0 20px;
+  margin: 14px 0 18px;
 }
 .hu-hp .hu-hero__sub strong { color: var(--fg); font-weight: 600; }
 .hu-hp .hu-hero__ctas {
@@ -278,7 +278,7 @@
 .hu-hp .hu-hero__cta-note {
   color: var(--fg-2);
   font-size: 13px;
-  margin: 0 0 24px;
+  margin: 0 0 16px;
   opacity: 0.85;
 }
 .hu-hp .hu-hero__cta-note--trust {
@@ -290,12 +290,12 @@
 .hu-hp .hu-hero__bullets {
   list-style: none;
   padding: 0;
-  margin: 0;
+  margin: 6px 0 0;
   display: flex;
   flex-wrap: wrap;
-  gap: 24px;
+  gap: 18px;
   color: var(--fg-2);
-  font-size: 14px;
+  font-size: 13px;
 }
 .hu-hp .hu-hero__bullets li { display: flex; align-items: center; gap: 10px; }
 .hu-hp .hu-bullet-dot {
@@ -314,7 +314,7 @@
   padding: 16px 0;
   border-top: 1px solid var(--line);
   border-bottom: 1px solid var(--line);
-  margin-bottom: 18px;
+  margin-bottom: 16px;
 }
 .hu-hp .hu-hero__stats > div:not(.hu-stat-divider) { flex: 1; }
 .hu-hp .hu-stat-divider {

--- a/blocksy-child/front-page.php
+++ b/blocksy-child/front-page.php
@@ -138,8 +138,7 @@ get_header();
 				</h1>
 
 				<p class="hu-hero__sub">
-					Für Solar-, Wärmepumpen- und Speicher-Anbieter im DACH-Raum, die weniger abhängig von Lead-Portalen werden wollen.
-					Ich prüfe, wo Website, Vorqualifizierung, Tracking und Werbekanäle aktuell Anfragen verlieren — und welche Hebel zuerst greifen.
+					Für Solar-, Wärmepumpen- und Speicher-Anbieter im DACH-Raum: Ich prüfe, wo Website, Vorqualifizierung, Tracking und Werbekanäle heute Anfragen verlieren — und welche Hebel zuerst greifen.
 				</p>
 
 				<div class="hu-hero__ctas">
@@ -153,8 +152,8 @@ get_header();
 						Case Study ansehen
 					</a>
 				</div>
-				<p class="hu-hero__cta-note hu-hero__cta-note--trust">Der Marktcheck kostet Sie 60 Sekunden — keine Zahlungsdaten, kein Newsletter, kein Pitch-Deck. Die Rückmeldung kommt persönlich geprüft innerhalb von 48 Stunden.</p>
-				<p class="hu-hero__cta-note">Keine neue Website auf Verdacht. Erst Diagnose, dann Entscheidung.</p>
+				<p class="hu-hero__cta-note hu-hero__cta-note--trust">60 Sekunden · keine Zahlungsdaten · kein Newsletter · kein Pitch-Deck — persönlich geprüfte Rückmeldung in 48 Stunden.</p>
+				<p class="hu-hero__cta-note">Keine neue Website auf Verdacht — erst Diagnose, dann Entscheidung.</p>
 
 				<div class="hu-hero__stats">
 					<div>


### PR DESCRIPTION
Startseiten-Hero kompakter und "auf einen Blick" nutzbar:
- Subtext von zwei Saetzen auf einen gestrafft (alle Hebel erhalten)
- Trust-Fussnote auf eine Zeile verdichtet (alle Signale erhalten)
- Kicker in einen Satz zusammengezogen
- Grid align-items: start -> SVG-Pipeline richtet sich oben aus
- Hero-Padding und vertikale Abstaende ueber den Case-Study-Zahlen gestrafft, damit die Zahlen ohne Scrollen sichtbar sind
- Bullet-Zeile visuell verschlankt


Claude-Session: https://claude.ai/code/session_01CnWX81ZbRGs7toqZfeAMgo