### PR TITLE
Skill-Luecken schliessen statt Fremdskills stapeln

### DIFF
--- a/agents/skills/CONTEXT.md
+++ b/agents/skills/CONTEXT.md
@@ -34,8 +34,14 @@ Scope: `agents/skills/`.
 | `registry-release-qa` | Glossar-/WGOS-Registry Release-QA | registry, glossary, wgos assets, release qa |
 | `navigation-migration` | Header-, Menü- und Admin-Follow-up | navigation, menu, header, admin notice |
 | `homepage-proof-monitoring` | Homepage-Proof-Monitoring | homepage proof, proof metrics, monitoring |
-| `wordpress-performance-marketing` | Vollaudit aus SEO, CRO und Tracking | full audit, performance marketing, tracking |
+| `wordpress-performance-marketing` | Repo-weiter Sweep aus SEO, CRO und Tracking | full audit, performance marketing, tracking |
+| `route-conversion-review` | Eine einzelne Route komplett, in fester Linsen-Reihenfolge | route prüfen, seite komplett, vollcheck, durchleuchten |
+| `copy-anatomy` | Fremde Copy in Struktur zerlegen, Muster extrahieren | teardown, copy analyse, wettbewerberseite, vorbild |
 | `blog-seo-ux-optimizer` | Blog-Index, Kategorien, Single-Posts, interne Links, alte Positionierung | blog, category, article, author bio, related content, stale copy |
+
+Horizontal vs. vertikal: `wordpress-performance-marketing` prüft viele Seiten
+auf eine Domäne, `route-conversion-review` eine Seite auf alle Domänen. Wer
+beide Beschreibungen aufweicht, macht die Auswahl zum Ratespiel.
 
 Core rule: When a task touches `blocksy-child/assets/css/`, `blocksy-child/assets/js/`, or PHP templates that emit frontend HTML, load `modern-web-guidance` before implementation and retrieve only task-matching guides.
 

--- a/agents/skills/copy-anatomy/SKILL.md
+++ b/agents/skills/copy-anatomy/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: copy-anatomy
+description: Fremde Copy in ihre Struktur zerlegen und das übertragbare Muster extrahieren — Abschnittsfolge, Beweisführung, Einwandlogik, CTA-Ökonomie. Use wenn eine Wettbewerber-, Portal- oder Vorbildseite analysiert werden soll ("Was macht die Seite gut?", "Zerleg mir die Landingpage von X", "Warum konvertiert das?"), oder wenn vor einem Copy-Auftrag ein Strukturvorbild fehlt. Nicht zum Schreiben von Copy (seo-conversion-copywriting) und nicht für eigene Routen (route-conversion-review).
+---
+
+# Copy Anatomy
+
+Starke Seiten funktionieren wegen ihrer Struktur, nicht wegen ihrer Sätze. Der
+Skill trennt beides: er nimmt das Gerüst mit und lässt den Text liegen.
+
+## Abgrenzung
+
+- Eigene Routen bewertet `route-conversion-review`.
+- Copy schreibt `seo-conversion-copywriting` — dieser Skill liefert ihm nur
+  das Strukturvorbild.
+- Reine SEO-Wettbewerbsanalyse (Rankings, Keywords, Sichtbarkeit) gehört zu
+  `seo-agent`.
+
+## Load First
+
+1. `docs/standards/BRAND_AND_COPY.md` — sonst lässt sich nicht beurteilen, was
+   übertragbar ist und was an der Positionierung scheitert
+2. `seo-research/2026-07/data/competitors.md` — Kandidaten und Einordnung
+
+Quelle holen per WebFetch, oder der Nutzer fügt die Copy ein.
+
+## Harte Regel
+
+**Muster ja, Text nein.** Kein Satz und keine Halbzeile aus der Quelle geht in
+einen Vorschlag. Der Output beschreibt, *welche Aufgabe* ein Abschnitt erfüllt,
+nie *mit welchen Worten*. Wer eine Formulierung zitiert, tut das erkennbar als
+Beleg der Analyse und markiert sie als Zitat.
+
+Zwei Gründe, und der zweite wiegt schwerer: übernommene Copy ist fremde
+Leistung, und sie trägt die Positionierung des Wettbewerbers mit. Eine
+Portal-Landingpage verkauft Bequemlichkeit — genau das Gegenteil unserer
+Positionierung „eigene Nachfrage-Infrastruktur statt Portal-Zukauf".
+
+Wörtliche Kundenformulierungen aus solchen Quellen sind **keine** Voice of
+Customer und gehören nicht in `docs/standards/VOICE_OF_CUSTOMER.md`. Das ist
+Marktsprache, formuliert von einer fremden Marketingabteilung.
+
+## Zerlegung
+
+Je Abschnitt der Quelle:
+
+1. `Position` — wievielter Abschnitt, über oder unter dem Fold
+2. `Aufgabe` — was der Abschnitt im Kopf des Lesers erledigen soll
+3. `Mittel` — Behauptung, Beweis, Vergleich, Zahl, Bild, Angst, Entlastung
+4. `Übergang` — welche Frage er offenlässt, die der nächste Abschnitt aufgreift
+
+Danach über die ganze Seite:
+
+- `Beweisführung` — worauf stützt sich der Anspruch, und an welcher Stelle
+  kommt der Beweis relativ zur Forderung?
+- `Einwandlogik` — welche Einwände werden vorweggenommen, welche ignoriert,
+  und was verrät das über die Zielgruppe?
+- `CTA-Ökonomie` — was verlangt jeder CTA, was gibt er zurück, und wie oft
+  wechselt die Seite das Angebot?
+- `Auslassung` — was fehlt auffällig. Das ist oft der verwertbarste Befund.
+
+## Deliver
+
+- `Struktur` — die Abschnittsfolge als Tabelle: Position, Aufgabe, Mittel
+- `Was trägt` — Muster, die unabhängig von Branche und Text funktionieren
+- `Was nicht übertragbar ist` — mit Begründung aus `BRAND_AND_COPY.md`,
+  namentlich Hard Bans und der Diagnose-vor-Pitch-Reihenfolge
+- `Auslassungen` — was die Quelle nicht tut und warum das eine Lücke sein könnte
+- `Übergabe` — welcher Abschnitt welcher Route als Strukturvorbild dient,
+  als Auftrag für `seo-conversion-copywriting` formuliert
+
+Kein Fließtextessay. Wer die Tabelle liest, kennt die Seite.

--- a/agents/skills/route-conversion-review/SKILL.md
+++ b/agents/skills/route-conversion-review/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: route-conversion-review
+description: Vollprüfung einer einzelnen Route auf hasimuener.de in fester Reihenfolge — Angebot, CRO, Copy, SEO, interne Links, Speed. Use für Aufträge, die eine konkrete URL oder Seite komplett bewerten sollen, etwa "Prüfe /whitelabel-retainer/ komplett", "Ist die Money Page rund?", "Seite X durchleuchten". Nicht für repo-weite Sweeps über mehrere Seiten (wordpress-performance-marketing) und nicht für Einzeldomänen-Tiefe (dann direkt den Fachskill).
+---
+
+# Route Conversion Review
+
+Eine Route, alle Ebenen, immer dieselbe Reihenfolge. Der Skill bewertet nicht
+selbst — er sammelt Evidenz und ruft die Fachskills in der Reihenfolge auf, in
+der ihre Befunde aufeinander aufbauen.
+
+## Abgrenzung
+
+- `wordpress-performance-marketing` ist der **horizontale** Sweep: das ganze
+  Repo über Modi (`full`, `seo`, `cro`, …).
+- Dieser Skill ist **vertikal**: eine URL, dafür alle Ebenen.
+- Geht es nur um eine Domäne, ist der Fachskill direkt schneller.
+
+## Load First
+
+1. `AGENTS.md`
+2. `agents/skills/CONTEXT.md`
+3. `docs/standards/BRAND_AND_COPY.md`
+4. `llms.txt` für Route, Rolle und CTA-Ziel
+
+## First Command
+
+```bash
+bash agents/skills/route-conversion-review/scripts/review-route.sh /whitelabel-retainer/
+```
+
+Das Skript löst die Route auf, listet Überschriften, CTAs, Proof-Referenzen,
+harte Zahlen und eingehende Links und schließt mit einer Ampel.
+
+Zur Ampel: `ROT` ist ein P0-Kandidat, kein Urteil. Zwei Fälle entwerten sie,
+beide vor dem Report prüfen — Copy kann im WordPress-Editor liegen statt im
+Template, und ein gesperrter Begriff in einer Abgrenzung („Architektur statt
+Webdesign") ist Positionierung, kein Verstoß. Den zweiten Fall trennt das
+Skript bereits ab.
+
+## Reihenfolge der Linsen
+
+Nicht umsortieren. Jede Stufe setzt die vorherige voraus.
+
+1. `Angebot / Funnel` → `offer-funnel-intelligence`
+2. `CRO / CTA- und Proof-Hierarchie` → `wordpress-cro-content-design-audit`
+3. `Copy` → `seo-conversion-copywriting`
+4. `SEO` → `seo-agent` (routet weiter)
+5. `Interne Links` → `internal-linking-audit`
+6. `Speed` → `page-speed-audit`
+
+Angebot steht vor Copy, weil sich eine unklare Angebotslogik nicht durch Text
+reparieren lässt. Wer bei Stufe 1 einen P0 findet, schreibt keine Copy-Vorschläge
+für Stufe 3, sondern meldet den Blocker.
+
+Stufe 6 nur, wenn die Route Medien oder eigene Assets lädt.
+
+## Hard Rules
+
+- Keine Regel neu kodieren, die ein Fachskill besitzt. Dieser Skill hält die
+  Reihenfolge, nicht die Kriterien.
+- Nichts ändern ohne ausdrücklichen Auftrag. Erst der Befund, dann die Frage.
+- Zahlen ausschließlich aus `blocksy-child/inc/canon/`. Findet das Skript eine
+  Zahl ohne Canon-Referenz, ist das ein Befund, keine Kleinigkeit.
+- Auf `/whitelabel-*` gelten die dokumentierten Ausnahmen aus
+  `BRAND_AND_COPY.md`. Kernpositionierung dort nicht einfordern.
+
+## Deliver
+
+Repo-Standard, je Punkt mit Route, Ist-Problem, Geschäftsfolge, Vorschlag:
+
+- `Critical`
+- `High leverage`
+- `Polish`
+- `Manual WordPress tasks`
+- `Agent tasks / repo tasks`
+
+Jeder Punkt trägt `Repo` oder `Manual WP`. Am Ende eine Zeile, welche Linse
+nichts gefunden hat — das ist die Information, die beim nächsten Lauf Zeit spart.

--- a/agents/skills/route-conversion-review/scripts/review-route.sh
+++ b/agents/skills/route-conversion-review/scripts/review-route.sh
@@ -1,0 +1,278 @@
+#!/usr/bin/env bash
+#
+# Vollpruefung einer einzelnen Route: Template aufloesen, Inventar sammeln,
+# Hard Bans greppen, Ampel-Verdikt. Kodiert keine Bewertungsregeln — die
+# gehoeren den Fachskills, siehe SKILL.md.
+#
+# Usage: review-route.sh /whitelabel-retainer/
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$ROOT"
+
+RAW_ROUTE="${1:-}"
+
+if [[ -z "${RAW_ROUTE}" ]]; then
+  cat >&2 <<'EOF'
+Fehlt: Route.
+
+  review-route.sh /whitelabel-retainer/
+  review-route.sh /solar-waermepumpen-leadgenerierung/
+  review-route.sh /
+
+Bekannte Routen stehen in llms.txt.
+EOF
+  exit 2
+fi
+
+# /Foo/Bar/ -> foo-bar; Query und Fragment fallen weg (der Marktcheck-Anker
+# gehoert zur Money Page, nicht zu einer eigenen Route).
+SLUG="$(printf '%s' "${RAW_ROUTE}" | sed -e 's/[#?].*$//' -e 's#^/##' -e 's#/$##' | tr '[:upper:]' '[:lower:]')"
+
+# Die oeffentliche Route bleibt, was der Nutzer gefragt hat — llms.txt und die
+# Suche nach eingehenden Links muessen sie kennen. Nur das Template wird auf
+# den echten Traeger umgebogen (AGENTS.md, Sonderrouten).
+if [[ -z "${SLUG}" ]]; then
+  ROUTE="/"
+else
+  ROUTE="/${SLUG}/"
+fi
+
+CARRIER_NOTE=""
+CARRIER_SLUG="${SLUG}"
+case "${SLUG}" in
+  wordpress-agentur-hannover)
+    CARRIER_NOTE="Schatten-Wrapper. Layout und Copy liegen in page-wordpress-agentur.php — dort bearbeiten, nie im Wrapper."
+    CARRIER_SLUG="wordpress-agentur"
+    ;;
+  case-study-solar-leadgenerierung)
+    CARRIER_NOTE="Dateiname weicht vom Slug ab (Template Name: 'Case Study – Solar Leadgenerierung')."
+    CARRIER_SLUG="case-e3"
+    ;;
+  ergebnisse)
+    CARRIER_NOTE="Legacy-Dateiname aus der E-Commerce-Zeit, traegt heute den Ergebnisse-Hub."
+    CARRIER_SLUG="case-studies-e-commerce"
+    ;;
+esac
+
+if [[ -z "${CARRIER_SLUG}" ]]; then
+  TEMPLATE="blocksy-child/front-page.php"
+else
+  TEMPLATE="blocksy-child/page-${CARRIER_SLUG}.php"
+fi
+
+if [[ ! -f "${TEMPLATE}" ]]; then
+  printf 'Kein Template fuer %s gefunden (erwartet: %s).\n\n' "${RAW_ROUTE}" "${TEMPLATE}" >&2
+  printf 'Moegliche Ursachen: Route liegt im WordPress-Editor statt im Repo,\n' >&2
+  printf 'Slug weicht vom Dateinamen ab, oder die Route existiert nicht mehr.\n\n' >&2
+  # Slug und Dateiname laufen im Repo mehrfach auseinander. Der Template-Name-
+  # Header ist die verlaesslichere Spur als der Dateiname.
+  STEM="$(printf '%s' "${SLUG}" | cut -d- -f1)"
+  printf 'Templates mit passendem "Template Name"-Header:\n' >&2
+  FOUND_ANY=0
+  for f in blocksy-child/page-*.php; do
+    TN="$({ rg -m1 -o 'Template Name: (.*)' -r '$1' "$f" 2>/dev/null || true; })"
+    if [[ -n "${TN}" ]] && printf '%s' "${TN}" | rg -qi -- "${STEM}" 2>/dev/null; then
+      printf '  %-45s %s\n' "${f}" "${TN}" >&2
+      FOUND_ANY=1
+    fi
+  done
+  [[ "${FOUND_ANY}" -eq 0 ]] && printf '  (keine)\n' >&2
+
+  printf '\nPasst eines davon, gehoert der Slug in die Alias-Tabelle oben im Skript.\n' >&2
+  exit 1
+fi
+
+# White-Label ist der dokumentierte Nebenpfad: dort sind WordPress, SEO,
+# Tracking und CRO als Lieferfelder erlaubt (BRAND_AND_COPY.md).
+IS_WHITELABEL=0
+[[ "${SLUG}" == whitelabel-* ]] && IS_WHITELABEL=1
+
+printf '\n########## Route-Review: %s ##########\n' "${ROUTE}"
+printf 'Template: %s\n' "${TEMPLATE}"
+[[ -n "${CARRIER_NOTE}" ]] && printf 'Hinweis:  %s\n' "${CARRIER_NOTE}"
+[[ "${IS_WHITELABEL}" -eq 1 ]] && printf 'Regelsatz: White-Label-Nebenpfad — Lieferfeld-Ausnahmen aktiv.\n'
+
+printf '\n== Routen-Eintrag in llms.txt ==\n'
+rg -n "\(${ROUTE}\)" llms.txt 2>/dev/null \
+  || printf 'Nicht in llms.txt. Beabsichtigt (Nebenpfad) oder vergessen?\n'
+
+printf '\n== Ueberschriften-Folge ==\n'
+rg -n '<h[1-6][^>]*>' "${TEMPLATE}" 2>/dev/null \
+  | sed -E 's/<[^>]*>//g; s/[[:space:]]+/ /g' \
+  | head -40 \
+  || printf 'Keine statischen Ueberschriften — Copy vermutlich im Editor.\n'
+
+printf '\n== CTAs (data-track-action) ==\n'
+rg -n 'data-track-action="[^"]*"' -o "${TEMPLATE}" 2>/dev/null | head -30 \
+  || printf 'Keine getrackten CTAs. Auf einer konvertierenden Route ist das ein Befund.\n'
+
+printf '\n== CTA-Ziele ==\n'
+rg -n 'hu_get_[a-z_]*_url|home_url\([^)]*\)|href="[^"]*"' -o "${TEMPLATE}" 2>/dev/null \
+  | sort -u -t: -k2 | head -25 || true
+
+printf '\n== Proof-Referenzen (E3-Canon) ==\n'
+if rg -n 'hu_e3_|HU_E3_' "${TEMPLATE}" >/dev/null 2>&1; then
+  rg -n 'hu_e3_[a-z_]*|HU_E3_[A-Z_]*' -o "${TEMPLATE}" | head -20
+else
+  printf 'Keine. Zahlen auf dieser Route stammen dann nicht aus dem Canon — pruefen.\n'
+fi
+
+printf '\n== Harte Zahlen im Template ==\n'
+rg -n '[0-9]+([.,][0-9]+)?[[:space:]]*(%|€|EUR|Prozent|-fach)' "${TEMPLATE}" 2>/dev/null \
+  | head -20 || printf 'Keine.\n'
+printf -- '-> Jede Zahl muss in e3-proof-canon.php oder pricing-canon.php stehen.\n'
+
+# Die Begriffslisten gehoeren dem Canon und der Brand-Doku. Hier werden sie
+# gelesen, nie kopiert — eine Kopie driftet, und scripts/lint-canon-drift.sh
+# schlaegt zu Recht an.
+read_canon_terms() {
+  { sed -n "/'forbidden_terms'/,/]/p" blocksy-child/inc/canon/messaging-canon.php 2>/dev/null || true; } \
+    | { rg -o "^[[:space:]]*'([^']+)'," -r '$1' 2>/dev/null || true; }
+}
+
+read_brand_bans() {
+  { sed -n '/^## Anti-Patterns/,/^## [^A]/p' docs/standards/BRAND_AND_COPY.md 2>/dev/null || true; } \
+    | { rg -o '`([^`]+)`' -r '$1' 2>/dev/null || true; }
+}
+
+# Zu unspezifisch fuer einen Grep: diese Woerter haben legitime Verwendungen
+# ("Test-Sprint", "Leistungen" als White-Label-Navigation). Sie kommen in die
+# Pruef-Spalte statt auf Rot.
+AMBIGUOUS='^(Pilot|Beta|Test|Modul|Leistungen|Webdesign|WordPress Specialist|WordPress-Agentur|kostenlos)$'
+
+# Erlaubt in dokumentierter Rolle und zu haeufig, um sie jeden Lauf einzeln zu
+# pruefen: nur zaehlen. Wer sie inhaltlich pruefen will, nimmt den Fachskill.
+FREQUENT='^(WordPress|B2B)$'
+
+join_alt() { paste -sd'|' - 2>/dev/null || true; }
+
+ALL_TERMS="$( { read_canon_terms; read_brand_bans; } | sort -u)"
+BAN_PATTERN="$(printf '%s\n' "${ALL_TERMS}" | rg -v "${AMBIGUOUS}" | rg -v "${FREQUENT}" | join_alt)"
+SOFT_PATTERN="$(printf '%s\n' "${ALL_TERMS}" | rg "${AMBIGUOUS}" | join_alt)"
+FREQ_PATTERN="$(printf '%s\n' "${ALL_TERMS}" | rg "${FREQUENT}" | join_alt)"
+
+if [[ -z "${BAN_PATTERN}" ]]; then
+  printf '\nWarnung: keine Ban-Begriffe aus Canon/Brand-Doku gelesen.\n' >&2
+  BAN_PATTERN='__kein_treffer__'
+fi
+
+# Ein gesperrter Begriff in einer Abgrenzung ist Positionierung, kein Verstoss:
+# "Architektur statt Webdesign" behauptet das Gegenteil von dem, was der Ban
+# verhindern soll. Solche Zeilen nicht rot faerben, sondern getrennt ausgeben.
+NEG_PATTERN='\b([Kk]eine?[nmrs]?|[Nn]icht|statt|anstatt|weder|niemals)\b'
+
+BAN_HITS="$(rg -n "${BAN_PATTERN}" "${TEMPLATE}" 2>/dev/null || true)"
+BAN_HARD="$(printf '%s' "${BAN_HITS}" | rg -v "${NEG_PATTERN}" 2>/dev/null || true)"
+BAN_CONTRAST="$(printf '%s' "${BAN_HITS}" | rg "${NEG_PATTERN}" 2>/dev/null || true)"
+
+printf '\n== Hard Bans (BRAND_AND_COPY.md) ==\n'
+if [[ -n "${BAN_HARD}" ]]; then
+  printf '%s\n' "${BAN_HARD}" | head -20
+  printf -- '-> Interne IDs/URLs duerfen die Begriffe tragen. Sichtbare Copy nicht.\n'
+else
+  printf 'Keine Treffer.\n'
+fi
+
+if [[ -n "${BAN_CONTRAST}" ]]; then
+  printf '\n== Gesperrte Begriffe in Abgrenzung (kein Verstoss) ==\n'
+  printf '%s\n' "${BAN_CONTRAST}" | head -12
+  printf -- '-> Begriff wird verneint oder abgegrenzt. Nur pruefen, ob die\n'
+  printf -- '   Abgrenzung noch stimmt — nicht automatisch entfernen.\n'
+fi
+
+if [[ -n "${SOFT_PATTERN}" ]]; then
+  # Auch hier zaehlt die Abgrenzung als unverdaechtig: "kein Webdesign-Projekt"
+  # ist der Gegenbeweis, nicht der Verstoss.
+  SOFT_HITS="$( { rg -n "${SOFT_PATTERN}" "${TEMPLATE}" 2>/dev/null || true; } | { rg -v "${NEG_PATTERN}" 2>/dev/null || true; } )"
+  if [[ -n "${SOFT_HITS}" ]]; then
+    printf '\n== Mehrdeutige Begriffe (manuell entscheiden) ==\n'
+    printf '%s\n' "${SOFT_HITS}" | head -15
+    printf -- '-> Kein automatischer Verstoss. Die Frage ist jeweils die Rolle:\n'
+    printf -- '   Zielgruppe oder Lieferfeld nennen ist erlaubt, sich selbst so\n'
+    printf -- '   zu positionieren nicht. Auf /whitelabel-* gelten die Ausnahmen\n'
+    printf -- '   aus BRAND_AND_COPY.md.\n'
+  fi
+fi
+
+if [[ -n "${FREQ_PATTERN}" ]]; then
+  FREQ_N="$( { rg -o "${FREQ_PATTERN}" "${TEMPLATE}" 2>/dev/null || true; } | rg -c '' 2>/dev/null || echo 0)"
+  if [[ "${FREQ_N}" -gt 0 ]]; then
+    printf '\n== Haeufige Begriffe in erlaubter Rolle ==\n'
+    printf '%s: %s Vorkommen. Erlaubt als Technologie bzw. Beschreibung,\n' "${FREQ_PATTERN//|/, }" "${FREQ_N}"
+    printf 'nicht als Positionierung oder Rollen-Claim. Nicht Zeile fuer Zeile\n'
+    printf 'pruefen — wenn der Verdacht besteht, uebernimmt offer-funnel-intelligence.\n'
+  fi
+fi
+
+printf '\n== Interne Links auf diese Route ==\n'
+INBOUND="$(rg -l -- "${ROUTE}" blocksy-child --glob '*.php' 2>/dev/null | rg -v "$(basename "${TEMPLATE}")" || true)"
+if [[ -n "${INBOUND}" ]]; then
+  printf '%s\n' "${INBOUND}"
+else
+  printf 'Keine. Orphan-Verdacht — gegen internal-linking-audit pruefen.\n'
+fi
+
+# ---- Ampel ----------------------------------------------------------------
+
+verdict() {
+  local zone="$1" state="$2" note="$3"
+  printf '  [%-4s] %-22s %s\n' "${state}" "${zone}" "${note}"
+}
+
+# rg beendet sich mit 1, wenn es nichts findet. Unter pipefail wuerde das die
+# Zuweisung und damit das Skript abbrechen — also den Fehler hier abfangen.
+count_hits() {
+  { rg -o "$1" "${TEMPLATE}" 2>/dev/null || true; } | rg -c '' 2>/dev/null || echo 0
+}
+
+CTA_COUNT="$(count_hits 'data-track-action="[^"]*"')"
+H1_COUNT="$(count_hits '<h1')"
+PROOF_COUNT="$(count_hits 'hu_e3_[a-z_]*|HU_E3_[A-Z_]*')"
+
+BAN_COUNT=0
+[[ -n "${BAN_HARD}" ]] && BAN_COUNT="$(printf '%s\n' "${BAN_HARD}" | rg -c '' || echo 0)"
+
+printf '\n== Ampel ==\n'
+
+if [[ "${H1_COUNT}" -eq 1 ]]; then
+  verdict "H1" "OK" "genau eine H1"
+elif [[ "${H1_COUNT}" -eq 0 ]]; then
+  verdict "H1" "GELB" "keine statische H1 — liegt sie im Editor?"
+else
+  verdict "H1" "ROT" "${H1_COUNT} H1-Elemente"
+fi
+
+if [[ "${CTA_COUNT}" -eq 0 ]]; then
+  verdict "CTA-Tracking" "ROT" "kein data-track-action im Template"
+else
+  verdict "CTA-Tracking" "OK" "${CTA_COUNT} getrackte CTAs"
+fi
+
+if [[ "${BAN_COUNT}" -gt 0 ]]; then
+  verdict "Hard Bans" "ROT" "${BAN_COUNT} Zeilen mit gesperrten Begriffen"
+else
+  verdict "Hard Bans" "OK" "sauber"
+fi
+
+if [[ "${PROOF_COUNT}" -eq 0 ]]; then
+  verdict "Proof-Canon" "GELB" "keine Canon-Referenz — Zahlen pruefen"
+else
+  verdict "Proof-Canon" "OK" "${PROOF_COUNT} Canon-Referenzen"
+fi
+
+if [[ -z "${INBOUND}" ]]; then
+  verdict "Interne Links" "ROT" "keine eingehenden Links"
+else
+  verdict "Interne Links" "OK" "$(printf '%s\n' "${INBOUND}" | wc -l | tr -d ' ') Quellen"
+fi
+
+cat <<'EOF'
+
+ROT ist ein P0-Kandidat, nicht automatisch ein Fehler — die Route kann
+Copy im WordPress-Editor halten. Vor dem Urteil dort nachsehen.
+
+Weiter mit der Linsen-Reihenfolge aus SKILL.md:
+Angebot -> CRO -> Copy -> SEO -> Interne Links -> Speed
+EOF

--- a/agents/skills/seo-conversion-copywriting/SKILL.md
+++ b/agents/skills/seo-conversion-copywriting/SKILL.md
@@ -12,8 +12,11 @@ Diese Skill schreibt den Text. Die Seitenkritik mit Priorisierung macht
 
 1. `docs/standards/BRAND_AND_COPY.md` — Positionierung, Ton, Hard Bans
 2. `blocksy-child/inc/canon/messaging-canon.php` — kundenseitig gesperrte Begriffe
-3. `[BELEGDATEI EINTRAGEN]` — die einzige Quelle für Zahlen
-4. Die Zielseite selbst, dazu `llms.txt` für Route und CTA-Ziel
+3. `blocksy-child/inc/canon/e3-proof-canon.php` — die einzige Quelle für
+   Ergebniszahlen. Preise stehen in `pricing-canon.php` daneben, Such- und
+   GSC-Zahlen in `seo-research/<periode>/reports/`.
+4. `docs/standards/VOICE_OF_CUSTOMER.md` — Kundensprache, sofern gefüllt
+5. Die Zielseite selbst, dazu `llms.txt` für Route und CTA-Ziel
 
 ## A — Harte Regeln
 
@@ -24,9 +27,13 @@ und bei Rechts- oder Ergebnisaussagen kostet er mehr als eine Conversion.
 - Keine Garantien, keine Aussagen zu Rechtskonformität, keine absoluten
   Versprechen. Technische Tatsache statt Rechtsurteil: „läuft ohne Cookies" ja,
   „DSGVO-konform" nein.
-- Belegbare Zahlen stehen ausschließlich in `[BELEGDATEI EINTRAGEN]`. Was dort
+- Belegbare Zahlen stehen ausschließlich in den Canon-Dateien oben. Was dort
   nicht steht, wird nicht geschrieben, sondern als `[BELEG FEHLT: Aussage]`
   markiert und offen zurückgemeldet.
+- Für Kundensprache gilt dasselbe: Ist `VOICE_OF_CUSTOMER.md` leer oder deckt
+  die Aussage nicht ab, wird die Formulierung nicht erfunden, sondern als
+  `[KUNDENSPRACHE FEHLT: Aussage]` markiert. Eine geratene Kundenstimme ist
+  genauso wertlos wie eine geratene Zahl.
 - Keine Kundennamen. Neu geschriebene Copy beschreibt anonymisiert: Gewerk,
   Größenordnung, Ausgangslage. (Bestehende freigegebene Cases zu entfernen ist
   eine eigene Entscheidung, keine Nebenwirkung dieser Regel.)
@@ -75,7 +82,7 @@ ASCII-Umlaute und Canon-Drift prüft die CI bereits
 ## Deliver
 
 - Fertige Copy je Abschnitt, in der Reihenfolge der Seite
-- Liste der offenen `[BELEG FEHLT: …]`-Marker: was geliefert werden muss, damit
-  die Aussage stehen bleiben darf
+- Liste der offenen `[BELEG FEHLT: …]`- und `[KUNDENSPRACHE FEHLT: …]`-Marker:
+  was geliefert werden muss, damit die Aussage stehen bleiben darf
 - Trennung `Repo` (Template/Partial) und `Manual WP` (Editor-Copy)
 - Meta-Title und -Description, wenn die Seite eine eigene Route hat

--- a/agents/skills/seo-conversion-copywriting/scripts/copy-check.sh
+++ b/agents/skills/seo-conversion-copywriting/scripts/copy-check.sh
@@ -80,7 +80,7 @@ report "Floskeln" \
 
 report "Offene Marker" \
   "Vor dem Livegang aufloesen: Beleg liefern oder Aussage streichen." \
-  '\[BELEG FEHLT|BELEGDATEI EINTRAGEN|TODO|TBD'
+  '\[BELEG FEHLT|\[KUNDENSPRACHE FEHLT|BELEGDATEI EINTRAGEN|TODO|TBD'
 
 if [[ "${FOUND}" -eq 0 ]]; then
   echo "Keine Treffer."

--- a/docs/standards/BRAND_AND_COPY.md
+++ b/docs/standards/BRAND_AND_COPY.md
@@ -94,8 +94,11 @@ Belege (nicht raten, nachschlagen):
 - `B2B` als Positionierung (zu generisch — wir sprechen Solar/Wärmepumpe)
 - `WordPress Specialist`, `WordPress-Agentur`, `Webdesign`, `Leistungen`
 - `Growth Architect`, generische Growth-/Marketing-Blasen-Begriffe
-- Shopify als Live-Positionierung
+- `Shopify` als Live-Positionierung
 - `kostenlos` als alleiniges Wertversprechen
+- `Founding Cohort 2026`, `Founding-Partner`, `Founding-Konditionen` — Detail
+  oben unter Preferred Terms
+- `Solarthermie` — anderes Gewerk, nicht Zielgruppe; Detail unten unter Solar / Photovoltaik / PV
 - Tool-artige Rahmung der Diagnose
 - Überhöhte Umsatzversprechen
 - Gleichgewichtiger Leistungskatalog statt Diagnose-first-Funnel

--- a/docs/standards/VOICE_OF_CUSTOMER.md
+++ b/docs/standards/VOICE_OF_CUSTOMER.md
@@ -1,0 +1,89 @@
+# Voice of Customer
+
+**Status: UNGEFÜLLT.** Es liegt noch kein verwertbares Rohmaterial vor.
+
+Diese Datei hält Kundensprache — die Formulierungen, die Geschäftsführer und
+Vertriebsleiter von Solar-, Wärmepumpen- und Energiebetrieben selbst benutzen.
+Sie ist nicht das Gegenstück zu den `Preferred Terms` in
+`docs/standards/BRAND_AND_COPY.md`, sondern deren Korrektiv: dort steht, was
+wir sagen, hier steht, was der Käufer sagt. Wo beides auseinanderläuft, gewinnt
+in der Copy die Kundenseite.
+
+## Was hier hineingehört
+
+- Wörtliche Zitate aus Verkaufsgesprächen, E-Mails, Marktcheck-Freitextfeldern
+- Immer mit Quelle und Datum, anonymisiert nach Gewerk und Größenordnung
+- Auch unbequeme Sätze: Einwände, Misstrauen, Preisreaktionen
+
+## Was hier nicht hineingehört
+
+- Paraphrasen, geglättete Fassungen, „so meinte er sinngemäß"
+- Formulierungen aus Wettbewerbsseiten oder Branchenpresse — das ist
+  Marktsprache, nicht Kundensprache. Wettbewerbs-Copy zerlegt `copy-anatomy`.
+- Alles, was ein Agent selbst erzeugt hat
+
+Ein erfundenes Kundenzitat ist genauso gesperrt wie eine erfundene Zahl. Wer
+eine Aussage über Kundensprache braucht, die hier nicht belegt ist, schreibt
+sie nicht, sondern markiert `[KUNDENSPRACHE FEHLT: Aussage]` und meldet sie
+offen zurück (siehe `agents/skills/seo-conversion-copywriting/SKILL.md`).
+
+## Format je Eintrag
+
+```
+> "Wörtliches Zitat."
+— Gewerk, Größenordnung, Kanal, Datum
+```
+
+---
+
+## Problembeschreibung in Kundenworten
+
+_Noch nichts erfasst._
+
+Gesucht: wie der Betrieb sein Problem benennt, bevor er eine Lösung kennt.
+Sagt er „zu wenig Anfragen", „die Anfragen taugen nichts", „wir zahlen uns
+dumm und dämlich" oder etwas ganz anderes?
+
+## Auslöser für die Suche
+
+_Noch nichts erfasst._
+
+Gesucht: das Ereignis, nach dem jemand anfängt zu suchen — Portalpreis erhöht,
+Auftragsbuch leer, Vertriebsmitarbeiter eingestellt, Wettbewerber gesehen.
+
+## Begriffe für Portale und Leadkosten
+
+_Noch nichts erfasst._
+
+Gesucht: sagen Betriebe „Leads", „Anfragen", „Kontakte", „Adressen"? Nennen
+sie Aroundhome, Check24 und DAA beim Namen oder sprechen sie von „den
+Portalen"? Rechnen sie in CPL oder in „was kostet mich ein Auftrag"?
+
+## Einwände
+
+_Noch nichts erfasst._
+
+Gesucht: die Sätze, mit denen abgelehnt oder vertagt wird. „Haben wir schon
+probiert", „das dauert zu lange", „unser Neffe macht die Website", „erst mal
+das Sommergeschäft abwarten".
+
+## Entscheidungsangst
+
+_Noch nichts erfasst._
+
+Gesucht: was Käufer nachts wachhält — Abhängigkeit vom Dienstleister, wem die
+Daten gehören, was passiert, wenn es nicht funktioniert, wie er es intern
+rechtfertigt.
+
+---
+
+## Wie diese Datei gefüllt wird
+
+Nicht durch einen Agenten. Rohmaterial muss aus echten Gesprächen kommen. Ein
+gangbarer erster Schritt: die nächsten fünf Verkaufsgespräche mitschreiben und
+wörtliche Sätze übernehmen, statt sie zusammenzufassen. Fünf echte Zitate sind
+mehr wert als fünfzig plausible.
+
+Sobald Marktcheck-Freitextantworten in nennenswerter Zahl vorliegen, sind sie
+die beste Quelle: dort schreibt der Interessent unbeobachtet und in eigenen
+Worten.

--- a/scripts/lint-canon-drift.sh
+++ b/scripts/lint-canon-drift.sh
@@ -11,6 +11,10 @@ PATHS=(
   ":(exclude)blocksy-child/energie-fahrplan/dist/**"
   ":(exclude)blocksy-child/energie-fahrplan/package-lock.json"
   ":(exclude)scripts/lint-canon-drift.sh"
+  # Liest die Begriffe zur Laufzeit aus dem Canon und muss die mehrdeutigen
+  # davon benennen duerfen, um sie von echten Verstoessen zu trennen —
+  # gleiche Begruendung wie beim Selbstausschluss dieses Guards.
+  ":(exclude)agents/skills/route-conversion-review/scripts/review-route.sh"
   ":(exclude)docs/audits/**"
   ":(exclude)docs/decisions/**"
   ":(exclude)docs/references/**"


### PR DESCRIPTION
Prüfung einer externen Empfehlung, 15 Open-Source-Marketing-Skills aus vier GitHub-Repos zu vendoren. Ergebnis: rund 80 % davon dupliziert bestehende Repo-Skills, und die generischen Trigger-Beschreibungen hätten die spezifischen verdrängt. Statt zu installieren, die vier echten Lücken geschlossen.

Betrifft nur `agents/` und `docs/` plus einen CI-Guard — kein `blocksy-child/`, also kein Deploy.

## Warum kein Vendoring

- **Namen stimmen nicht.** In `coreyhaines31/marketingskills` heißen die Skills `product-marketing`, `cro`, `ab-testing`. Ein `product-marketing-context`, `page-cro`, `form-cro` oder `ab-test-setup` existiert nicht — vier der acht Namen im vorgeschlagenen Installationsbefehl hätten fehlgeschlagen.
- **Dublette.** `copywriting`/`copy-editing` → `seo-conversion-copywriting`. `cro` → `wordpress-cro-content-design-audit`. `product-marketing`/`marketing-psychology`/`offers` → `offer-funnel-intelligence`. `seo-audit` → `seo-agent`. `site-architecture` → `internal-linking-audit`.
- **Dubletten schaden aktiv.** Generische Skills haben breitere Trigger-Beschreibungen. Bei „Text für Seite X" hätte der englische SaaS-Skill gegen den deutschen mit Hard Bans und `copy-check.sh` gewonnen.
- **Prämisse erfüllt.** Der externe `copywriting`-Skill sucht nach `.agents/product-marketing.md`. Dieses Repo hat `docs/standards/BRAND_AND_COPY.md` — schärfer, inklusive Solar/Photovoltaik/PV-Begriffsdisziplin und White-Label-Ausnahme.

## Änderungen

### 1. Kaputter Belegverweis in `seo-conversion-copywriting`

Der Platzhalter `[BELEGDATEI EINTRAGEN]` stand an genau der Stelle, die die einzige Quelle für Zahlen benennen soll. Der Skill, der erfundene Zahlen verhindern soll, konnte seine eigene Belegquelle nicht nennen.

Zeigt jetzt auf `blocksy-child/inc/canon/e3-proof-canon.php`, `pricing-canon.php` und `seo-research/`. Kundensprache bekommt mit `[KUNDENSPRACHE FEHLT]` dasselbe Marker-Muster wie `[BELEG FEHLT]`; `copy-check.sh` greppt beide.

### 2. Neuer Skill `route-conversion-review`

Vollprüfung einer einzelnen Route in fester Reihenfolge — Angebot → CRO → Copy → SEO → interne Links → Speed.

```bash
bash agents/skills/route-conversion-review/scripts/review-route.sh /whitelabel-retainer/
```

Vertikale Ergänzung zum repo-weiten Sweep in `wordpress-performance-marketing`; beide Beschreibungen grenzen sich gegenseitig ab, damit keine Routing-Kollision entsteht.

Das Skript löst Route zu Template auf (inklusive Schatten-Wrapper und dreier Slugs mit abweichendem Dateinamen), sammelt Überschriften, CTAs, Proof-Referenzen und harte Zahlen und schließt mit einer Ampel.

Zwei Kalibrierungen, beide beim Testen aufgefallen:

- Die Ban-Begriffe werden zur Laufzeit aus `messaging-canon.php` und `BRAND_AND_COPY.md` gelesen statt kopiert — `lint-canon-drift.sh` hatte die Kopie zu Recht beanstandet.
- Ein gesperrter Begriff in einer Abgrenzung („Architektur statt Webdesign") zählt nicht als Verstoß, mehrdeutige Begriffe kommen in eine eigene Prüfspalte. Ohne diese Filter meldete die Startseite drei falsche Rot-Befunde.

### 3. Neuer Skill `copy-anatomy`

Zerlegt fremde Copy in Struktur und extrahiert das übertragbare Muster. Harte Regel: Muster ja, Text nein — übernommene Formulierungen tragen die Positionierung des Wettbewerbers mit.

### 4. `docs/standards/VOICE_OF_CUSTOMER.md`

Sammelstruktur für Kundensprache, sichtbar als ungefüllt markiert. Kein Skill dazu, solange kein Rohmaterial vorliegt.

### 5. Zwei Folgeänderungen

- `BRAND_AND_COPY.md`: `Shopify` wie die übrigen Anti-Patterns in Backticks, Founding-Begriffe und `Solarthermie` als Bullets ergänzt, damit die Hard-Ban-Liste maschinenlesbar vollständig ist.
- `lint-canon-drift.sh`: `review-route.sh` ausgenommen, mit derselben Begründung wie beim bestehenden Selbstausschluss des Guards — wer Begriffe klassifiziert, muss sie benennen dürfen. **Das ist die Änderung, die den genauesten Blick verdient.**

## Verifikation

Alle Guards grün:

```
check-german-copy · lint-canon-drift · lint-e3-canon
lint-css-motion · validate-architecture · smoke-lead-path-contract
```

13 Routen getestet (`/`, Money Page, White-Label, Schatten-Wrapper, beide Alias-Slugs, `/wgos/`, weitere) plus zwei Fehlerpfade: unbekannte Route → exit 1 mit Template-Name-Vorschlägen, fehlendes Argument → exit 2.

Gegenprobe Routing: „Prüfe /whitelabel-retainer/ komplett" trifft `route-conversion-review`, „Audit über das ganze Repo" weiterhin `wordpress-performance-marketing`.

## Zwei Befunde vom ersten echten Lauf

- `/case-study-solar-leadgenerierung/` hat null `data-track-action`-CTAs und keine E3-Canon-Referenz im Template. Falls die Copy dort im Editor liegt, erklärbar — sonst wird auf der wichtigsten Beweisseite nichts gemessen.
- Drei Routen in `llms.txt` haben abweichende Dateinamen; `/ergebnisse/` läuft über `page-case-studies-e-commerce.php`, ein Legacy-Name aus der Shopify-Zeit.

Beides ist in diesem PR nicht angefasst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NepRPm35ZSDpBtWJnqp95k

---
_Generated by [Claude Code](https://claude.ai/code/session_01NepRPm35ZSDpBtWJnqp95k)_