### PR TITLE
Whitelabel-Barrierefreiheit absichern

### DIFF
--- a/blocksy-child/assets/css/whitelabel.css
+++ b/blocksy-child/assets/css/whitelabel.css
@@ -9,6 +9,13 @@
 	background: var(--nx-bg-deep);
 }
 
+/* Das Parent-Theme liefert zwei eigene Skip-Links. Auf dieser Route bleibt
+   nur der Link der geschlossenen Seitennavigation in der Tab-Reihenfolge. */
+body.page-template-page-whitelabel-retainer > .skip-to-content,
+body.page-template-page-whitelabel-retainer > .skip-link {
+	display: none !important;
+}
+
 html {
 	scroll-padding-top: 6rem;
 }
@@ -115,7 +122,7 @@ html {
 .wl-site-header__nav a {
 	padding-inline: clamp(0.7rem, 1.2vw, 1rem);
 	border: 1px solid transparent;
-	color: var(--nx-text-dim);
+	color: var(--nx-text-secondary);
 }
 
 .wl-site-header__nav a:hover {
@@ -150,11 +157,19 @@ html {
 	outline-offset: 3px;
 }
 
+.wl-page .nx-btn--ghost {
+	border-color: hsl(30 6% 90% / 0.42) !important;
+}
+
+.wl-page .nx-btn--ghost:hover {
+	border-color: hsl(23 60% 60%) !important;
+}
+
 .wl-page-footer {
 	padding: 1.5rem 1.25rem;
 	border-top: 1px solid var(--nx-border);
 	background: var(--nx-bg-deep);
-	color: var(--nx-text-dim);
+	color: var(--nx-text-secondary);
 }
 
 .wl-page-footer__inner {
@@ -180,7 +195,7 @@ html {
 	gap: 0.6rem;
 	min-height: 44px;
 	padding: 0.65rem 1rem;
-	border: 1px solid hsl(23 50% 47% / 0.4);
+	border: 1px solid hsl(23 60% 62% / 0.85);
 	border-radius: 999px;
 	background: linear-gradient(180deg, hsl(30 8% 13% / 0.94), hsl(28 8% 8% / 0.94));
 	box-shadow:
@@ -336,7 +351,7 @@ html {
 	font-weight: 600;
 	letter-spacing: 0.22em;
 	text-transform: uppercase;
-	color: var(--accent);
+	color: hsl(23 50% 70%);
 }
 
 .wl-eyebrow::before {
@@ -558,7 +573,7 @@ html {
 	border-bottom: 1px solid hsl(30 10% 100% / 0.06);
 }
 
-.wl-flow__kicker { color: var(--accent); font-family: var(--nx-font-mono); }
+.wl-flow__kicker { color: hsl(23 50% 70%); font-family: var(--nx-font-mono); }
 
 .wl-flow__list {
 	list-style: none;
@@ -832,7 +847,7 @@ html {
 	font-family: var(--nx-font-mono);
 	font-size: 0.7rem;
 	letter-spacing: 0.04em;
-	color: var(--accent);
+	color: hsl(23 50% 70%);
 	background: hsl(23 50% 47% / 0.08);
 	border: 1px solid hsl(23 50% 47% / 0.25);
 	border-radius: 6px;
@@ -902,7 +917,7 @@ html {
 .wl-contract-card__num {
 	font-family: var(--nx-font-mono);
 	font-size: 0.78rem;
-	color: var(--accent);
+	color: hsl(23 50% 70%);
 	letter-spacing: 0.1em;
 }
 
@@ -1006,7 +1021,7 @@ html {
 .wl-proof__disclaimer {
 	margin: 1.5rem 0 0;
 	font-size: 0.83rem;
-	color: hsl(30 6% 90% / 0.5);
+	color: hsl(30 6% 90% / 0.62);
 	text-align: center;
 }
 
@@ -1157,7 +1172,7 @@ html {
 .wl-entry-card__tag {
 	font-family: var(--nx-font-mono);
 	font-size: 0.72rem;
-	color: var(--accent);
+	color: hsl(23 50% 70%);
 	letter-spacing: 0.16em;
 	text-transform: uppercase;
 }
@@ -1215,7 +1230,7 @@ html {
 	font-size: 0.66rem;
 	text-transform: uppercase;
 	letter-spacing: 0.14em;
-	color: hsl(30 6% 90% / 0.5);
+	color: hsl(30 6% 90% / 0.62);
 	margin: 0 0 0.2rem;
 }
 
@@ -1290,7 +1305,7 @@ html {
 	font-size: 0.66rem;
 	letter-spacing: 0.12em;
 	text-transform: uppercase;
-	color: hsl(30 6% 90% / 0.5);
+	color: hsl(30 6% 90% / 0.62);
 }
 
 .wl-test-sprint-details__item dd {
@@ -1514,6 +1529,31 @@ html {
 		text-align: center;
 	}
 
+	.wl-founder__grid,
+	.wl-founder__body,
+	.wl-founder__chips,
+	.wl-founder__chips li {
+		min-width: 0;
+		max-width: 100%;
+	}
+
+	.wl-founder__media {
+		width: min(300px, 100%);
+		max-width: 100%;
+	}
+
+	.wl-founder__chips .wl-chip {
+		max-width: 100%;
+		white-space: normal;
+		overflow-wrap: anywhere;
+	}
+
+	.wl-tech__code-body {
+		overflow-x: hidden;
+		white-space: pre-wrap;
+		overflow-wrap: anywhere;
+	}
+
 	.wl-sticky-cta {
 		padding-inline: 0.75rem;
 	}
@@ -1584,7 +1624,7 @@ html {
 	gap: 0.25rem;
 	margin: 0;
 	padding: 0.3rem;
-	border: 1px solid hsl(30 10% 100% / 0.12);
+	border: 1px solid hsl(30 6% 90% / 0.42);
 	border-radius: 999px;
 	background: hsl(30 5% 9% / 0.85);
 	box-shadow:
@@ -1623,7 +1663,7 @@ html {
 	color: var(--nx-text);
 	background: linear-gradient(180deg, hsl(23 50% 47% / 0.32), hsl(23 50% 40% / 0.22));
 	box-shadow:
-		0 0 0 1px hsl(23 50% 47% / 0.55) inset,
+		0 0 0 2px hsl(23 60% 60%) inset,
 		0 6px 18px -8px hsl(23 50% 40% / 0.55);
 }
 
@@ -1635,7 +1675,7 @@ html {
 .wl-mode__hint {
 	margin: 0;
 	font-size: 0.8rem;
-	color: hsl(30 6% 90% / 0.5);
+	color: hsl(30 6% 90% / 0.62);
 }
 
 /* Panels als Grid-Stack: beide teilen dieselbe Zelle, der Wrapper reserviert
@@ -1843,7 +1883,7 @@ thead .wl-compare__col--hl {
 		font-weight: 600;
 		text-transform: uppercase;
 		letter-spacing: 0.12em;
-		color: hsl(30 6% 90% / 0.48);
+		color: hsl(30 6% 90% / 0.62);
 	}
 
 	.wl-compare__cell--hl {
@@ -2009,7 +2049,7 @@ thead .wl-compare__col--hl {
 	flex-shrink: 0;
 	width: 22px;
 	height: 22px;
-	border: 1px solid hsl(23 50% 47% / 0.4);
+	border: 1px solid hsl(23 60% 60%);
 	border-radius: 50%;
 	transition: transform 0.2s ease, background-color 0.2s ease;
 }
@@ -2179,13 +2219,13 @@ thead .wl-compare__col--hl {
 	line-height: 1.4;
 	color: hsl(30 6% 90% / 0.88);
 	background: hsl(30 10% 100% / 0.04);
-	border: 1px solid hsl(30 10% 100% / 0.1);
+	border: 1px solid hsl(30 6% 90% / 0.42);
 	border-radius: 12px;
 	transition: border-color 0.15s ease, background-color 0.15s ease;
 }
 
 .wl-fitcheck__opt:hover {
-	border-color: hsl(23 50% 47% / 0.45);
+	border-color: hsl(23 60% 60%);
 	background: hsl(23 50% 47% / 0.06);
 }
 
@@ -2200,7 +2240,11 @@ thead .wl-compare__col--hl {
 	color: hsl(23 60% 78%);
 }
 
-.wl-fitcheck__result:focus { outline: none; }
+.wl-fitcheck__result:focus {
+	border-radius: 12px;
+	outline: 3px solid hsl(23 60% 60%);
+	outline-offset: 6px;
+}
 
 .wl-fitcheck__result-note {
 	font-size: 0.9rem;

--- a/blocksy-child/assets/js/whitelabel.js
+++ b/blocksy-child/assets/js/whitelabel.js
@@ -39,6 +39,21 @@
 		});
 	}
 
+	// ─── FAQ: nativen <details>-Zustand mit explizitem ARIA spiegeln ───
+	// <summary> bleibt das native Tastaturziel (Enter/Leertaste); die Attribute
+	// machen Zustand und kontrollierte Antwort zusätzlich im DOM nachvollziehbar.
+	document.querySelectorAll('.wl-faq__item').forEach(function (item) {
+		var summary = item.querySelector('.wl-faq__summary');
+		if (!summary) {
+			return;
+		}
+		var syncExpanded = function () {
+			summary.setAttribute('aria-expanded', item.open ? 'true' : 'false');
+		};
+		item.addEventListener('toggle', syncExpanded);
+		syncExpanded();
+	});
+
 	// ─── Fit-Check: 3 Klickfragen → Termin ───
 	// Rein clientseitig, keine Speicherung: Antworten sind Enum-Werte und
 	// fließen nur in die bestehende data-track-Delegation plus als Vorlage

--- a/blocksy-child/page-whitelabel-retainer.php
+++ b/blocksy-child/page-whitelabel-retainer.php
@@ -339,6 +339,7 @@ $faq_items = [
 $tech_bullets = [
 	'Individuelle WordPress-Templates für vorhandene Layouts',
 	'Performance-Optimierung: Core Web Vitals, kritischer Renderpfad',
+	'Barrierefreiheit: semantisches HTML, Fokusreihenfolge, Kontraste nach WCAG 2.2 AA und vollständige Tastaturbedienung — die technischen Voraussetzungen, an denen Standard-Themes regelmäßig scheitern.',
 	'Versionierter Code, dokumentierte Übergabe',
 ];
 
@@ -380,7 +381,7 @@ $fitcheck_steps = [
 ];
 ?>
 
-<main id="main" class="site-main wl-page" data-track-section="whitelabel_proof" tabindex="-1">
+<div class="wl-page" data-track-section="whitelabel_proof">
 
 	<noscript>
 		<style>
@@ -818,7 +819,7 @@ $fitcheck_steps = [
 						<span class="wl-tech__code-dot wl-tech__code-dot--g"></span>
 						<span class="wl-tech__code-file">inc/enqueue.php</span>
 					</figcaption>
-<pre class="wl-tech__code-body"><span class="wl-tech__c">// Bedarfsgesteuertes Asset-Loading pro Template</span>
+<pre class="wl-tech__code-body" tabindex="-1"><span class="wl-tech__c">// Bedarfsgesteuertes Asset-Loading pro Template</span>
 <span class="wl-tech__k">if</span> ( is_page_template( <span class="wl-tech__s">'page-whitelabel.php'</span> ) ) {
     hu_enqueue_css( <span class="wl-tech__s">'whitelabel'</span>, <span class="wl-tech__s">'whitelabel.css'</span>, [ <span class="wl-tech__s">'design-system'</span> ] );
     hu_enqueue_js(  <span class="wl-tech__s">'whitelabel'</span>,  <span class="wl-tech__s">'whitelabel.js'</span> );
@@ -850,11 +851,24 @@ window.dataLayer.push({
 			<div class="wl-faq reveal-stagger">
 				<?php foreach ( $faq_items as $item ) : ?>
 					<details class="wl-faq__item">
-						<summary class="wl-faq__summary" data-track-action="faq_whitelabel_open" data-track-label="<?php echo esc_attr( $item['key'] ); ?>" data-track-category="engagement" data-track-section="faq">
+						<summary
+							id="wl-faq-summary-<?php echo esc_attr( $item['key'] ); ?>"
+							class="wl-faq__summary"
+							aria-expanded="false"
+							aria-controls="wl-faq-answer-<?php echo esc_attr( $item['key'] ); ?>"
+							data-track-action="faq_whitelabel_open"
+							data-track-label="<?php echo esc_attr( $item['key'] ); ?>"
+							data-track-category="engagement"
+							data-track-section="faq"
+						>
 							<span class="wl-faq__q"><?php echo esc_html( $item['q'] ); ?></span>
 							<span class="wl-faq__icon" aria-hidden="true"></span>
 						</summary>
-						<div class="wl-faq__answer">
+						<div
+							id="wl-faq-answer-<?php echo esc_attr( $item['key'] ); ?>"
+							class="wl-faq__answer"
+							aria-labelledby="wl-faq-summary-<?php echo esc_attr( $item['key'] ); ?>"
+						>
 							<p><?php echo esc_html( $item['a'] ); ?></p>
 						</div>
 					</details>
@@ -911,8 +925,9 @@ window.dataLayer.push({
 						<?php endforeach; ?>
 					</div>
 
-					<div class="wl-fitcheck__result" data-fitcheck-result tabindex="-1">
-						<p class="wl-fitcheck__result-note" data-fitcheck-note aria-live="polite" hidden>Aus euren Antworten ergibt sich eine passende nächste Option.</p>
+					<div class="wl-fitcheck__result" data-fitcheck-result role="group" aria-labelledby="wl-fitcheck-result-title" tabindex="-1">
+						<h3 id="wl-fitcheck-result-title" class="wl-visually-hidden">Ergebnis des Fit-Checks</h3>
+						<p class="wl-fitcheck__result-note" data-fitcheck-note role="status" aria-live="polite" aria-atomic="true" hidden>Aus euren Antworten ergibt sich eine passende nächste Option.</p>
 						<div class="wl-cta__actions">
 							<a href="<?php echo esc_url( $whitelabel_fit_url ); ?>" class="nx-btn nx-btn--primary" data-fitcheck-book data-track-action="cta_whitelabel_fitcheck_book" data-track-category="lead_gen" data-track-section="fitcheck_result">
 								Termin wählen (30 Min, direkt mit mir)
@@ -946,7 +961,7 @@ window.dataLayer.push({
 		</div>
 	</div>
 
-</main>
+	</div>
 
 <?php
 if ( function_exists( 'blocksy_after_current_template' ) ) {


### PR DESCRIPTION
## Ziel

Die noindex White-Label-Seite wurde zuerst manuell und browsergestützt auf die vereinbarten Barrierefreiheitskriterien geprüft und korrigiert. Erst danach wurde Barrierefreiheit als zusätzlicher Punkt in die bestehende technische Leistungsliste aufgenommen.

## Audit-Ergebnis

1. **Struktur und Semantik**
   - genau eine H1; Überschriftenhierarchie ohne Sprünge
   - Landmarks für Header, Navigation, Hauptinhalt und Footer vorhanden
   - das versehentlich verschachtelte zweite `main` wurde entfernt
   - Angebotskarten und Inhalte nutzen `article`, `ul`/`ol`, `dl` und Tabelle statt reiner Div-Strukturen
   - dekorative Elemente sind für assistive Technik ausgeblendet; das informative Portrait behält seinen Alternativtext

2. **Tastaturbedienung**
   - Tab-Reihenfolge folgt der sichtbaren Reihenfolge; keine Fokusfalle und kein positiver `tabindex`
   - individuelle, kontrastreiche Fokuszustände sind sichtbar
   - FAQ funktioniert nativ mit Enter und Leertaste; `aria-expanded` wird mit dem `details`-Zustand synchronisiert, `aria-controls` und Antwortzuordnung sind gesetzt
   - Fit-Check vollständig mit Tastatur geprüft: Fokus wandert von Schrittüberschrift zu Optionen, weiter zum nächsten Schritt und anschließend zum Ergebnis samt erster Folgeaktion
   - das dekorative Code-Beispiel ist nicht mehr versehentlich Teil der Tab-Reihenfolge

3. **Skip-Link**
   - ein seitenlokaler Skip-Link bleibt als erstes Tastaturziel erhalten, wird erst bei Fokus sichtbar und springt zum Hauptinhalt
   - zwei redundante Skip-Links des Parent-Themes werden ausschließlich auf dieser Route aus der Tab-Reihenfolge entfernt

4. **Kontraste nach AA-Schwellen**
   - Karten-Fließtext: **5,82:1 → 5,82:1** (bereits ausreichend)
   - kleine kupferfarbene Labels: **4,24:1 → 8,43:1**
   - orange Preisangabe: **10,42:1 → 10,42:1** (bereits ausreichend)
   - gedimmte Navigation/Footer-Texte: **3,15:1 → 6,44:1**
   - kleine Metadaten/Disclaimer: **4,45–4,49:1 → 6,09–6,26:1**
   - Bedienelement-Rand: **1,31:1 → 3,51:1**
   - Ghost-Button-Rand: **1,21:1 → 3,49:1**
   - Fokusindikator: fehlte am Fit-Ergebnis; jetzt **7,13:1**
   - ausschließlich Helligkeit/Deckkraft vorhandener Warmgrau- und Kupfertöne angepasst

5. **Formulare und Fit-Check**
   - die Seite enthält keine Texteingabe- oder Pflichtfelder und keine Platzhalter
   - die Darstellungswahl besteht aus beschrifteten nativen Radio-Inputs
   - der Fit-Check nutzt beschriftete Buttons; sein Ergebnis besitzt eine programmatische Überschrift und wird per `role=status`, `aria-live=polite` und `aria-atomic=true` angekündigt
   - Pflichtfeld- und Fehlermeldungsanforderungen sind mangels entsprechender Felder nicht anwendbar

6. **Bewegung**
   - bei `prefers-reduced-motion: reduce` werden Reveal-Inhalte sofort sichtbar; Scroll-Reveal, Statuspunkt- und FAQ-Animationen bleiben aus

7. **Zoom und schmale Viewports**
   - bei 200 % Zoom kein globaler horizontaler Überlauf
   - bei 320 px kein abgeschnittener Nutzinhalt und kein globales horizontales Scrollen
   - Founder-Chips und Codebeispiel umbrechen innerhalb des Viewports

## Korrekturen nach Datei

- `blocksy-child/page-whitelabel-retainer.php`
  - zweite `main`-Landmark entfernt
  - FAQ-Zuordnungen und ARIA-Zustände ergänzt
  - Fit-Check-Ergebnis als fokussierbare, live angekündigte Ergebnisgruppe ausgezeichnet
  - dekoratives Codebeispiel aus der Tab-Reihenfolge genommen
  - exakten Leistungspunkt in die vorhandene technische Liste aufgenommen
- `blocksy-child/assets/css/whitelabel.css`
  - redundante Parent-Skip-Links seitenlokal ausgeblendet
  - bestehende Farbwerte für Text, Labels, Ränder und Fokus aufgehellt
  - Fit-Check-Fokus sichtbar gemacht
  - 320-px-Umbruch für Founder-Inhalt und Codebeispiel abgesichert
- `blocksy-child/assets/js/whitelabel.js`
  - FAQ-`aria-expanded` mit dem nativen `details`-Zustand synchronisiert

## Leistungsergänzung

Der vorgegebene Text wurde unverändert als zusätzlicher Listeneintrag auf derselben Ebene wie technisches SEO/Performance ergänzt. Keine neue Karte, Sektion oder Zusatzformulierung.

## Nicht behoben / Grenzen

Bei den vereinbarten Prüfungen blieb nach den Korrekturen kein reproduzierbarer Verstoß offen. Die Browserprüfung erfolgte gegen den lokalen Template-Harness; Einflüsse späterer Plugins, Editor-Inhalte oder eines künftigen Deployments sind damit nicht abgedeckt. Es wird keine vollständige Konformität für andere Kundenprojekte zugesichert.

## Inhaltskontrolle

- `noindex, follow` für die Route aktiv
- keine sichtbare E3-Nennung
- einziger Angebotspreis: **590 € netto**
- die sichtbare Kennzahl **150 € → 22 €** ist ein anonymisierter Kosten-pro-Anfrage-Beleg, kein Angebotspreis
- kein Stunden- oder Tagessatz

## Validierung

- `php -l blocksy-child/page-whitelabel-retainer.php`
- `node --check blocksy-child/assets/js/whitelabel.js`
- `npm run lint:php`
- `npm run lint:architecture`
- `npm run build:theme`
- `bash scripts/lint-e3-canon.sh`
- `bash scripts/check-german-copy.sh`
- `bash scripts/lint-canon-drift.sh`
- `git diff --check`
- Headless-Chromium: Accessibility Tree, echte Tastatureingaben, reduzierte Bewegung, 320 px und 200 % Zoom

Kein Merge und kein Deploy.