### PR TITLE
Checkfox-Schluss-CTA um Portrait ergänzen

### DIFF
--- a/blocksy-child/assets/css/checkfox-decision.css
+++ b/blocksy-child/assets/css/checkfox-decision.css
@@ -670,6 +670,10 @@
 }
 
 .hu-checkfox__final {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) minmax(210px, 280px);
+	gap: clamp(30px, 5vw, 58px);
+	align-items: center;
 	margin-bottom: 60px;
 	padding-inline: clamp(22px, 5vw, 56px);
 	border: 1px solid rgba(221, 150, 104, 0.46);
@@ -679,7 +683,11 @@
 		var(--checkfox-surface);
 }
 
-.hu-checkfox__final > p:not(.hu-checkfox__eyebrow) {
+.hu-checkfox__final-copy {
+	min-width: 0;
+}
+
+.hu-checkfox__final-copy > p:not(.hu-checkfox__eyebrow) {
 	max-width: 68ch;
 	color: var(--checkfox-muted);
 }
@@ -705,6 +713,23 @@
 
 .hu-checkfox__deeper a:hover {
 	color: var(--checkfox-copper-light);
+}
+
+.hu-checkfox__final-portrait {
+	width: min(100%, 280px);
+	padding: 8px;
+	justify-self: end;
+	border: 1px solid rgba(221, 150, 104, 0.48);
+	border-radius: 50%;
+	background: rgba(8, 11, 13, 0.72);
+	box-shadow: 0 24px 54px rgba(0, 0, 0, 0.32);
+}
+
+.hu-checkfox__final-portrait img {
+	display: block;
+	width: 100%;
+	height: auto;
+	border-radius: 50%;
 }
 
 .hu-checkfox + .nexus-author-bio {
@@ -784,6 +809,15 @@
 
 	.hu-cpo-calculator__portal-results {
 		grid-template-columns: 1fr;
+	}
+
+	.hu-checkfox__final {
+		grid-template-columns: 1fr;
+	}
+
+	.hu-checkfox__final-portrait {
+		width: min(72vw, 240px);
+		justify-self: center;
 	}
 
 }

--- a/blocksy-child/template-parts/checkfox-decision-cockpit.php
+++ b/blocksy-child/template-parts/checkfox-decision-cockpit.php
@@ -16,6 +16,9 @@ $analysis_url = function_exists( 'hu_get_request_analysis_url' ) ? hu_get_reques
 $tco_url      = home_url( '/eigene-leadgenerierung-vs-portale/' );
 $solar_url    = home_url( '/solar-leads-kaufen-alternative/' );
 $heatpump_url = home_url( '/waermepumpen-leads/' );
+$portrait_url = function_exists( 'nexus_asset_url' )
+	? nexus_asset_url( 'img/hasim-portrait.png' )
+	: get_stylesheet_directory_uri() . '/assets/img/hasim-portrait.png';
 $reading_time = function_exists( 'nexus_get_reading_time' ) ? (int) nexus_get_reading_time() : 0;
 
 $contract_items = [
@@ -281,14 +284,26 @@ $editorial_content = str_replace(
 	</section>
 
 	<section class="hu-checkfox__final" id="finaler-marktcheck" data-track-section="checkfox_final">
-		<p class="hu-checkfox__eyebrow">Nächster Schritt</p>
-		<h2>Mit Ihren Zahlen in den Marktcheck.</h2>
-		<p>Wenn Preis pro Anfrage, Abschlussquote und Vertriebsaufwand eingetragen sind, lässt sich der Kanal im nächsten Schritt mit Region, Projektwert und Portalabhängigkeit einordnen.</p>
-		<a class="hu-checkfox__button hu-checkfox__button--primary" href="<?php echo esc_url( $analysis_url ); ?>" data-track-action="cta_checkfox_final_marktcheck" data-track-category="lead_gen" data-track-section="checkfox_final">Marktcheck mit meinen Zahlen starten</a>
-		<nav class="hu-checkfox__deeper" aria-label="Sekundäre Vertiefung">
-			<a href="<?php echo esc_url( $tco_url ); ?>" data-track-action="checkfox_deeper_tco" data-track-category="internal_link" data-track-section="checkfox_final">TCO-Vergleich Portal vs. eigenes System</a>
-			<a href="<?php echo esc_url( $solar_url ); ?>" data-track-action="checkfox_deeper_solar" data-track-category="internal_link" data-track-section="checkfox_final">Photovoltaik-Anfragen vertiefen</a>
-			<a href="<?php echo esc_url( $heatpump_url ); ?>" data-track-action="checkfox_deeper_heatpump" data-track-category="internal_link" data-track-section="checkfox_final">Wärmepumpen-Anfragen vertiefen</a>
-		</nav>
+		<div class="hu-checkfox__final-copy">
+			<p class="hu-checkfox__eyebrow">Nächster Schritt</p>
+			<h2>Mit Ihren Zahlen in den Marktcheck.</h2>
+			<p>Wenn Preis pro Anfrage, Abschlussquote und Vertriebsaufwand eingetragen sind, lässt sich der Kanal im nächsten Schritt mit Region, Projektwert und Portalabhängigkeit einordnen.</p>
+			<a class="hu-checkfox__button hu-checkfox__button--primary" href="<?php echo esc_url( $analysis_url ); ?>" data-track-action="cta_checkfox_final_marktcheck" data-track-category="lead_gen" data-track-section="checkfox_final">Marktcheck mit meinen Zahlen starten</a>
+			<nav class="hu-checkfox__deeper" aria-label="Sekundäre Vertiefung">
+				<a href="<?php echo esc_url( $tco_url ); ?>" data-track-action="checkfox_deeper_tco" data-track-category="internal_link" data-track-section="checkfox_final">TCO-Vergleich Portal vs. eigenes System</a>
+				<a href="<?php echo esc_url( $solar_url ); ?>" data-track-action="checkfox_deeper_solar" data-track-category="internal_link" data-track-section="checkfox_final">Photovoltaik-Anfragen vertiefen</a>
+				<a href="<?php echo esc_url( $heatpump_url ); ?>" data-track-action="checkfox_deeper_heatpump" data-track-category="internal_link" data-track-section="checkfox_final">Wärmepumpen-Anfragen vertiefen</a>
+			</nav>
+		</div>
+		<div class="hu-checkfox__final-portrait">
+			<img
+				src="<?php echo esc_url( $portrait_url ); ?>"
+				alt="Haşim Üner"
+				width="1254"
+				height="1254"
+				loading="lazy"
+				decoding="async"
+			>
+		</div>
 	</section>
 </article>


### PR DESCRIPTION
## Änderung

- Das vorhandene Portrait von Haşim Üner wird im abschließenden Checkfox-Marktcheck-CTA eingebunden.
- Desktop zeigt das Portrait rechts im CTA; mobil steht es zentriert unter dem CTA-Inhalt.
- Feste Bildmaße, `loading="lazy"` und `decoding="async"` vermeiden Layout-Sprünge und unnötige Initiallast.

## Warum

Das Checkfox-Cockpit wurde bereits über #166 nach `main` gemergt. Der danach ergänzte Portrait-Commit fehlte noch auf `main`. Dieser PR enthält deshalb ausschließlich den Portrait-Nachtrag auf Basis des aktuellen `main`-Stands.

## Auswirkung

Nur der Schluss-CTA der Checkfox-Einordnung ändert sich visuell. Das bestehende, bereits deploybare Theme-Asset wird wiederverwendet; keine zusätzliche Bilddatei wird ausgeliefert.

## Prüfungen

- Pre-Deploy-Smoke: SAFE TO PUSH
- `npm run lint:php`
- PHPStan, vollständiger Lauf
- `npm run lint:architecture`
- `npm run build:theme`
- `git diff --check`