### PR TITLE
Solar-LP: Founding-Cohort-Chip aus dem Trust-Strip entfernen

### DIFF
--- a/blocksy-child/page-solar-waermepumpen-leadgenerierung.php
+++ b/blocksy-child/page-solar-waermepumpen-leadgenerierung.php
@@ -69,7 +69,6 @@ $trust_items = [
 	'Hardcoded WordPress · kein Page-Builder',
 	'1:1 Senior · keine Junior-Kette',
 	'Marktcheck · Fit-Befund in 48 h',
-	sprintf( '%s · %d/%d Plätze', $founding_label, $founding_open, $founding_seats ),
 ];
 
 // 01 / Status quo — drei Kostenkarten (Creme)


### PR DESCRIPTION
Der Chip "Founding Cohort 2026 · 3/3 Plätze" war das letzte Element der Vertrauensleiste. Er faellt raus; die uebrigen sechs Signale bleiben unveraendert.


Claude-Session: https://claude.ai/code/session_01QwmHz8YN3sQjwXMHaWCFVj