### PR TITLE
WGOS-Bausteine aus dem Index nehmen: noindex, follow + raus aus der Sitemap

### DIFF
--- a/blocksy-child/inc/seo-meta.php
+++ b/blocksy-child/inc/seo-meta.php
@@ -786,6 +786,26 @@ function hu_get_noindex_follow_slugs() {
 }
 
 /**
+ * Return post types that should stay noindex but keep passing link equity.
+ *
+ * `wgos_asset`: WGOS ist als Angebot eingestellt (Hard Ban in
+ * docs/standards/BRAND_AND_COPY.md), /wgos/ ist noindex. Die 32 Baustein-
+ * Unterseiten waren es nicht — der CPT ist `public` mit
+ * `exclude_from_search => false` registriert und hatte keine Robots-Regel.
+ * Ergebnis laut GSC-Coverage-Export vom 2026-07-28: 32 der 72 indexierten URLs
+ * gehoerten diesem Framework, ohne eine einzige Impression, teils auf denselben
+ * Themen wie die Money-Pages (server-side-tracking, local-seo, cwv-optimierung).
+ * `follow` bleibt, weil Glossar- und Cluster-Seiten dorthin verlinken.
+ *
+ * @return array<int, string>
+ */
+function hu_get_noindex_follow_post_types() {
+	return [
+		'wgos_asset',
+	];
+}
+
+/**
  * Resolve the effective robots directive for a singular post/page.
  *
  * @param int $post_id Post ID.
@@ -808,6 +828,7 @@ function hu_get_singular_robots_context( $post_id ) {
 	$is_noindex_nofollow = in_array( $template, hu_get_noindex_nofollow_templates(), true )
 		|| in_array( $slug, hu_get_noindex_nofollow_slugs(), true );
 	$is_noindex_follow   = in_array( $slug, hu_get_noindex_follow_slugs(), true )
+		|| in_array( (string) get_post_type( $post_id ), hu_get_noindex_follow_post_types(), true )
 		|| $acf_noindex
 		|| $legacy_noindex;
 
@@ -1490,6 +1511,23 @@ add_filter( 'wp_sitemaps_posts_query_args', function ( $args, $post_type ) {
 
 	return $args;
 }, 10, 2 );
+
+/**
+ * Drop noindex post types from the core sitemap entirely.
+ *
+ * Ein Sitemap-Eintrag sagt "crawl mich", der noindex-Header sagt das Gegenteil.
+ * Fuer `wgos_asset` faellt damit ein ganzer Post-Type raus statt einzelner IDs.
+ *
+ * @param array<string, WP_Post_Type> $post_types Public post type objects.
+ * @return array<string, WP_Post_Type>
+ */
+add_filter( 'wp_sitemaps_post_types', function ( $post_types ) {
+	foreach ( hu_get_noindex_follow_post_types() as $type ) {
+		unset( $post_types[ $type ] );
+	}
+
+	return $post_types;
+} );
 
 /**
  * Keep native taxonomy sitemaps focused on curated category archives.


### PR DESCRIPTION
## Warum PR statt direkt auf main

Nach der Entscheidungsregel in `CLAUDE.md`: Das Ergebnis ist auf der Live-Seite **nicht** sichtbar — Robots-Meta und Sitemap sind unsichtbare Suchsignale. Damit ist der Diff das einzige Review.

## Befund

GSC-Coverage-Export vom 2026-07-28: **32 der 72 indexierten URLs** liegen unter `/wgos-assets/`. 44 % des Index gehören einem Framework, das laut `docs/standards/BRAND_AND_COPY.md` unter Hard Bans steht und nicht mehr verkauft wird.

Die Sperre war halb gesetzt: `/wgos/` steht in `hu_get_noindex_nofollow_slugs()`, die Unterseiten nicht. Der CPT `wgos_asset` ist mit `'public' => true` und `'exclude_from_search' => false` registriert (`wgos-assets.php:875-882`) und hatte keine Robots-Regel — die Hülle war zu, der Inhalt offen.

## Warum das nicht neutral ist

- **Null Leistung.** Keine einzige Impression in beiden GSC-Exporten.
- **Dünn.** Median rund 1.340 Zeichen je Registry-Eintrag.
- **Themenüberschneidung mit Money-Pages:**

| WGOS-Seite | Konkurriert mit |
|---|---|
| `/wgos-assets/server-side-tracking/`, `/consent-mode-v2/` | `/server-side-tracking-b2b/` — 229 Impr., Pos. 59 |
| `/wgos-assets/technical-seo-audit/`, `/local-seo/`, `/cwv-optimierung/` | `/wordpress-agentur-hannover/` — 459 Impr., Pos. 22 |
| `/wgos-assets/ga4-event-blueprint/` | `/ga4-tracking-setup/` |

**Nicht behauptet wird ein Kausalzusammenhang** zum Hannover-Rückgang. Der Index-Sprung lag am 2026-07-11 (+46 an einem Tag), der Positionsverlust im selben Zeitraum — das ist zeitliche Nähe, kein Beweis.

## Umsetzung

- `hu_get_noindex_follow_post_types()` als Post-Type-Pendant zu den vorhandenen Slug-Listen; `wgos_asset` liefert jetzt `noindex, follow`.
- **`follow` bleibt bewusst:** Glossar- und Cluster-Seiten verlinken auf die Bausteine, die interne Linkkraft soll erhalten bleiben.
- `wp_sitemaps_post_types` entfernt den Post-Type komplett aus `wp-sitemap.xml` — Sitemap-Eintrag und noindex-Header wären sonst widersprüchliche Signale.

Eine Datei, 38 Zeilen, keine Löschung. Rückgängig machen heißt: Eintrag aus der Liste entfernen.

## Erwartete Wirkung

Index fällt von 72 auf rund 40. Kein Rückschritt — es verschwinden 32 URLs ohne Impressionen.

## Verifikation nach dem Merge

1. View-Source auf `/wgos-assets/technical-seo-audit/` → `<meta name="robots" content="noindex, follow">`
2. `wp-sitemap.xml` → kein `wgos_asset`-Eintrag mehr
3. Gegenprobe: `/server-side-tracking-b2b/` muss weiterhin `index, follow` liefern

---
_Generated by [Claude Code](https://claude.ai/code/session_01FSC7sr5yMux6xBiKqWUhtq)_