### PR TITLE
Remove Article schema from Hannover money page

### DIFF
--- a/blocksy-child/inc/org-schema.php
+++ b/blocksy-child/inc/org-schema.php
@@ -1144,7 +1144,12 @@ function hu_output_schema()
 
                 $schemas[] = $professional_service;
 
-                $schemas[] = [
+                // Kommerzielle Leistungsseite, kein redaktioneller Beitrag: die
+                // Seitenentitaet bleibt WebPage, Hauptentitaet ist der Service.
+                // Ein zusaetzlicher Article-Node waere hier weder Rich-Result-
+                // berechtigt noch inhaltlich zutreffend und setzte nur eine
+                // zweite Inhaltsentitaet auf dieselbe URL.
+                $agentur_webpage = [
                     '@context'    => 'https://schema.org',
                     '@type'       => 'WebPage',
                     '@id'         => home_url('/wordpress-agentur-hannover/#webpage'),
@@ -1162,41 +1167,31 @@ function hu_output_schema()
                     'reviewedBy'  => hu_person_schema_ref(),
                 ];
 
-                $agentur_article = [
-                    '@context'         => 'https://schema.org',
-                    '@type'            => 'Article',
-                    '@id'              => home_url('/wordpress-agentur-hannover/#article'),
-                    'url'              => home_url('/wordpress-agentur-hannover/'),
-                    'mainEntityOfPage' => ['@id' => home_url('/wordpress-agentur-hannover/#webpage')],
-                    'headline'         => 'WordPress Agentur Hannover für B2B-Websites und Anfrage-Systeme',
-                    'description'      => $def['description'],
-                    'inLanguage'       => 'de',
-                    'articleSection'   => 'WordPress, technisches SEO und B2B-Anfrage-Systeme',
-                    'author'           => hu_person_schema_ref( true ),
-                    'publisher'        => ['@id' => home_url('/#organization')],
-                    'about'            => [
-                        ['@id' => home_url('/wordpress-agentur-hannover/#service')],
-                        ['@id' => home_url('/#organization')],
-                    ],
-                ];
-
+                // Aktualitaets- und Bildsignale bleiben erhalten, haengen aber am
+                // korrekten Typ statt am entfernten Article-Node.
                 $agentur_published_date = get_post_time( DATE_W3C, true, $post_id );
                 $agentur_modified_date  = get_post_modified_time( DATE_W3C, true, $post_id );
 
                 if ( $agentur_published_date ) {
-                    $agentur_article['datePublished'] = $agentur_published_date;
+                    $agentur_webpage['datePublished'] = $agentur_published_date;
                 }
 
                 if ( $agentur_modified_date ) {
-                    $agentur_article['dateModified'] = $agentur_modified_date;
+                    $agentur_webpage['dateModified'] = $agentur_modified_date;
                 }
 
-                $agentur_article_image = hu_get_post_schema_image_object( $post_id );
-                if ( is_array( $agentur_article_image ) ) {
-                    $agentur_article['image'] = $agentur_article_image;
+                $agentur_page_image = hu_get_post_schema_image_object( $post_id );
+                if ( is_array( $agentur_page_image ) ) {
+                    $agentur_webpage['primaryImageOfPage'] = $agentur_page_image;
                 }
 
-                $schemas[] = $agentur_article;
+                if ( hu_should_output_global_breadcrumb_schema() ) {
+                    $agentur_webpage['breadcrumb'] = [
+                        '@id' => home_url('/wordpress-agentur-hannover/#breadcrumb'),
+                    ];
+                }
+
+                $schemas[] = $agentur_webpage;
             }
         }
 


### PR DESCRIPTION
## Warum

Der Rich-Results-Test meldet für `/wordpress-agentur-hannover/` ein gültiges **Artikel**-Element. Die Seite ist aber eine kommerzielle Leistungs- und Local-Business-Seite (Service, ProfessionalService, Offers, FAQ), kein redaktioneller Beitrag.

Drei Probleme in einem Node:

- **Kein Upside.** Article erzeugt für eine Nicht-News-Domain kein Rich Result — reines Risiko ohne Gegenwert.
- **Typ passt nicht zum Inhalt.** Google dokumentiert Article für News-, Sport- und Blog-Beiträge.
- **Zwei Inhaltsentitäten auf einer URL.** `WebPage.mainEntity` zeigte auf `#service`, gleichzeitig beanspruchte `Article.mainEntityOfPage` die `#webpage`.

## Was sich ändert

`blocksy-child/inc/org-schema.php` — der `#article`-Node entfällt, die `WebPage` bleibt alleinige Seitenentität mit dem Service als `mainEntity`. Die brauchbaren Signale gehen nicht verloren, sie wandern an den korrekten Typ:

| Signal | vorher | nachher |
|---|---|---|
| `datePublished` / `dateModified` | Article | WebPage |
| Bild | `Article.image` | `WebPage.primaryImageOfPage` |
| `breadcrumb`-Referenz | fehlte | WebPage → `#breadcrumb` |
| `author` / `reviewedBy` | Article **und** WebPage | WebPage (lag dort schon) |
| `headline`, `articleSection`, `publisher` | Article | entfallen (Article-Semantik) |

Keine weiteren Referenzen auf `#article` für diesen Slug — der Graph bleibt ohne lose Enden.

## Geprüft

- PHP-Lint, `pre-deploy-smoke` (SAFE TO PUSH), `validate-architecture`, Canon-Drift, German-Copy-Guard — alle grün
- Übrige Article-Nodes im Repo gegengeprüft und korrekt: Cornerstone-Template, E3-Case-Post, Kosten-Marktstudie, `TechArticle` auf den Stack-Seiten. Die Hannover-Seite war der einzige Typ-Fehler.

## Warum PR statt direkt auf main

`CLAUDE.md` führt Schema ausdrücklich auf der Nein-Seite von „Kann man das Ergebnis auf der Live-Seite sehen?" — der entfernte Node ist im Frontend nirgends sichtbar, der Diff hier ist das einzige Review.

## Nicht Teil dieses PRs

Die Seite zeichnet den Betrieb **zweimal** aus — `#organization` (sitewide, `[Organization, LocalBusiness]`) und `#localbusiness` (`ProfessionalService`). Adresse, Geo, Telefon, E-Mail, Maps-CID, Öffnungszeiten und `sameAs` sind byte-identisch, nur `name` unterscheidet sich. Das erklärt die „2 gültige Elemente" bei *Lokale Unternehmen* und *Unternehmen* im Rich-Results-Test.

Bewusst nicht mitgefixt: beide Wege haben echte Kosten (`LocalBusiness` aus dem sitewide Node zu nehmen wirkt auf jede Seite; den ProfessionalService zu streichen kostet die Hannover-spezifische `areaServed`-Liste). Eigene Entscheidung, eigener PR.

## Nach dem Merge

Rich-Results-Test erneut laufen lassen — *Artikel* verschwindet, *Navigationspfade* bleibt 1, *Lokale Unternehmen* und *Unternehmen* bleiben bei 2/2. Danach Neuindexierung für `/wordpress-agentur-hannover/` in der Search Console anstoßen.