### PR TITLE
Doppelte LocalBusiness-Entität auf der Hannover-Seite entfernen

### DIFF
--- a/blocksy-child/inc/org-schema.php
+++ b/blocksy-child/inc/org-schema.php
@@ -1049,100 +1049,15 @@ function hu_output_schema()
             $schemas[] = $service;
 
             if ('wordpress-agentur-hannover' === $slug) {
-                // Dedicated ProfessionalService (LocalBusiness subtype) for the
-                // Hannover money page: explicit geo, address and an extended
-                // areaServed array boost local-pack relevance.
-                $hannover_area_served = [
-                    [
-                        '@type'  => 'City',
-                        'name'   => 'Hannover',
-                        'sameAs' => 'https://de.wikipedia.org/wiki/Hannover',
-                    ],
-                    [
-                        '@type'  => 'City',
-                        'name'   => 'Pattensen',
-                        'sameAs' => 'https://de.wikipedia.org/wiki/Pattensen',
-                    ],
-                    [
-                        '@type'  => 'City',
-                        'name'   => 'Braunschweig',
-                        'sameAs' => 'https://de.wikipedia.org/wiki/Braunschweig',
-                    ],
-                    [
-                        '@type'  => 'City',
-                        'name'   => 'Wolfsburg',
-                        'sameAs' => 'https://de.wikipedia.org/wiki/Wolfsburg',
-                    ],
-                    [
-                        '@type'  => 'City',
-                        'name'   => 'Hildesheim',
-                        'sameAs' => 'https://de.wikipedia.org/wiki/Hildesheim',
-                    ],
-                    [
-                        '@type'  => 'AdministrativeArea',
-                        'name'   => 'Region Hannover',
-                        'sameAs' => 'https://de.wikipedia.org/wiki/Region_Hannover',
-                    ],
-                    [
-                        '@type'  => 'AdministrativeArea',
-                        'name'   => 'Niedersachsen',
-                        'sameAs' => 'https://de.wikipedia.org/wiki/Niedersachsen',
-                    ],
-                ];
-
-                $professional_service = [
-                    '@context'           => 'https://schema.org',
-                    '@type'              => 'ProfessionalService',
-                    '@id'                => home_url('/wordpress-agentur-hannover/#localbusiness'),
-                    'name'               => 'Haşim Üner – WordPress Agentur Hannover',
-                    'alternateName'      => 'WordPress Agentur Hannover',
-                    'description'        => $def['description'],
-                    'url'                => home_url('/wordpress-agentur-hannover/'),
-                    'image'              => hu_get_profile_image_url(),
-                    'logo'               => function_exists( 'hu_get_brand_logo_url' ) ? hu_get_brand_logo_url() : content_url( '/uploads/2025/08/cropped-Logo-hasim-uener-1.webp' ),
-                    'telephone'          => '+49 176 76596580',
-                    'email'              => 'info@hasimuener.de',
-                    'priceRange'         => '€€',
-                    'currenciesAccepted' => 'EUR',
-                    'paymentAccepted'    => 'Überweisung',
-                    'parentOrganization' => ['@id' => home_url('/#organization')],
-                    'address'            => [
-                        '@type'           => 'PostalAddress',
-                        'streetAddress'   => 'Warschauer Str. 5',
-                        'addressLocality' => 'Pattensen',
-                        'addressRegion'   => 'Niedersachsen',
-                        'postalCode'      => '30982',
-                        'addressCountry'  => 'DE',
-                    ],
-                    'geo' => [
-                        '@type'     => 'GeoCoordinates',
-                        'latitude'  => '52.2736456',
-                        'longitude' => '9.7559953',
-                    ],
-                    'hasMap'        => $google_maps_url,
-                    'areaServed'    => $hannover_area_served,
-                    'knowsAbout'    => [
-                        'WordPress',
-                        'Technisches SEO',
-                        'Core Web Vitals',
-                        'Conversion Rate Optimization',
-                        'GA4 Tracking',
-                        'Server-Side Tagging',
-                        'B2B Lead Generation',
-                    ],
-                    'knowsLanguage' => ['de', 'en', 'tr'],
-                    'sameAs'        => hu_business_same_as_urls(),
-                    'openingHoursSpecification' => [
-                        [
-                            '@type'     => 'OpeningHoursSpecification',
-                            'dayOfWeek' => ['Monday', 'Tuesday', 'Wednesday', 'Thursday'],
-                            'opens'     => '08:30',
-                            'closes'    => '16:00',
-                        ],
-                    ],
-                ];
-
-                $schemas[] = $professional_service;
+                // Kein eigener LocalBusiness-Node fuer diese Seite. Der
+                // sitewide #organization-Node ist bereits
+                // [Organization, LocalBusiness] und traegt dieselbe Adresse,
+                // Geo, Telefon, E-Mail, Oeffnungszeiten, hasMap und sameAs —
+                // sein areaServed ist sogar eine Obermenge. Ein zweiter Node
+                // beschriebe denselben physischen Betrieb unter einer zweiten
+                // @id und zwaenge Google zu einer Entitaetsentscheidung, die
+                // es nicht treffen muesste. Der lokale Bezug der Seite haengt
+                // an Service, Copy und WebPage, nicht an einer Dublette.
 
                 // Kommerzielle Leistungsseite, kein redaktioneller Beitrag: die
                 // Seitenentitaet bleibt WebPage, Hauptentitaet ist der Service.
@@ -1158,10 +1073,7 @@ function hu_output_schema()
                     'description' => $def['description'],
                     'inLanguage'  => 'de',
                     'isPartOf'    => ['@id' => home_url('/#website')],
-                    'about'       => [
-                        ['@id' => home_url('/#organization')],
-                        ['@id' => home_url('/wordpress-agentur-hannover/#localbusiness')],
-                    ],
+                    'about'       => ['@id' => home_url('/#organization')],
                     'mainEntity'  => ['@id' => home_url('/wordpress-agentur-hannover/#service')],
                     'author'      => hu_person_schema_ref(),
                     'reviewedBy'  => hu_person_schema_ref(),


### PR DESCRIPTION
## Warum

Nach dem Article-Fix (#185) meldet der Rich-Results-Test für `/wordpress-agentur-hannover/` weiterhin **je 2 gültige Elemente** unter *Lokale Unternehmen* und *Unternehmen*:

- „Haşim Üner | Architekt für eigene Anfrage-Systeme" → `#organization` (sitewide, `[Organization, LocalBusiness]`)
- „Haşim Üner – WordPress Agentur Hannover" → `#localbusiness` (`ProfessionalService`)

Beide beschreiben denselben physischen Betrieb. `ProfessionalService` erbt von `LocalBusiness` von `Organization`, deshalb zählt Google jeden der beiden Nodes in beiden Kategorien.

## Der zweite Node trug keine eigene Information

Feldvergleich am ausgelieferten HTML:

| Feld | Ergebnis |
|---|---|
| `address`, `geo`, `telephone`, `email` | identisch |
| `openingHoursSpecification`, `hasMap` (gleiche Maps-CID), `sameAs` | identisch |
| `image`, `logo`, `priceRange`, `currenciesAccepted`, `paymentAccepted` | identisch |
| `knowsAbout` | identisch |
| `areaServed` | echte **Teilmenge** — `#organization` führt dieselben 7 Orte plus DACH |
| exklusiv auf `#localbusiness` | nur `parentOrganization` |

`parentOrganization` existierte ausschließlich, um die Dublette zusammenzuhalten. Bei byte-identischer NAP ist das keine Filiale, sondern dieselbe Firma unter einer zweiten `@id` — und zwingt Google zu einer Entitätsentscheidung, die es nicht treffen müsste. Googles LocalBusiness-Leitlinie ist eine Entität pro Standort.

## Was sich ändert

`blocksy-child/inc/org-schema.php` — der `ProfessionalService`-Block und das nur dort genutzte `$hannover_area_served` entfallen. `#organization` bleibt alleinige Geschäftsentität; die `about`-Referenz der WebPage zeigt nur noch dorthin.

Warum diese Richtung und nicht `LocalBusiness` aus `#organization` streichen: der sitewide Node ist der Anker des Graphen (`provider`, `publisher`, `about`) und trägt `geo`, `openingHoursSpecification`, `priceRange`, `currenciesAccepted`, `paymentAccepted` — allesamt LocalBusiness-Eigenschaften. Ihn zum reinen `Organization` zu machen hieße, diese Felder mit zu entsorgen und die lokale Identität von jeder Seite außer Hannover zu nehmen. Der eine überflüssige Node ist der kleinere Eingriff.

## Ortsbezug bleibt

Er hängt an `Service`, an der sichtbaren Copy, an der WebPage und am `areaServed` des Organization-Nodes, das Hannover, Pattensen, Braunschweig, Wolfsburg, Hildesheim, Region Hannover und Niedersachsen ohnehin führt.

„WordPress Agentur Hannover" wandert **bewusst nicht** als `alternateName` auf `#organization`: Keywords im Firmennamen widersprechen Googles LocalBusiness-Richtlinie. Der `alternateName` dort führt Schreibvarianten des Personennamens — das ist die richtige Verwendung. Das Keyword gehört in `Service.name`, H1 und Copy, wo es bereits steht.

## Geprüft

PHP-Lint, `pre-deploy-smoke` (SAFE TO PUSH), `validate-architecture`, Canon-Drift, German-Copy-Guard — alle grün. Keine verwaisten Referenzen auf `#localbusiness`, `$professional_service` oder `$hannover_area_served`. `$google_maps_url` bleibt in Gebrauch (Organization-Node).

## Erwartung nach dem Deploy

*Lokale Unternehmen* und *Unternehmen* gehen von 2 auf **1**. Danach Neuindexierung für `/wordpress-agentur-hannover/` anstoßen.

⚠️ Beim Mergen bitte kurz warten, bis CI auf `main` durchgelaufen ist, bevor ein weiterer PR gemergt wird — `ci.yml` hat `cancel-in-progress: true`, ein schneller Zweit-Merge bricht die CI dieses Commits ab und verschluckt seinen Deploy (genau das ist bei #185 passiert).

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEbwKHoWbHDXVWZjaaJBXa)_