### PR TITLE
Brand-Doc: Vokabular-Regel Solar / Photovoltaik / PV festschreiben

### DIFF
--- a/docs/standards/BRAND_AND_COPY.md
+++ b/docs/standards/BRAND_AND_COPY.md
@@ -42,11 +42,45 @@ Marktcheck -> Anfrage-System-Analyse -> Umsetzung / Retainer
 `Kosten pro Anfrage`, `qualifizierte Anfragen`, `Abschlussquote`,
 `Vorqualifizierung`, `Tracking`, `Nachfrage-Infrastruktur`,
 `System-Diagnose`, `Potenzial-Check`, `priorisierte Hebel`,
-`Solar`, `Wärmepumpe`, `Speicher`, `Energie-Anbieter`, `Handwerk`
+`Solar`, `Photovoltaik`, `PV`, `Wärmepumpe`, `Speicher`, `Energie-Anbieter`, `Handwerk`
 
 `Founding-Partner` darf im 2026-Angebotsframe verwendet werden, muss auf der
 ersten sichtbaren Nutzung aber als früher Umsetzungspartner erklärt werden:
 kein Mitgründer, kein Anteilseigner, keine gesellschaftsrechtliche Partnerschaft.
+
+## Solar / Photovoltaik / PV
+
+Die drei Begriffe sind keine Synonyme und haben feste Rollen. Sie stehen
+absichtlich nebeneinander — wer sie gegeneinander austauscht, verliert
+entweder den Suchbegriff oder die Präzision.
+
+| Begriff | Rolle | Wo |
+| --- | --- | --- |
+| `Solar` | Zielgruppen- und Marken-Rahmen: **wen** wir ansprechen | Slug, Header-Nav, Footer, Positionierung, Site-Title |
+| `Photovoltaik` | Produkt- und Suchbegriff: **worum** es geht | H1, Fließtext, Meta-Titles, Anchor-Texte |
+| `PV` | Branchenkürzel der Betriebe, Insider-Ton | Nur in Komposita: `PV-Anfragen`, `PV-Projekte`, `PV-Termine`, `Gewerbe-PV` |
+
+Regeln:
+
+- **Nicht `Solar` schreiben, wenn konkret die PV-Anlage gemeint ist.** `Solar`
+  ist der Oberbegriff und führt Solarthermie mit — ein anderes Gewerk, das nicht
+  Zielgruppe ist. (`Solarthermie` kommt im Theme bewusst 0× vor.)
+- `Wärmepumpe` bleibt **gleichrangig** neben `Photovoltaik`, nicht nachgeordnet.
+  `/waermepumpen-leads/` besitzt die Query `wärmepumpen leads` und wird nicht
+  durch PV-lastige Copy auf anderen Seiten verwässert.
+- Zielgruppen-Rahmen über Produktaussage ist die gewollte Schichtung, z. B. auf
+  der Money Page: Tag „Für Solar- & Wärmepumpen-Betriebe" über der H1
+  „… Photovoltaik-Anfragen …".
+
+Belege (nicht raten, nachschlagen):
+
+- `seo-research/2026-07/reports/gsc-verlauf-2026-07-20.md`,
+  Kannibalisierungs-Karte: „**Money-Page besitzt die Query**
+  `leadgenerierung photovoltaik`" → deshalb trägt die Money-Page-H1
+  `Photovoltaik` und nicht nur `Solar`.
+- `seo-research/2026-07/data/keywords-master.csv`, Cluster `a-money`:
+  Photovoltaik-Terme tragen das größte Volumen, `PV` folgt, `Solar` liegt
+  darunter. Zahlen dort nachsehen statt hier duplizieren.
 
 ## Anti-Patterns (Hard Bans)
 


### PR DESCRIPTION
Nachtrag zu #148. **Reine Dokumentationsänderung — eine Datei, kein Deploy-Effekt.** `docs/` liegt außerhalb des Theme-Pakets (`scripts/build-theme-dist.sh:33` rsynct nur `blocksy-child/`), die Live-Seite ändert sich also nicht.

## Warum

Die Money-Page-H1 führt seit #148 „Photovoltaik-Anfragen" statt nur „Anfragen". Damit stehen drei Vokabulare nebeneinander — Tag: **Solar**, H1: **Photovoltaik**, Slug/Nav/Footer: **Solar**. Das deckt sich mit dem Muster der Sub-Pages (`/cost-per-lead-photovoltaik/`, `/qualifizierte-pv-anfragen/`, `/b2b-solar-leads/` mischen alle drei bewusst nach Suchintent), war aber **nirgends geregelt**: die Preferred Terms listeten nur `Solar`, `Wärmepumpe`, `Speicher` — obwohl `Photovoltaik` 119× und `PV-` 99× im Theme vorkommen.

Ohne Regel entscheidet jede künftige Copy-Änderung die Frage neu. Genau diese Drift soll das Brand-Doc verhindern.

## Was drin steht

| Begriff | Rolle | Wo |
| --- | --- | --- |
| `Solar` | Zielgruppen- und Markenrahmen: **wen** wir ansprechen | Slug, Nav, Footer, Site-Title |
| `Photovoltaik` | Produkt- und Suchbegriff: **worum** es geht | H1, Fließtext, Meta |
| `PV` | Branchenkürzel, Insider-Ton | nur Komposita: `PV-Anfragen`, `Gewerbe-PV` |

Kernregel: **nicht „Solar" schreiben, wenn die PV-Anlage gemeint ist.** `Solar` ist der Oberbegriff und führt Solarthermie mit — ein Gewerk außerhalb der Zielgruppe, das im Theme bewusst 0× vorkommt.

`Wärmepumpe` bleibt ausdrücklich **gleichrangig**, damit PV-lastige Copy die Query-Ownership von `/waermepumpen-leads/` nicht verwässert.

## Belegt statt behauptet

- `seo-research/2026-07/reports/gsc-verlauf-2026-07-20.md`, Kannibalisierungs-Karte: „**Money-Page besitzt die Query** `leadgenerierung photovoltaik`" — genau deshalb trägt ihre H1 `Photovoltaik`.
- `seo-research/2026-07/data/keywords-master.csv`, Cluster `a-money`: Volumen im Doc referenziert statt dupliziert.

Gegengeprüft, dass die Regel den Ist-Zustand **beschreibt** statt ihm zu widersprechen: Slug, Nav, Footer, Site-Title und Money-Page-Meta erfüllen sie bereits; die einzigen freistehend wirkenden `PV`-Treffer sind `Gewerbe-PV`, also reguläre Komposita.

## Nicht angefasst

`blocksy-child/**`, Canon-Dateien, sichtbare Copy, Slug, Nav, Footer, `inc/seo-meta.php`.

## Checks

`check-german-copy.sh`, `lint-canon-drift.sh`, `lint:architecture`, `pre-deploy-smoke` — alle grün.

---
_Generated by [Claude Code](https://claude.ai/code/session_019mb21KikDP8k1ey6DiSbfq)_