### PR TITLE
b2b-solar-leads: Feindbild korrigieren — gekaufte PV-Termine statt Lead-Portale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## 2026-07
 
+### `/b2b-solar-leads/`: Feindbild korrigiert — gekaufte PV-Termine statt Lead-Portale
+
+- **Datenbefund** (`seo-research/2026-07/data/gsc/gsc-export-28d-2026-07-03.csv`, 28 Tage): Die Seite sammelt **207 Impressionen über 20 Queries, 0 Klicks**. `pv termine b2b` trägt davon **86 Impressionen (42 %) auf Position 9,65** — die einzige Seite-1-Position der gesamten Site. Zum Vergleich: Money Page 11 Impressionen, `/solar-leads-kaufen-alternative/` 34.
+- **Die geplante Suchintention existiert nicht.** `b2b leads photovoltaik` hat in `keywords-master.csv` Volumen 0 und ist der einzige Gewerbe-Term im Money-Cluster; „Termin" kommt im gesamten Research-Set kein einziges Mal vor. Semrush sieht den Longtail nicht, Google schon.
+- **Das Portal-Feindbild trug nicht.** Unter allen 20 Queries kommt Aroundhome, DAA, Check24, Wattfox oder „leads kaufen" **kein einziges Mal** vor — der Kauf-Intent sitzt auf `/solar-leads-kaufen-alternative/`. Die Seite argumentierte seitenlang gegen einen Wettbewerber, den ihre Zielgruppe nicht hat; die eigene FAQ gab das bereits zu („Wie passt das mit DAA, Aroundhome oder Check24 zusammen? — Gar nicht."). Der reale Wettbewerber im Gewerbe sind **Terminierungs-Dienstleister und Callcenter**.
+- **Umgebaut:** H1, Lead, Title und die Sektion „Warum …" argumentieren jetzt gegen eingekaufte Gewerbe-Termine. Fakten-Karte 4 stellt auf das Abrechnungsmodell der Terminierung um (Aussage über das Preismodell, keine erfundene Statistik — gleiche Vorsicht wie in #150). Sektions-Anker `#warum-b2c-funnel` → `#warum-gekaufte-termine` (keine interne oder externe Referenz darauf, geprüft).
+- **Title auf die tragende Query gezogen** (`inc/seo-meta.php`, Forced-Map): „PV-Termine B2B & Photovoltaik Leads: Gewerbe statt Masse". H1 synchron gehalten — sonst laufen Snippet und Einstieg wieder auseinander, genau der Fehler aus #150. Die H1 behält „Photovoltaik", weil `leadgenerierung photovoltaik` und `photovoltaik leads gewerbe` ebenfalls auf die Seite zeigen.
+- **Drei FAQ-Einträge zur Termin-Frage ergänzt** (wertloser vs. qualifizierter Termin, einkaufen vs. selbst aufbauen) — beantwortbar aus eigenen Kriterien, ohne erfundene Quoten oder Preise. `$faq` speist sichtbaren Text und `FAQPage`-Schema; das Schema bekommt via `wp_strip_all_tags()` Klartext, weil eine Antwort jetzt einen Link trägt.
+- **Intent-Trennung in zwei Richtungen:** Die Portal-FAQ bleibt und verlinkt Portal-Suchende auf `/solar-leads-kaufen-alternative/` (Ziel über `hu_get_solar_cluster_link_map()`). Der Eyebrow grenzt sichtbar gegen Modul-Großhandel ab — `b2b-handel pv`, `b2b solar panels` u. a. brachten 12 Impressionen ohne jede Chance.
+- `Service`-Schema nachgezogen (`name`, `alternateName`, `serviceType`, `description`). Slug, Canon-Werte, Matrix und Proof-Band aus #150 unverändert, kein CSS.
+
 ### `/b2b-solar-leads/`: Einstieg auf „pv termine b2b" ausgerichtet, unbelegte Zahlen entschärft
 
 - **Ausgangslage:** Die Seite rankt laut `seo-research/2026-07/reports/gsc-verlauf-2026-07-20.md` für `pv termine b2b` auf Position 9,7 — 45 Impressionen, **0 Klicks**, im Report als „dichtester Klick-Kandidat" markiert. Ursache im Repo auffindbar: Der Title verspricht seit #147 „PV-Termine", aber H1 und Lead erwähnten sie nicht, und der Abschnitt „PV-Termine im B2B" stand an dritter Stelle hinter zwei Kartenrastern.

--- a/blocksy-child/inc/seo-meta.php
+++ b/blocksy-child/inc/seo-meta.php
@@ -259,9 +259,13 @@ function hu_get_forced_singular_seo_map() {
 				'title'       => 'Server-Side Tracking Agentur: DSGVO, GA4 & CAPI',
 				'description' => 'Server-Side Tracking für B2B-Anfrage-Systeme: GA4, Meta CAPI und Consent Mode v2 auf eigenem Server. Attribution für qualifizierte Anfragen statt Klickberichte.',
 			],
+			// "pv termine b2b" traegt 42 % der Impressionen dieser Seite und ist
+			// die einzige Seite-1-Position der Site (Pos. 9,65) — deshalb steht
+			// die Termin-Aussage vorn. "B2B Leads" bleibt als zweiter Teil, die
+			// H1 im Template ist synchron gehalten.
 			'b2b-solar-leads' => [
-				'title'       => 'Photovoltaik B2B Leads & PV-Termine: Gewerbe statt Masse',
-				'description' => 'Gewerbliche PV-Anfragen & B2B-Termine für Hallendächer, Quartiere & PPA — exklusiv statt mehrfach verkauft. Eigenes Anfrage-System statt Portal-Leads.',
+				'title'       => 'PV-Termine B2B & Photovoltaik Leads: Gewerbe statt Masse',
+				'description' => 'Gewerbliche PV-Termine und Anfragen für Hallendächer, Quartiere & PPA: vorqualifiziert statt eingekauft. Eigenes Anfrage-System statt Termin-Provision.',
 			],
 			'eigene-leadgenerierung-vs-portale' => [
 				'title'       => 'Portal-Leads vs. eigenes System: TCO-Vergleich Solar/SHK',

--- a/blocksy-child/page-b2b-solar-leads.php
+++ b/blocksy-child/page-b2b-solar-leads.php
@@ -33,6 +33,9 @@ $cluster_url  = static function ( $slug, $fallback ) use ( $cluster_map ) {
 $qualified_url = $cluster_url( 'qualifizierte-pv-anfragen', '/qualifizierte-pv-anfragen/' );
 $cpl_url       = $cluster_url( 'cost-per-lead-photovoltaik', '/cost-per-lead-photovoltaik/' );
 $tracking_url  = $cluster_url( 'server-side-tracking-b2b', '/server-side-tracking-b2b/' );
+// Intent-Trennung: wer den Portal-Vergleich sucht, gehoert auf die
+// Kauf-Alternative — nicht auf diese Gewerbe-/Termin-Seite.
+$portal_alternative_url = $cluster_url( 'solar-leads-kaufen-alternative', '/solar-leads-kaufen-alternative/' );
 
 // ── E3-Canon ──────────────────────────────────────────────────
 $e3_canon            = function_exists( 'hu_e3_canon' ) ? hu_e3_canon() : [];
@@ -54,25 +57,29 @@ $b2b_facts = [
 	[ 'k' => 'ab 50.000 €', 'l' => 'Projektwert, ab dem sich ein eigenes Anfrage-System gegenüber Lead-Einkauf rechnet' ],
 	[ 'k' => '3 – 6 Monate', 'l' => 'typische Dauer von der Erstanfrage bis zur Freigabe, wenn ein Buying-Center entscheidet' ],
 	[ 'k' => '3 – 6', 'l' => 'Entscheider und Einflussnehmer, die in der Regel an einer gewerblichen Anfrage beteiligt sind' ],
-	[ 'k' => '0 Felder', 'l' => 'fragen B2C-Portalformulare zu Anschlussleistung, Dachstatik oder EEG-Status ab — genau den Angaben, an denen ein Gewerbeprojekt hängt' ],
+	[ 'k' => 'Pro Termin', 'l' => 'rechnen Terminierungs-Dienstleister ab — unabhängig davon, ob Anschlussleistung, Budget und Entscheider am Tisch überhaupt passen' ],
 ];
 
+// Feindbild ist bewusst der Terminierungs-Dienstleister, nicht das
+// B2C-Lead-Portal: Ein Betrieb mit Hallendach-Projekten kauft bei Aroundhome
+// oder DAA ohnehin nicht ein. Was im Gewerbe wirklich eingekauft wird, sind
+// gelegte Vertriebstermine — dagegen argumentiert diese Seite.
 $why_b2c_funnel_fails = [
 	[
-		't' => 'Falsche Sprache',
-		's' => 'B2C-Portale werben mit „Solaranlage Kosten" – ein gewerblicher Einkäufer sucht nach „PPA", „Eigenverbrauchsoptimierung" oder „Hallendach Photovoltaik". Die Anfrage ist da, das Funnel-Vokabular fehlt.',
+		't' => 'Qualifizierung kommt zu spät',
+		's' => 'Ein gekaufter Termin ist ein Kalendereintrag. Ob Anschlussleistung, Dachstatik und Investitionsabsicht zusammenpassen, klärt sich erst, wenn Ihr Vertrieb schon angereist ist – und die Stunde ist bezahlt, egal wie sie ausgeht.',
 	],
 	[
 		't' => 'Buying-Center wird ignoriert',
-		's' => 'Im Gewerbe entscheiden Geschäftsführung, CFO, Energie-Manager und Technik gemeinsam. Ein 5-Felder-Formular passt nicht zu einem Beschaffungsprozess mit drei Freigaben.',
+		's' => 'Im Gewerbe entscheiden Geschäftsführung, CFO, Energie-Manager und Technik gemeinsam. Ein Termin mit genau einer Person führt zu einer zweiten Runde, die niemand eingeplant hat.',
 	],
 	[
 		't' => 'Förder- und Finanzierungslogik fehlt',
-		's' => 'KfW-Programme, IAB, Sonderabschreibung, PPA-Modelle, Investitions-Contracting – das gehört in die Anfragestrecke, nicht in ein FAQ am Seitenende.',
+		's' => 'KfW-Programme, IAB, Sonderabschreibung, PPA-Modelle, Investitions-Contracting – das gehört in die Vorqualifizierung, nicht in ein Gespräch, in dem beide Seiten bei null anfangen.',
 	],
 	[
-		't' => 'Geteilte Datensätze',
-		's' => 'Ein Gewerbe-Lead, der bei drei Wettbewerbern liegt, wird nicht angenommen. Einkäufer wollen mit einem Anbieter sprechen, der ihre Sprache spricht – nicht im Bieterkrieg landen.',
+		't' => 'Fremde Kriterien',
+		's' => 'Ein Callcenter entscheidet, was ein „guter" Gewerbe-Termin ist – nach eigener Erfolgsquote, nicht nach Ihrer Projektschwelle. Was durchfällt und was durchgeht, bestimmen Sie nicht.',
 	],
 ];
 
@@ -144,6 +151,18 @@ $faq = [
 		'answer'   => 'Termin-Anbieter verkaufen fertig gelegte Vertriebstermine statt Datensätze – klingt bequem, verlagert aber die Qualifizierung nach hinten: Ob Anschlussleistung, Entscheiderrolle und Investitionsabsicht stimmen, zeigt sich erst im Gespräch. Für Gewerbe-PV mit Buying-Center-Logik gilt dieselbe Rechnung wie beim Lead-Kauf: Kosten pro Auftrag zählen, nicht Kosten pro Termin. Ein eigenes System qualifiziert vor dem Termin – nicht danach.',
 	],
 	[
+		'question' => 'Woran erkenne ich einen wertlosen Gewerbe-PV-Termin?',
+		'answer'   => 'An vier Dingen, die vorher hätten geklärt sein müssen: Am Tisch sitzt niemand mit Freigabekompetenz. Die Anschlussleistung passt nicht zur eigenen Projektgröße. Es gibt kein Investitionsbudget, sondern eine Interessensbekundung. Und das Dach ist statisch oder rechtlich gar nicht bespielbar. Jeder dieser Punkte lässt sich vor dem Termin abfragen — wenn die Anfragestrecke danach fragt.',
+	],
+	[
+		'question' => 'Was macht einen PV-Termin im Gewerbe überhaupt qualifiziert?',
+		'answer'   => 'Dass die Entscheidung im Termin auch fallen könnte. Konkret heißt das: Projektwert oberhalb Ihrer Schwelle, Dachfläche und Anschlussleistung bekannt, EEG- und Netzanschluss-Status geklärt, Investitionsabsicht mit Zeithorizont, und mindestens ein Teilnehmer mit Budgetverantwortung. Ein Termin, der nur eines dieser Kriterien offen lässt, ist ein Informationsgespräch — das kann sinnvoll sein, sollte aber nicht als Vertriebstermin bezahlt werden.',
+	],
+	[
+		'question' => 'Terminierung einkaufen oder selbst aufbauen — wann lohnt sich was?',
+		'answer'   => 'Einkaufen lohnt sich, wenn Sie kurzfristig Vertriebskapazität auslasten wollen und die Streuverluste einkalkuliert sind. Selbst aufbauen lohnt sich, wenn Ihre Projekte groß genug sind, dass ein einzelner Fehltermin teurer ist als die Vorqualifizierung — und wenn Sie über zwölf Monate hinaus planen. Der Unterschied ist nicht Qualität gegen Menge, sondern wer die Kriterien setzt. Was in Ihrem Fall trägt, klärt der Marktcheck.',
+	],
+	[
 		'question' => 'Warum reicht eine B2C-Solar-Seite nicht für Gewerbe-PV?',
 		'answer'   => 'B2C- und B2B-PV haben unterschiedliche Sprache, unterschiedliche Entscheider und unterschiedliche Vertragsstrukturen. Ein gewerblicher Einkäufer mit 800 kWp Anschlussleistung und PPA-Bedarf erkennt sich in einer Hausbesitzer-Seite mit „CO₂-Fußabdruck" nicht wieder. Die Anfragequalität fällt drastisch.',
 	],
@@ -157,7 +176,7 @@ $faq = [
 	],
 	[
 		'question' => 'Wie passt das mit DAA, Aroundhome oder Check24 zusammen?',
-		'answer'   => 'Gar nicht. Diese Portale liefern überwiegend B2C-Anfragen, oft mehrfach verkauft, oft ohne Projektsubstanz. Für gewerbliche PV-Anbieter sind sie weder qualitativ noch wirtschaftlich tragfähig. Das B2B-Solar-System ist explizit als Alternative gebaut.',
+		'answer'   => sprintf( 'Gar nicht — und das ist hier der Punkt. Diese Portale sind auf Privathaushalte gebaut. Ein Betrieb mit Hallendach- oder Quartiersprojekten kauft dort ohnehin nicht ein, deshalb argumentiert diese Seite auch nicht gegen Portale, sondern gegen eingekaufte Vertriebstermine. Wenn Sie den Portal-Vergleich für das Privatkundengeschäft suchen, steht er unter %s.', '<a href="' . esc_url( $portal_alternative_url ) . '">Photovoltaik- und Solar-Leads kaufen: die Alternative</a>' ),
 	],
 	[
 		'question' => 'Wie lange dauert der Aufbau eines B2B-Solar-Systems?',
@@ -175,10 +194,11 @@ $service_schema = [
 	'@context'    => 'https://schema.org',
 	'@type'       => 'Service',
 	'@id'         => trailingslashit( $page_url ) . '#service',
-	'name'        => 'B2B-Leadgenerierung für gewerbliche Photovoltaik',
-	'serviceType' => 'Anfrage-System für gewerbliche PV-, Speicher- und PPA-Anbieter',
+	'name'        => 'PV-Termine und Anfrage-Systeme für gewerbliche Photovoltaik',
+	'alternateName' => [ 'PV-Termine B2B', 'B2B Solar Leads', 'Gewerbe-PV-Anfragen' ],
+	'serviceType' => 'Vorqualifizierung und Terminlogik für gewerbliche PV-, Speicher- und PPA-Anbieter',
 	'url'         => $page_url,
-	'description' => sprintf( 'Buying-Center-taugliche Anfrage-Architektur für gewerbliche Photovoltaik-Projekte. Referenz %1$s: %2$s niedrigere Cost per Lead in %3$s.', $e3_case_label, $e3_cpl_reduction, $e3_timeframe ),
+	'description' => sprintf( 'Buying-Center-taugliche Anfrage- und Terminarchitektur für gewerbliche Photovoltaik-Projekte: Qualifizierung vor dem Termin statt Provision pro Kalendereintrag. Referenz %1$s: %2$s niedrigere Cost per Lead in %3$s.', $e3_case_label, $e3_cpl_reduction, $e3_timeframe ),
 	'provider'    => [ '@id' => home_url( '/#organization' ) ],
 	'author'      => $author_person,
 	'audience'    => [
@@ -206,7 +226,9 @@ foreach ( $faq as $faq_item ) {
 		'name'           => $faq_item['question'],
 		'acceptedAnswer' => [
 			'@type' => 'Answer',
-			'text'  => $faq_item['answer'],
+			// Sichtbare Antwort kann Markup tragen; das Schema bekommt Klartext,
+			// damit JSON-LD und sichtbarer Text dieselbe Aussage transportieren.
+			'text'  => wp_strip_all_tags( $faq_item['answer'] ),
 		],
 	];
 }
@@ -218,17 +240,22 @@ get_header();
 
 	<section class="hu-intercept__hero" id="hero" aria-labelledby="hu-b2b-hero-title">
 		<div class="hu-intercept__container">
-			<p class="hu-intercept__eyebrow">Gewerbliche Photovoltaik · Speicher · PPA</p>
+			<?php
+			// Scope-Abgrenzung im Eyebrow: die Seite zieht laut GSC auch
+			// Grosshandels-Queries ("b2b-handel pv", "b2b solar panels").
+			// Der Zusatz sortiert diesen Intent sichtbar aus.
+			?>
+			<p class="hu-intercept__eyebrow">Gewerbliche Photovoltaik · Speicher · PPA — kein Modul-Großhandel</p>
 			<?php
 			// H1 nimmt den Meta-Title auf ("Photovoltaik B2B Leads & PV-Termine"),
 			// damit der Einstieg das SERP-Versprechen einlöst. "B2B Solar Leads"
 			// bleibt vorn — das ist das rankende Asset.
 			?>
 			<h1 class="hu-intercept__title" id="hu-b2b-hero-title">
-				B2B Solar Leads &amp; PV-Termine für gewerbliche Projekte ab 50.000 €
+				PV-Termine im B2B: eigene Photovoltaik-Anfragen statt eingekaufter Termine
 			</h1>
 			<p class="hu-intercept__lead">
-				Gewerbliche Photovoltaik braucht keine B2C-Leadportale und keine eingekauften Termine. Sie braucht eine Anfrage-Architektur, die <strong>Buying-Center</strong>, <strong>lange Sales-Zyklen</strong> und <strong>komplexe Förderlogik</strong> abbildet – und die qualifiziert, <em>bevor</em> ein Termin im Kalender steht.
+				Gekaufte Gewerbe-Termine verlagern die Qualifizierung dorthin, wo sie am teuersten ist: in den Termin selbst. Gewerbliche Photovoltaik braucht eine Anfrage-Architektur, die <strong>Buying-Center</strong>, <strong>lange Sales-Zyklen</strong> und <strong>komplexe Förderlogik</strong> abbildet – und die qualifiziert, <em>bevor</em> Ihr Vertrieb anreist. Gebaut für Projekte <strong>ab 50.000 €</strong>.
 			</p>
 			<?php get_template_part( 'template-parts/seo-subpage-byline', null, [ 'template_path' => __FILE__ ] ); ?>
 			<div class="hu-intercept__cta">
@@ -272,7 +299,7 @@ get_header();
 				</div>
 			</dl>
 			<p class="hu-b2b-proof__note">
-				Ein realer Fall über <?php echo esc_html( $e3_timeframe ); ?>, eigener Anfrageweg statt Portal-Leads — dokumentiert,
+				Ein realer Fall über <?php echo esc_html( $e3_timeframe ); ?>, eigener Anfrageweg statt eingekaufter Nachfrage — dokumentiert,
 				keine pauschale Übertragbarkeitsgarantie.
 			</p>
 		</div>
@@ -326,9 +353,10 @@ get_header();
 		</div>
 	</section>
 
-	<section class="hu-intercept__why" id="warum-b2c-funnel" aria-labelledby="hu-b2b-why-title">
+	<?php // Anker umbenannt (vorher #warum-b2c-funnel): keine interne oder externe Referenz darauf, geprueft. ?>
+	<section class="hu-intercept__why" id="warum-gekaufte-termine" aria-labelledby="hu-b2b-why-title">
 		<div class="hu-intercept__container">
-			<h2 class="hu-intercept__h2" id="hu-b2b-why-title">Warum klassische B2C-Funnel im Gewerbe scheitern</h2>
+			<h2 class="hu-intercept__h2" id="hu-b2b-why-title">Warum eingekaufte Gewerbe-Termine scheitern</h2>
 			<div class="hu-intercept__grid hu-intercept__grid--four">
 				<?php foreach ( $why_b2c_funnel_fails as $item ) : ?>
 					<article class="hu-intercept__card">
@@ -397,7 +425,8 @@ get_header();
 				<?php foreach ( $faq as $item ) : ?>
 					<details class="hu-intercept__faq-item">
 						<summary class="hu-intercept__faq-q"><?php echo esc_html( $item['question'] ); ?></summary>
-						<p class="hu-intercept__faq-a"><?php echo esc_html( $item['answer'] ); ?></p>
+						<?php // wp_kses_post: eine Antwort traegt einen kontextuellen Link (Intent-Trennung). ?>
+						<p class="hu-intercept__faq-a"><?php echo wp_kses_post( $item['answer'] ); ?></p>
 					</details>
 				<?php endforeach; ?>
 			</div>


### PR DESCRIPTION
Folgt auf #150. Diesmal keine Politur, sondern eine Korrektur der Ausrichtung — ausgelöst durch die Frage, ob es die Suchintention „B2B Solar Leads" überhaupt gibt.

## Datenbefund

`seo-research/2026-07/data/gsc/gsc-export-28d-2026-07-03.csv`, 28 Tage: **207 Impressionen über 20 Queries, 0 Klicks.**

| Query | Impr. | Pos. |
| --- | --- | --- |
| **`pv termine b2b`** | **86** (42 %) | **9,65** |
| `photovoltaik b2b lösung` | 61 | 40,7 |
| `leadgenerierung photovoltaik` | 14 | 67,3 |
| `b2b-handel pv` / `b2b photovoltaik handel` / `b2b solar panels` … | 12 | 23–67 |

Zum Vergleich: Money Page 11 Impressionen, `/solar-leads-kaufen-alternative/` 34. Die Seite ist die **stärkste Solar-Seite der Site** — und `pv termine b2b` ist die **einzige Seite-1-Position**, die es überhaupt gibt.

## Zwei Dinge stimmten nicht

**1. Die geplante Suchintention existiert nicht.** `b2b leads photovoltaik` hat in `keywords-master.csv` **Volumen 0** und ist der einzige Gewerbe-Term im Money-Cluster. „Termin" kommt im gesamten Research-Set **kein einziges Mal** vor. Semrush sieht den Longtail nicht, Google schon.

**2. Das Portal-Feindbild trug nicht.** Unter allen 20 Queries kommt Aroundhome, DAA, Check24, Wattfox oder „leads kaufen" **kein einziges Mal** vor — der Kauf-Intent sitzt auf `/solar-leads-kaufen-alternative/`. Die Seite argumentierte seitenlang gegen einen Wettbewerber, den ihre Zielgruppe nicht hat. Die eigene FAQ gab das längst zu:

> „Wie passt das mit DAA, Aroundhome oder Check24 zusammen? — **Gar nicht.**"

Der reale Wettbewerber im Gewerbe sind **Terminierungs-Dienstleister und Callcenter**.

## Umbau

- **H1, Lead, Title und die „Warum …"-Sektion** argumentieren jetzt gegen eingekaufte Gewerbe-Termine. Anker `#warum-b2c-funnel` → `#warum-gekaufte-termine` (keine interne oder externe Referenz darauf, geprüft).
- **Fakten-Karte 4** stellt auf das Abrechnungsmodell der Terminierung um — eine Aussage über das **Preismodell**, keine erfundene Statistik. Gleiche Vorsicht wie in #150.
- **Title auf die tragende Query gezogen**: „PV-Termine B2B & Photovoltaik Leads: Gewerbe statt Masse". H1 synchron — sonst laufen Snippet und Einstieg wieder auseinander, genau der Fehler aus #150. Die H1 behält `Photovoltaik`, weil auch `leadgenerierung photovoltaik` und `photovoltaik leads gewerbe` auf die Seite zeigen.
- **Drei FAQ-Einträge zur Termin-Frage** (wertloser vs. qualifizierter Termin, einkaufen vs. selbst aufbauen) — beantwortbar aus eigenen Kriterien, **ohne erfundene Quoten oder Preise**. Das Schema bekommt via `wp_strip_all_tags()` Klartext, weil eine Antwort jetzt einen Link trägt.
- **Intent-Trennung in zwei Richtungen:** Die Portal-FAQ bleibt (sie ist ehrlich) und verlinkt Portal-Suchende auf `/solar-leads-kaufen-alternative/`. Der Eyebrow grenzt sichtbar gegen Modul-Großhandel ab — `b2b-handel pv`, `b2b solar panels` u. a. brachten 12 Impressionen ohne jede Chance.
- `Service`-Schema nachgezogen (`name`, `alternateName`, `serviceType`, `description`).

## Nicht angefasst

Slug, Canon-Werte, Matrix und Proof-Band aus #150, `/solar-leads-kaufen-alternative/` (behält die Portal-Argumentation, hat den einzigen Klick im Cluster). Kein CSS.

## Checks

`lint:php`, `pre-deploy-smoke`, `check-german-copy`, `lint-canon-drift`, `lint-e3-canon`, `lint:architecture` — grün. Gegenprobe „keine neuen unbelegten Zahlen": einzige neue Zahl im Diff ist `50.000 €`, die etablierte eigene Fit-Schwelle. Anonymität geprüft.

**Nach dem Deploy:** Indexierung beantragen — Template-Änderungen bewegen `post_modified` nicht.

**Wirkungsmessung** (nächster GSC-Export in 2–4 Wochen): nicht die Position — die steht schon bei 9,65 — sondern **die ersten Klicks auf `pv termine b2b`**, und ob die Großhandels-Impressionen zurückgehen.

---
_Generated by [Claude Code](https://claude.ai/code/session_019mb21KikDP8k1ey6DiSbfq)_