### PR TITLE
SEO Phase 1: Verlaufs-Audit 2026-07-20 + Checkfox/b2b/Anchor-Fixes

### DIFF
--- a/blocksy-child/inc/blog-provider-posts.php
+++ b/blocksy-child/inc/blog-provider-posts.php
@@ -342,8 +342,8 @@ MD,
 		[
 			'title'            => 'Checkfox für Solar- und Wärmepumpen-Betriebe: Seriosität, Mechanik und Markteinordnung',
 			'slug'             => 'checkfox-solar-waermepumpe-einordnung',
-			'seo_title'        => 'Checkfox Erfahrungen & Seriosität: Einordnung für Betriebe',
-			'seo_description'  => 'Ist Checkfox seriös? Einordnung des breiten Vergleichsportal-Modells für Solar- und Wärmepumpen-Anfragen: Mechanik, Kosten-Logik und die Alternative eigener Anfrage-Systeme.',
+			'seo_title'        => 'Checkfox Erfahrungen: Ist das Portal seriös für Betriebe?',
+			'seo_description'  => 'Ist Checkfox seriös? Unabhängige Einordnung für Solar- & Wärmepumpen-Betriebe: Portal-Mechanik, Kosten-Logik und die Alternative zu gekauften Leads.',
 			'excerpt'          => 'Checkfox aus Sicht von Solar- und Wärmepumpen-Betrieben eingeordnet: Seriositäts-Frage, Portal-Mechanik über viele Produktkategorien, Kosten-Logik und Ownership.',
 			'tags'             => [ 'Checkfox', 'Solar Leads', 'Wärmepumpe', 'Vergleichsportal', 'Markteinordnung' ],
 			'markdown_content' => <<<'MD'

--- a/blocksy-child/page-b2b-solar-leads.php
+++ b/blocksy-child/page-b2b-solar-leads.php
@@ -80,6 +80,18 @@ $gewerbe_layers = [
 	],
 ];
 
+$pv_termine_bought = [
+	[ 't' => 'Termin ≠ Projekt', 's' => 'Gekaufte PV-Termine sind gelegte Kalendereinträge. Ob Anschlussleistung, Investitionsbudget und Entscheiderrolle stimmen, zeigt sich erst im Gespräch – die Qualifizierung passiert zu spät.' ],
+	[ 't' => 'Provision pro Termin', 's' => 'Bezahlt wird der Termin, nicht der Abschluss. No-Shows und unpassende Gewerbe-Projekte gehen zu Ihren Lasten.' ],
+	[ 't' => 'Fremde Vorqualifizierung', 's' => 'Ein Callcenter entscheidet, was ein „guter" B2B-Termin ist – nach eigenen Kriterien, nicht nach Ihrer Buying-Center-Logik.' ],
+];
+
+$pv_termine_own = [
+	[ 't' => 'Termin = qualifizierte Anfrage', 's' => 'Vorqualifizierung nach Dachfläche, Anschlussleistung und Buying-Center läuft vor dem Termin – nicht danach.' ],
+	[ 't' => 'Kosten pro Auftrag', 's' => 'Gemessen wird der Projektwert je Anfrage (> 50.000 €), nicht der Preis pro Kalendereintrag.' ],
+	[ 't' => 'Eigene Terminlogik', 's' => 'Ihr CRM und Ihre Kriterien bestimmen, welcher Gewerbe-Termin überhaupt in den Vertrieb geht.' ],
+];
+
 $fit_yes = [
 	[ 't' => 'Gewerbliche PV-Anbieter', 's' => 'Mit Fokus auf Hallendächer, Quartiere, Industrieanlagen oder PPA-Modelle.' ],
 	[ 't' => 'Speicher-Lösungsanbieter', 's' => 'Großspeicher für Gewerbe, Eigenverbrauchsoptimierung, Spitzenlastmanagement.' ],
@@ -224,6 +236,39 @@ get_header();
 						<p class="hu-intercept__card-text"><?php echo esc_html( $item['s'] ); ?></p>
 					</article>
 				<?php endforeach; ?>
+			</div>
+		</div>
+	</section>
+
+	<section class="hu-intercept__compare" id="pv-termine" aria-labelledby="hu-b2b-termine-title">
+		<div class="hu-intercept__container">
+			<h2 class="hu-intercept__h2" id="hu-b2b-termine-title">PV-Termine im B2B: gekauft oder selbst erzeugt?</h2>
+			<p class="hu-intercept__section-lead">
+				„PV-Termine B2B" klingt nach Abkürzung zum Abschluss. Im Gewerbe mit Buying-Center und langen Sales-Zyklen entscheidet aber nicht der Termin, sondern die Qualifizierung dahinter – sonst sitzen teure Vertriebstermine ohne Projektsubstanz im Kalender.
+			</p>
+			<div class="hu-intercept__grid hu-intercept__grid--two">
+				<div class="hu-intercept__panel hu-intercept__panel--negative">
+					<h3 class="hu-intercept__panel-title">Gekaufte PV-Termine</h3>
+					<ul class="hu-intercept__facts">
+						<?php foreach ( $pv_termine_bought as $item ) : ?>
+							<li>
+								<span class="hu-intercept__fact-key"><?php echo esc_html( $item['t'] ); ?></span>
+								<span class="hu-intercept__fact-label"><?php echo esc_html( $item['s'] ); ?></span>
+							</li>
+						<?php endforeach; ?>
+					</ul>
+				</div>
+				<div class="hu-intercept__panel hu-intercept__panel--positive">
+					<h3 class="hu-intercept__panel-title">Eigene B2B-PV-Termine</h3>
+					<ul class="hu-intercept__facts">
+						<?php foreach ( $pv_termine_own as $item ) : ?>
+							<li>
+								<span class="hu-intercept__fact-key"><?php echo esc_html( $item['t'] ); ?></span>
+								<span class="hu-intercept__fact-label"><?php echo esc_html( $item['s'] ); ?></span>
+							</li>
+						<?php endforeach; ?>
+					</ul>
+				</div>
 			</div>
 		</div>
 	</section>

--- a/blocksy-child/page-solar-leads-kaufen-alternative.php
+++ b/blocksy-child/page-solar-leads-kaufen-alternative.php
@@ -381,7 +381,7 @@ get_header();
 		<div class="hu-intercept__container">
 			<h2 class="hu-intercept__h2" id="hu-intercept-system-title">So sieht ein eigenes Anfrage-System für Solar und Wärmepumpe aus</h2>
 			<p class="hu-intercept__section-lead">
-				Vier Bausteine – jeder einzeln messbar, gemeinsam ergeben sie eine Strecke, die <strong>qualifizierte Photovoltaik-Anfragen</strong> und <strong>exklusive Wärmepumpen-Leads</strong> produziert, statt sie zu mieten.
+				Vier Bausteine – jeder einzeln messbar, gemeinsam ergeben sie eine Strecke, die <strong>qualifizierte Photovoltaik-Anfragen</strong> und <a href="<?php echo esc_url( home_url( '/waermepumpen-leads/' ) ); ?>" data-track-action="related_waermepumpen_leads" data-track-category="internal_link_hierarchy" data-track-section="system">exklusive Wärmepumpen-Leads</a> produziert, statt sie zu mieten.
 			</p>
 			<ol class="hu-intercept__layers">
 				<?php foreach ( $own_system_layers as $i => $layer ) : ?>

--- a/seo-research/2026-07/reports/gsc-verlauf-2026-07-20.md
+++ b/seo-research/2026-07/reports/gsc-verlauf-2026-07-20.md
@@ -1,0 +1,132 @@
+# GSC-Verlaufskontrolle & SEO-Voll-Audit (SEO-Cockpit-Exporte 2026-07-20)
+
+Datenbasis: Uploads `seocockpitexport7d-2026-07-20` und `seocockpitexport28d-2026-07-20`.
+Baseline für den Verlauf: `gsc-abgleich.md` (Stand 2026-07-03). Dieser Report ist eine
+**Verlaufskontrolle** — er misst, welche Vorhersagen des 07-03-Sprints eingetroffen sind, nicht nur
+eine Momentaufnahme.
+
+> **Methodik-Hinweis:** Die CSV-Spalten `seo_title`/`seo_description` spiegeln das in der DB gespeicherte
+> ACF-Feld, **nicht immer das live gerenderte `<title>`**. Homepage/Blog-Index/Cornerstone/Marktcheck/
+> Kontakt/WGOS-Titel werden im Code erzwungen (`inc/seo-meta.php:936-1005`). Für page-Typ-Money-Pages
+> zieht `seo-meta.php` zuerst das ACF-Feld → Title/Meta-Edits dort sind **WP-Admin-Aufgaben**, nicht Repo.
+> Blog-Post-Titel/-Metas liegen in den Seed-Registries (`inc/blog-pillar-posts.php`,
+> `inc/blog-provider-posts.php`) → **Repo-Aufgaben**.
+
+## Gesamtbild
+
+- **28 Tage: ~1.299 Impressionen, 4 Klicks (CTR 0,31 %).** 7 Tage: 259 Impressionen, **0 Klicks**.
+- Das Muster ist unverändert: **viele Impressionen, fast keine Klicks.** Ursache ist doppelt —
+  überwiegend Position Seite 2–7 **und** schwache Snippets auf den wenigen Seite-1-Rankings.
+- Die 4 Klicks (28 T): `wordpress agentur hannover` → Hannover; `checkfox erfahrungen` → Checkfox;
+  `b2b photovoltaik` → b2b-solar-leads; `wattfox` → solar-leads-kaufen-alternative.
+
+### Verlauf vs. Baseline 2026-07-03
+| Seite / Query | 07-03 | 07-20 | Befund |
+|---|---|---|---|
+| Hannover · „wordpress agentur hannover" | 342 Impr., Pos. → 11,5 (7d) | 274 Impr., Pos. 17,6 (28d) / **32,1 (7d)** | **Rückschritt** — Aufwärtstrend gekippt |
+| b2b-solar-leads · „pv termine b2b" | 86 Impr., Pos. 9,65 | 45 Impr., Pos. 9,69 | Seite 1; **dichtester Klick-Kandidat**; Impr. gesunken |
+| waermepumpen-leads · „wärmepumpen leads" | erwartete Übernahme | 28 Impr., Pos. 28,7 | Teilerfolg — rankt jetzt, aber noch kannibalisiert |
+| **checkfox-…-einordnung** · „checkfox seriös" + Var. | (Post neu) | **~120 Impr. gesamt, Pos. ~7–8** | **Neuer Seite-1-Cluster** — Portal-Post-Strategie bestätigt |
+| server-side-tracking-b2b · „server side tracking agentur" | Pos. 60–90 | 92 Impr., Pos. 56,8 | Nachfrage da, nicht konkurrenzfähig |
+
+---
+
+## Critical
+
+1. **Hannover-Ranking abgesackt.** `/wordpress-agentur-hannover/` war am 07-03 auf dem Sprung auf Seite 1
+   (Pos. 11,5 im 7d-Fenster), steht jetzt bei Pos. 17,6 (28d) und **32,1 im letzten 7d-Fenster**. Das ist
+   das reichweitenstärkste Asset der Domain (274 Impr. auf einer Query) — der Rückschritt kostet am meisten.
+   → **Positions-Problem, kein Snippet-Problem.** Hebel: Content-Tiefe + interne Links (siehe Repo-/Admin-Tasks).
+2. **Homepage-Titel im Export veraltet — aber vermutlich nur Daten-Hygiene.** Der Export zeigt weiter die
+   alte Positionierung („WordPress Growth Architect…"). Der Code erzwingt aber bereits den neuen Titel
+   („Anfrage-Systeme für Solar & Wärmepumpe | Haşim Üner", `seo-meta.php:30-35,937-939`), **unabhängig vom
+   ACF-Feld**. → Live-`<title>` per View-Source verifizieren; danach das veraltete ACF-Feld der Startseite
+   leeren, damit künftige Exporte stimmen. (Offen seit 07-03.)
+
+## High-Leverage
+
+3. **Checkfox = der beste Snippet-Hebel der Domain.** ~120 Impressionen auf Seite 1 (Pos. ~7–8) für
+   `checkfox seriös`, `checkfox erfahrungen`, `ist checkfox seriös`, `checkfox bewertung`. **Repo-Edit** (Blog-Post).
+   Zusätzlicher Befund: die aktuelle Meta-Description ist **~172 Zeichen → über dem 160-Limit** und wird
+   im SERP abgeschnitten. → In Phase 1 gekürzt + geschärft (siehe unten).
+4. **„PV-Termine B2B" — dichtester Klick-Kandidat.** `/b2b-solar-leads/` rankt Pos. 9,7 (45 Impr., 0 Klicks)
+   für `pv termine b2b`. Die Seite bediente das bisher nur in einer FAQ. → In Phase 1 eigener Abschnitt
+   „PV-Termine im B2B" ergänzt (Repo).
+5. **Kannibalisierung „wärmepumpen leads".** Vier Seiten konkurrieren; die dedizierte `/waermepumpen-leads/`
+   (Pos. 28,7) soll die Query allein besitzen. Kernproblem: `/solar-leads-kaufen-alternative/` (Pos. 55)
+   verlinkte **gar nicht** auf die dedizierte Seite. → In Phase 1 interner Anker gesetzt (Repo).
+
+## Polish
+
+6. **Server-Side-Cluster differenzieren.** `/server-side-tracking-gtm/` (2.227 W.) sammelt nur 4 Impr.,
+   während `/server-side-tracking-b2b/` (793 W.) 238 Impr. holt. USPs aus dem Ratgeber in die Landingpage
+   ziehen, den Ratgeber klar als Info-Support abgrenzen + interlinken. **Der GTM-Post ist nicht im Repo
+   geseedet → WP-Admin-Aufgabe** (301 nur, falls sich der Guide nicht sauber abgrenzen lässt).
+7. **Non-Target-Rauschen bewusst ignorieren:** `woocommerce agentur hannover` (63 Impr., bereits als
+   non-target markiert), `elevar server side tracking`, `server side tracking regensburg`, retirete
+   Wartungs-Queries. Keine Optimierung, keine neuen Seiten.
+
+## Bestätigte Stärke — nicht anfassen
+
+**Core Web Vitals / Performance sind exzellent** (PageSpeed 2026-07-23, Startseite mobil: Leistung 99,
+Barrierefreiheit 100, Best Practices 100, SEO 100). Das ist ein Wettbewerbsvorteil und bleibt so.
+→ Keine Snippet-/Content-/CRO-Maßnahme darf CWV regressieren; Homepage-Assets (JS/CSS) werden nicht
+angefasst, solange die Werte stehen. Die „Asset-Slimming"-Empfehlung des fremden Prompts ist gegenstandslos.
+
+## Kannibalisierungs-Karte (2026-07-20)
+
+| Query | Seiten (Impr./Pos.) | Empfehlung |
+|---|---|---|
+| **wärmepumpen leads** | /waermepumpen-leads/ (28/28,7) · /solar-leads-kaufen-alternative/ (25/55) · /…-lohnt-sich/ (5/81) · /…-kosten-studie/ (3/69) | /waermepumpen-leads/ **besitzt** die Query → Anker + interne Links dorthin; Wärmepumpen-Entität auf den Sekundärseiten nicht weiter ausbauen |
+| **leadgenerierung photovoltaik** | /b2b-solar-leads/ (24/46,7) · Money-Page | Money-Page besitzt die Query → Anker „Leadgenerierung Photovoltaik" auf Money-Page |
+| **leads kaufen / leadgenerator solar** | /b2b-solar-leads/ ↔ /solar-leads-kaufen-alternative/ | Intents trennen: b2b = Gewerbe/Transactional, kaufen-alternative = Commercial Investigation (Portal-Vergleich) |
+| **server side tracking** | /server-side-tracking-b2b/ (238) ↔ /server-side-tracking-gtm/ (4) | differenzieren + interlinken (Polish #6) |
+
+## Löschen? — Verdikt
+
+**Kein Löschen der jungen Solar-/WP-Cluster-Seiten.** Kannibalisierung ≠ Überflüssigkeit: die Seiten
+bedienen unterschiedliche Intents und stützen die Money-Pages über interne Links. Der 07-03-Report empfahl
+aus denselben Gründen „Keine Seite löschen". Insbesondere **NICHT** `/lead-funnel-solar/` (Pillar-Page,
+struktureller Hub) oder `/qualifizierte-pv-anfragen/` (junges Support-Asset) de-indexieren/301'en — das
+zerstört interne Linkkraft. Einzig echter Konsolidierungs-Kandidat: das Server-Side-Paar (Merge/Abgrenzung,
+kein Blind-Delete). Optional `noindex` für echte Altlasten mit ~0 Signal (`/ga4-tracking-setup/`,
+`/design-ist-mehr-als-aesthetik/`). `/e3-new-energy/` ist bereits sauberer Legacy-301.
+
+---
+
+## Repo-Aufgaben (in Phase 1 umgesetzt)
+
+- **Checkfox-Snippet** (`inc/blog-provider-posts.php`): Title in Frage-Format, Description auf ≤160 Z. gekürzt.
+- **„PV-Termine im B2B"-Abschnitt** (`page-b2b-solar-leads.php`): neuer Compare-Abschnitt „gekauft vs. selbst erzeugt".
+- **Anchor-Disziplin** (`page-solar-leads-kaufen-alternative.php`): kontextueller interner Link
+  „exklusive Wärmepumpen-Leads" → `/waermepumpen-leads/`.
+
+## Manuelle WordPress-Aufgaben (getrennt, kein Repo)
+
+> Die folgenden Title/Meta gehören in das ACF-Feld „SEO Meta (Growth Architect)" der jeweiligen **Seite**
+> (page-Typ). Title ≤65 Z., Description ≤160 Z.
+
+**`/b2b-solar-leads/`** — verstärkt „pv termine b2b" (Pos. 9,7) im Snippet:
+- Title: `Photovoltaik B2B Leads & PV-Termine: Gewerbe statt Masse`
+- Description: `Gewerbliche PV-Anfragen & B2B-Termine für Hallendächer, Quartiere & PPA — exklusiv statt mehrfach verkauft. Eigenes Anfrage-System statt Portal-Leads.`
+
+**`/waermepumpen-leads/`** — Snippet ist ok; Priorität ist **Ownership** (interne Anker aus Repo-Task).
+Keine Snippet-Änderung nötig.
+
+**`/wordpress-agentur-hannover/`** — **Positions-Problem, nicht Snippet.** Erst auf Seite 1 bringen
+(Content-Tiefe zu „wordpress agentur/hannover"-Cluster, interne Links von thematisch nahen Seiten).
+Optionaler Titel-Feinschliff, sobald auf Seite 1: `WordPress Agentur Hannover: B2B-Systeme, SEO & Tracking`.
+
+**Homepage-Daten-Hygiene:** View-Source auf hasimuener.de prüfen (Titel sollte bereits neu sein) →
+veraltetes ACF-`seo_title`/`seo_description`-Feld der Startseite leeren.
+
+**Server-Side-Konsolidierung:** Entscheidung Abgrenzung vs. 301 für `/server-side-tracking-gtm/`;
+USPs in `/server-side-tracking-b2b/` übernehmen (GTM-Post ist WP-DB, nicht Repo).
+
+**Nach Deploy:** GSC-Recrawl der geänderten URLs (Checkfox, b2b-solar-leads) anfordern.
+
+## Wirkungsmessung
+
+Nächster GSC-Export in **2–4 Wochen**. Erfolgskriterien: CTR-Lift auf Checkfox + b2b-solar-leads
+(Seite-1-Rankings holen Klicks), Position von `/waermepumpen-leads/` steigt, `wärmepumpen leads`
+konsolidiert sich auf eine Seite, Hannover zurück Richtung Seite 1.


### PR DESCRIPTION
- Audit-Dokument (Verlaufskontrolle vs. Baseline 2026-07-03) mit Kannibalisierungs-Karte, ready-to-paste Snippet-Rewrites und getrennter WP-Admin-Aufgabenliste
- Checkfox-Blogpost: Title in Frage-Format ("Ist das Portal serioes?"), Meta-Description von ~172 auf <=160 Zeichen gekuerzt (SERP-Abschnitt)
- b2b-solar-leads: neuer Abschnitt "PV-Termine im B2B" fuer Query "pv termine b2b" (Pos. 9,7 / 45 Impr., dichtester Klick-Kandidat)
- solar-leads-kaufen-alternative: kontextueller interner Anker auf /waermepumpen-leads/ gegen Kannibalisierung "waermepumpen leads"

CWV/Startseiten-Performance (99 mobil) bewusst unangetastet.


Claude-Session: https://claude.ai/code/session_01HKKB9NDmEUPzhM2jEt8maK