### PR TITLE
Fix Solar Leads hero headline

### DIFF
--- a/blocksy-child/assets/css/solar-leads-kaufen-alternative-page.css
+++ b/blocksy-child/assets/css/solar-leads-kaufen-alternative-page.css
@@ -124,13 +124,21 @@
 }
 
 .hu-buy .hu-buy__h1 {
-	max-width: 16ch;
+	max-width: 19ch;
 	margin: 0 0 1.4rem;
-	font-size: clamp(2.55rem, 6vw, 5.2rem);
+	font-size: clamp(2.55rem, 4.75vw, 4.25rem);
 	font-weight: 720;
-	line-height: 0.99;
+	line-height: 1.01;
 	letter-spacing: -0.045em;
 	color: var(--buy-on-dark);
+}
+
+.hu-buy .hu-buy__h1-line {
+	display: block;
+}
+
+.hu-buy .hu-buy__h1-line + .hu-buy__h1-line {
+	margin-top: 0.04em;
 }
 
 .hu-buy .hu-buy__h2 {
@@ -202,6 +210,7 @@
 /* ── Hero ─────────────────────────────────────────────────────────── */
 
 .hu-buy .hu-buy__band--hero {
+	--buy-max: 82rem;
 	padding-top: clamp(3.5rem, 8vw, 6.75rem);
 	background:
 		linear-gradient(rgba(255, 255, 255, 0.027) 1px, transparent 1px),
@@ -227,8 +236,8 @@
 
 .hu-buy .hu-buy__hero-grid {
 	display: grid;
-	grid-template-columns: minmax(0, 1.16fr) minmax(19rem, 0.84fr);
-	gap: clamp(3rem, 7vw, 7rem);
+	grid-template-columns: minmax(0, 1.3fr) minmax(27rem, 0.72fr);
+	gap: clamp(3rem, 5vw, 5rem);
 	align-items: center;
 }
 
@@ -1033,7 +1042,7 @@
 	}
 
 	.hu-buy .hu-buy__h1 {
-		max-width: 18ch;
+		max-width: 19ch;
 	}
 
 	.hu-buy .hu-buy__proof {
@@ -1085,7 +1094,7 @@
 
 @media (max-width: 36rem) {
 	.hu-buy .hu-buy__h1 {
-		font-size: clamp(2.35rem, 12vw, 3.3rem);
+		font-size: clamp(2.3rem, 10.8vw, 2.95rem);
 	}
 
 	.hu-buy .hu-buy__actions,

--- a/blocksy-child/page-solar-leads-kaufen-alternative.php
+++ b/blocksy-child/page-solar-leads-kaufen-alternative.php
@@ -262,7 +262,11 @@ get_header();
 			<div class="hu-buy__hero-grid">
 				<div class="hu-buy__hero-copy">
 					<p class="hu-buy__eyebrow">Für Solar-, Wärmepumpen- und Speicher-Anbieter im DACH-Markt</p>
-					<h1 class="hu-buy__h1" id="hu-buy-hero-title">Solar Leads kaufen — oder den Anfragekanal selbst besitzen?</h1>
+					<h1 class="hu-buy__h1" id="hu-buy-hero-title">
+						<span class="hu-buy__h1-line">Solar Leads kaufen —</span>
+						<span class="hu-buy__h1-line">oder eigene Anfragen</span>
+						<span class="hu-buy__h1-line">gewinnen?</span>
+					</h1>
 					<p class="hu-buy__lead">
 						Der Zukauf kann kurzfristig die Pipeline füllen. Er löst aber nicht automatisch Exklusivität, Vorqualifizierung, Messbarkeit oder Datenbesitz. Diese Seite zeigt, welche Modelle Sie vergleichen sollten — und wann ein eigener Anfrageweg wirtschaftlich sinnvoller sein kann.
 					</p>


### PR DESCRIPTION
## Änderung

- H1 auf „Solar Leads kaufen — oder eigene Anfragen gewinnen?“ gekürzt
- Desktop-Umbruch auf drei klare Sinnzeilen stabilisiert
- maximale Schriftgröße reduziert
- Hero-Breite so angepasst, dass H1 und Proof-Karte ausgewogen bleiben
- Mobile-Umbruch weiterhin ohne horizontalen Überlauf

## Ursache

PR #181 wurde bereits mit Commit `9b5e996` gemergt. Die spätere H1-Korrektur `c0fa0ca` wurde danach auf denselben, bereits geschlossenen Branch gepusht und konnte deshalb nicht mehr Teil von PR #181 oder `main` werden.

Dieser PR basiert frisch auf dem aktuellen `main` und enthält ausschließlich die fehlende Nachbesserung.

## Validierung

- PHP-Syntaxprüfung
- `npm run build:theme`
- CSS-Motion-Guard
- `git diff --check`
- Browser-Vorschau Desktop und Mobile