### PR TITLE
CSS-Motion-Guard einfuehren und transition:all aufloesen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,9 @@ jobs:
       - name: Check E3 canon
         run: bash scripts/lint-e3-canon.sh
 
+      - name: Check CSS motion rules
+        run: bash scripts/lint-css-motion.sh
+
       - name: Check visible German copy
         run: bash scripts/check-german-copy.sh "${{ steps.refs.outputs.base }}" "${{ steps.refs.outputs.head }}"
 

--- a/agents/skills/b2b-design-system/SKILL.md
+++ b/agents/skills/b2b-design-system/SKILL.md
@@ -90,6 +90,14 @@ Full specs in `references/motion.md`. Core rules:
 - Total animation budget per page load: < 2 seconds cumulative.
 - Respect `prefers-reduced-motion`.
 - CSS + Intersection Observer only. No React/GSAP. <50KB JS for animations.
+- Never `transition: all` — name the properties that actually change.
+- Never bare `ease-in` — entrances use `var(--ease-default)`, exits `ease-out`.
+
+Run the guard before pushing CSS; CI runs it too:
+
+```bash
+bash scripts/lint-css-motion.sh
+```
 
 ## WordPress / Blocksy Notes
 
@@ -118,5 +126,6 @@ Full specs in `references/motion.md`. Core rules:
 - [ ] Mobile: Responsive, CTA accessible without scrolling
 - [ ] Performance: CSS-first animations, web fonts <= 2 weights
 - [ ] Motion: prefers-reduced-motion respected, total < 2s
+- [ ] Motion guard green: `bash scripts/lint-css-motion.sh`
 - [ ] No anti-patterns from Hard Bans list
 - [ ] Dark/Light: Both modes tested

--- a/agents/skills/b2b-design-system/references/motion.md
+++ b/agents/skills/b2b-design-system/references/motion.md
@@ -594,3 +594,28 @@ function toggleTheme() {
 6. **Intersection Observer > scroll listeners**: Never use `scroll` event for reveal animations.
 7. **`prefers-reduced-motion`**: Always respected. No exceptions.
 8. **No animation on mobile that isn't on desktop**: Consistency across devices.
+9. **Never `transition: all`**: It animates every property that ever changes,
+   including layout and paint work nobody asked for. Name the properties.
+10. **Never bare `ease-in`**: It accelerates from a standstill, so entering
+    elements look sluggish. Use `var(--ease-default)`; `ease-out` for exits.
+
+---
+
+## Enforcement
+
+Rules 4, 7, 9, and 10 are checked by `scripts/lint-css-motion.sh`, which runs in
+CI and can be run by hand:
+
+```bash
+bash scripts/lint-css-motion.sh
+```
+
+It fails the build on `transition: all`, on bare `ease-in`, and on a stylesheet
+that animates without a `prefers-reduced-motion` block. Files that predate the
+guard sit in `BASELINE_REDUCED_MOTION` inside the script — that list may shrink,
+never grow.
+
+Slow transitions, hardcoded timings, and layout-property transitions are
+reported without failing, because a 900ms scroll reveal is a choice and a 200ms
+hover is not. Mark a deliberate exception with `lint-css-motion: allow` on the
+line or the line above it.

--- a/blocksy-child/assets/css/audit-results.css
+++ b/blocksy-child/assets/css/audit-results.css
@@ -894,7 +894,8 @@
   background: rgba(255, 255, 255, 0.03) !important;
   border: 1px solid rgba(255, 255, 255, 0.08) !important;
   border-radius: 10px !important;
-  transition: all 0.2s ease !important;
+  transition: background var(--duration-normal) var(--ease-default),
+              border-color var(--duration-normal) var(--ease-default) !important;
   cursor: pointer;
 }
 
@@ -912,7 +913,8 @@
   border: 2px solid rgba(255, 255, 255, 0.2) !important;
   background: rgba(255, 255, 255, 0.04) !important;
   cursor: pointer;
-  transition: all 0.2s ease !important;
+  transition: background var(--duration-normal) var(--ease-default),
+              border-color var(--duration-normal) var(--ease-default) !important;
   flex-shrink: 0;
   position: relative;
   vertical-align: middle;
@@ -1014,7 +1016,8 @@
 .deepdive-form-wrap .ff-btn-prev {
   padding: 0.85rem 1.5rem !important;
   font-size: 0.88rem !important;
-  transition: all 0.2s ease !important;
+  transition: background var(--duration-normal) var(--ease-default),
+              color var(--duration-normal) var(--ease-default) !important;
   cursor: pointer;
 }
 

--- a/blocksy-child/assets/css/design-system.css
+++ b/blocksy-child/assets/css/design-system.css
@@ -147,7 +147,6 @@
         border-color var(--duration-fast) var(--ease-default);
     --transition-transform: transform var(--duration-normal) var(--ease-default);
     --transition-shadow: box-shadow var(--duration-normal) var(--ease-default);
-    --transition-all: all var(--duration-normal) var(--ease-default);
 
     /* --- Repo compatibility aliases --- */
     --nx-gold: var(--accent);
@@ -862,7 +861,11 @@ h1, h2, h3, h4, h5, h6 {
     background: var(--nx-bg-glass-light);
     border: 1px solid var(--nx-border);
     color: var(--nx-text);
-    transition: all var(--nx-duration) var(--nx-ease);
+    transition: transform var(--nx-duration) var(--nx-ease),
+                background var(--nx-duration) var(--nx-ease),
+                color var(--nx-duration) var(--nx-ease),
+                border-color var(--nx-duration) var(--nx-ease),
+                box-shadow var(--nx-duration) var(--nx-ease);
     cursor: pointer;
     padding: 0;
     line-height: 0;
@@ -919,7 +922,11 @@ h1, h2, h3, h4, h5, h6 {
     border-radius: 50px;
     border: 1px solid var(--nx-border);
     box-shadow: var(--nx-shadow);
-    transition: all 0.4s var(--nx-ease-spring);
+    transition: width var(--duration-slow) var(--nx-ease-spring),
+                padding-left var(--duration-slow) var(--nx-ease-spring),
+                border-radius var(--duration-slow) var(--nx-ease-spring),
+                border-color var(--duration-slow) var(--nx-ease-spring),
+                background var(--duration-slow) var(--nx-ease-spring);
     width: 60px;
     overflow: hidden;
     white-space: nowrap;
@@ -963,7 +970,9 @@ h1, h2, h3, h4, h5, h6 {
     background: var(--nx-dot-base);
     border-radius: 50%;
     flex-shrink: 0;
-    transition: all var(--nx-duration) var(--nx-ease);
+    transition: background var(--nx-duration) var(--nx-ease),
+                box-shadow var(--nx-duration) var(--nx-ease),
+                transform var(--nx-duration) var(--nx-ease);
     box-shadow: 0 0 0 2px transparent;
 }
 
@@ -982,7 +991,8 @@ h1, h2, h3, h4, h5, h6 {
 .nx-sidenav__text {
     opacity: 0;
     transform: translateX(10px);
-    transition: all var(--nx-duration) var(--nx-ease);
+    transition: opacity var(--nx-duration) var(--nx-ease),
+                transform var(--nx-duration) var(--nx-ease);
 }
 
 .nx-sidenav:hover .nx-sidenav__text {

--- a/blocksy-child/assets/css/homepage-cro.css
+++ b/blocksy-child/assets/css/homepage-cro.css
@@ -1326,7 +1326,9 @@
     font-size: 0.9rem;
     font-weight: 600;
     cursor: pointer;
-    transition: all 0.2s ease;
+    transition: border-color var(--duration-normal) var(--ease-default),
+                background var(--duration-normal) var(--ease-default),
+                color var(--duration-normal) var(--ease-default);
     text-align: center;
     min-height: 44px;
 }
@@ -1355,7 +1357,9 @@
     color: var(--nx-text-secondary);
     font-size: 0.95rem;
     line-height: 1.6;
-    transition: all 0.3s ease;
+    transition: border-color var(--duration-slow) var(--ease-default),
+                background var(--duration-slow) var(--ease-default),
+                color var(--duration-slow) var(--ease-default);
 }
 .cro-diagnose__result.is-active {
     border-style: solid;

--- a/blocksy-child/assets/css/seo.css
+++ b/blocksy-child/assets/css/seo.css
@@ -11,7 +11,13 @@
   --glass-bg: rgba(255, 255, 255, 0.03);
   --glass-border: rgba(255, 255, 255, 0.1);
   --radius-lg: 16px;
-  --transition: all 0.3s ease;
+  /* Covers every property the six call sites actually change. */
+  --transition: opacity var(--duration-slow) var(--ease-default),
+                color var(--duration-slow) var(--ease-default),
+                background var(--duration-slow) var(--ease-default),
+                border-color var(--duration-slow) var(--ease-default),
+                box-shadow var(--duration-slow) var(--ease-default),
+                transform var(--duration-slow) var(--ease-default);
   --success: #10b981;
   color: #fff;
   font-family: var(--nx-font, 'Figtree', sans-serif);

--- a/scripts/lint-css-motion.sh
+++ b/scripts/lint-css-motion.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+
+# Motion guard for the child theme stylesheets.
+#
+# Hard rules cover what is unambiguously wrong and fail the build. Judgement
+# calls — a 900ms scroll reveal is a choice, not a bug — land in the drift
+# report, which stays visible without blocking a release.
+#
+# Suppress a deliberate exception with "lint-css-motion: allow" on the
+# offending line or the line above it.
+
+set -euo pipefail
+
+CSS_DIR="${1:-blocksy-child/assets/css}"
+
+# A transition above this reads as lag on a discrete state change. Reveal
+# choreography legitimately runs longer, so this only reports.
+SLOW_TRANSITION_MS=600
+
+if [[ ! -d "${CSS_DIR}" ]]; then
+  echo "Motion guard failed: no CSS directory at ${CSS_DIR}" >&2
+  exit 1
+fi
+
+# Files that animate without a prefers-reduced-motion block. New files must not
+# join this list — shrink it instead. Same idea as phpstan-baseline.neon.
+BASELINE_REDUCED_MOTION=(
+  "audit-results.css"
+  "audit.css"
+  "blog-header.css"
+  "blog-notify.css"
+  "case-study.css"
+  "cluster-pillar.css"
+  "deep-dive.css"
+  "footer-cta.css"
+  "glossary.css"
+  "seo-cockpit-admin.css"
+  "single.css"
+  "site-header.css"
+  "waermepumpen-leads.css"
+  "wgos.css"
+)
+
+failures=0
+
+report_rule() {
+  local label="$1"
+  local guidance="$2"
+  local matches="$3"
+
+  if [[ -n "${matches}" ]]; then
+    echo "FAIL: ${label}"
+    echo "      ${guidance}"
+    printf '%s\n' "${matches}" | sed 's/^/      /'
+    echo
+    failures=$((failures + 1))
+  else
+    echo "OK: ${label}"
+  fi
+}
+
+# Emits "file:line:text" for lines matching $1, skipping allow-listed lines.
+scan() {
+  local pattern="$1"
+
+  awk -v pattern="${pattern}" '
+    FNR == 1 { prev = "" }
+    {
+      line = $0
+      if (line ~ pattern && line !~ /lint-css-motion: allow/ && prev !~ /lint-css-motion: allow/) {
+        text = line
+        sub(/^[ \t]+/, "", text)
+        printf "%s:%d:%s\n", FILENAME, FNR, text
+      }
+      prev = line
+    }
+  ' "${CSS_DIR}"/*.css
+}
+
+# Emits "file:line:ms:text" for transitions whose longest time value exceeds
+# $1 milliseconds. Regex cannot do this: "0.2s" contains the substring "2s",
+# so the numbers have to be parsed and compared. The value pattern also has to
+# accept ".15s", which carries no leading zero — hence the [0-9.] class rather
+# than an optional dot, which mawk skips over.
+#
+# transition-delay is deliberately excluded: a long delay is how staged reveal
+# choreography is written, not a slow animation.
+scan_slow_transitions() {
+  local limit_ms="$1"
+
+  awk -v limit="${limit_ms}" '
+    FNR == 1 { prev = "" }
+    {
+      line = $0
+      if (line ~ /transition(-duration)?[ \t]*:/ && line !~ /lint-css-motion: allow/ && prev !~ /lint-css-motion: allow/) {
+        rest = line
+        worst = 0
+        while (match(rest, /[0-9.]+(ms|s)/)) {
+          token = substr(rest, RSTART, RLENGTH)
+          rest = substr(rest, RSTART + RLENGTH)
+          value = token + 0
+          if (token !~ /ms$/) {
+            value = value * 1000
+          }
+          if (value > worst) {
+            worst = value
+          }
+        }
+        if (worst > limit) {
+          text = line
+          sub(/^[ \t]+/, "", text)
+          printf "%s:%d:%dms:%s\n", FILENAME, FNR, worst, text
+        }
+      }
+      prev = line
+    }
+  ' "${CSS_DIR}"/*.css
+}
+
+echo
+echo "=== Motion guard: hard rules ==="
+
+# "all" animates every property that ever changes, including layout and paint
+# work nobody asked for. Name the properties instead.
+report_rule \
+  "No 'transition: all'" \
+  "Enumerate the properties that actually change." \
+  "$(scan "transition[^:]*:[[:space:]]*all[[:space:]]")"
+
+# ease-in accelerates from a standstill, so entering elements look sluggish.
+# ease-out and ease-in-out are unaffected.
+report_rule \
+  "No bare 'ease-in' easing" \
+  "Use var(--ease-default) for entrances, ease-out for exits." \
+  "$(scan "ease-in([^-]|$)")"
+
+missing_reduced_motion=""
+for file in "${CSS_DIR}"/*.css; do
+  name="$(basename "${file}")"
+
+  if ! grep -qE "transition:|@keyframes|animation:" "${file}"; then
+    continue
+  fi
+
+  if grep -q "prefers-reduced-motion" "${file}"; then
+    continue
+  fi
+
+  baselined=0
+  for known in "${BASELINE_REDUCED_MOTION[@]}"; do
+    if [[ "${name}" == "${known}" ]]; then
+      baselined=1
+      break
+    fi
+  done
+
+  if [[ "${baselined}" -eq 0 ]]; then
+    missing_reduced_motion+="${file}"$'\n'
+  fi
+done
+
+report_rule \
+  "Animated files honour prefers-reduced-motion" \
+  "Add a @media (prefers-reduced-motion: reduce) block, or extend the baseline with a reason." \
+  "${missing_reduced_motion%$'\n'}"
+
+# A baselined file that grew a reduced-motion block should leave the list, so
+# the baseline can only shrink.
+stale_baseline=""
+for known in "${BASELINE_REDUCED_MOTION[@]}"; do
+  path="${CSS_DIR}/${known}"
+
+  if [[ ! -f "${path}" ]]; then
+    stale_baseline+="${known} (file is gone)"$'\n'
+  elif grep -q "prefers-reduced-motion" "${path}"; then
+    stale_baseline+="${known} (now compliant)"$'\n'
+  fi
+done
+
+report_rule \
+  "Reduced-motion baseline is current" \
+  "Drop these entries from BASELINE_REDUCED_MOTION in this script." \
+  "${stale_baseline%$'\n'}"
+
+echo
+echo "=== Motion guard: drift report (never fails) ==="
+
+slow="$(scan_slow_transitions "${SLOW_TRANSITION_MS}")"
+slow_count="$(printf '%s' "${slow}" | grep -c . || true)"
+
+hardcoded_count="$(scan "transition:[^;]*[0-9](\\.[0-9]+)?(m?s)" | grep -v "var(--" | grep -c . || true)"
+layout_count="$(scan "transition:[^;]*(width|height|top|left|right|bottom|margin|padding)[^;]*[0-9]" | grep -c . || true)"
+
+echo "Transitions over ${SLOW_TRANSITION_MS}ms:                    ${slow_count}"
+if [[ -n "${slow}" ]]; then
+  printf '%s\n' "${slow}" | sed 's/^/  /'
+fi
+echo "Transitions with hardcoded timing, no token:  ${hardcoded_count}"
+echo "Transitions on layout properties:             ${layout_count}"
+echo
+echo "These shrink by editing CSS, not by editing this script."
+echo
+
+if [[ "${failures}" -gt 0 ]]; then
+  echo "Motion guard failed with ${failures} rule violation(s)." >&2
+  exit 1
+fi
+
+echo "Motion guard passed."

--- a/scripts/validate-architecture.sh
+++ b/scripts/validate-architecture.sh
@@ -108,6 +108,7 @@ require_text ".github/workflows/ci.yml" 'id:[[:space:]]*refs' "CI computes diff 
 require_text ".github/workflows/ci.yml" 'bash scripts/validate-architecture\.sh' "CI runs architecture validation"
 require_text ".github/workflows/ci.yml" 'bash scripts/lint-canon-drift\.sh.*steps\.refs\.outputs\.base.*steps\.refs\.outputs\.head' "CI runs canon drift guard with diff refs"
 require_text ".github/workflows/ci.yml" 'bash scripts/lint-e3-canon\.sh' "CI runs E3 canon guard"
+require_text ".github/workflows/ci.yml" 'bash scripts/lint-css-motion\.sh' "CI runs CSS motion guard"
 require_text ".github/workflows/ci.yml" 'bash scripts/check-german-copy\.sh.*steps\.refs\.outputs\.base.*steps\.refs\.outputs\.head' "CI runs German copy guard with diff refs"
 
 echo


### PR DESCRIPTION
Die Motion-Regeln standen laengst in references/motion.md, geprueft hat sie nichts. scripts/lint-css-motion.sh schliesst die Luecke: harte Regeln gegen transition:all, blankes ease-in und fehlendes prefers-reduced-motion, dazu ein Drift-Report fuer langsame Transitions, harte Timings und Transitions auf Layout-Properties.

Der Report faellt bewusst nicht durch: ein 900ms-Scroll-Reveal ist eine Entscheidung, ein 200ms-Hover nicht. Die 14 Dateien, die heute ohne prefers-reduced-motion animieren, stehen als Baseline im Skript - nach dem Muster von phpstan-baseline.neon, und die Liste darf nur schrumpfen.

Die zehn transition:all-Stellen zaehlen jetzt die Properties auf, die tatsaechlich wechseln, und ziehen Dauer und Kurve aus den Tokens. Bei .nx-sidenav waren es fuenf Properties - genau deshalb stand da "all". Der ungenutzte Token --transition-all faellt weg.


Claude-Session: https://claude.ai/code/session_011ho1fMSriE591vUkzWQp4B