### PR TITLE
Marktcheck: DACH-Sperre, falsche Firmendomain, geschätzte CRM-Werte

### DIFF
--- a/blocksy-child/assets/js/solar-leadgenerierung-solara.js
+++ b/blocksy-child/assets/js/solar-leadgenerierung-solara.js
@@ -169,7 +169,9 @@
       if (a.email && /^[^\s@]+@(gmail|gmx|web|t-online|outlook|hotmail|yahoo|icloud|aol|live|mail|googlemail)\.(com|de|net|at|ch)$/i.test(a.email)) {
         errs.email = 'Bitte nutzen Sie Ihre geschäftliche E-Mail-Adresse (Firmen-Domain) — so kann ich Betrieb und Region eindeutig zuordnen. Keine eigene Domain? Schreiben Sie direkt an hasim@hasimuener.de.';
       }
-      if (!a.postal_code || !/^[0-9]{5}$/.test(String(a.postal_code).trim())) errs.postal_code = 'Bitte eine fünfstellige Firmen-PLZ angeben.';
+      // 4-5 Stellen: DE hat fünfstellige PLZ, AT und CH vierstellige. Die Seite
+      // verspricht DACH — eine reine DE-Regel sperrt AT/CH komplett aus.
+      if (!a.postal_code || !/^[0-9]{4,5}$/.test(String(a.postal_code).trim())) errs.postal_code = 'Bitte die Firmen-PLZ angeben — vierstellig (AT, CH) oder fünfstellig (DE).';
       if (!a.consent_privacy) errs.consent_privacy = 'Bitte den Datenschutzhinweis bestätigen.';
       return errs;
     }
@@ -507,7 +509,7 @@
       form.appendChild(renderField({ k: 'postal_code', t: 'Firmen-PLZ', type: 'text', ph: '30159', req: true, ac: 'postal-code', im: 'numeric',
         maxlength: '5',
         validator: function (v) {
-          return /^[0-9]{5}$/.test(String(v || '').trim()) ? null : 'Bitte eine fünfstellige PLZ angeben — sie steuert die Regions-Verfügbarkeitsprüfung.';
+          return /^[0-9]{4,5}$/.test(String(v || '').trim()) ? null : 'Bitte die Firmen-PLZ angeben — vierstellig (AT, CH) oder fünfstellig (DE). Sie steuert die Regions-Verfügbarkeitsprüfung.';
         }
       }));
 

--- a/blocksy-child/inc/review-crm.php
+++ b/blocksy-child/inc/review-crm.php
@@ -1637,6 +1637,10 @@ function nexus_validate_energy_review_request_payload( $payload ) {
 			: ( 'medium' === $portal_margin_loss ? '151_bis_300' : '80_bis_150' );
 		$primary_bottleneck = 'low' === $portal_margin_loss ? 'tracking_klarheit' : 'lead_qualitaet';
 	} else {
+		// Nur der Standard-Audit fragt Lead-Volumen und CPL wirklich ab. Im
+		// Marktcheck oben werden beide aus Vertriebsgröße und Margendruck
+		// geschätzt — das muss im CRM erkennbar bleiben, sonst liest sich eine
+		// Ableitung später wie eine Angabe des Betriebs.
 		if ( '' === $postal_code || ! preg_match( '/^[0-9]{5}$/', $postal_code ) ) {
 			return new WP_Error( 'invalid_postal_code', 'Bitte eine gültige fünfstellige deutsche Postleitzahl angeben.' );
 		}
@@ -1736,9 +1740,23 @@ function nexus_validate_energy_review_request_payload( $payload ) {
 	$entry_page_url        = nexus_sanitize_review_request_internal_url( $payload['entry_page_url'] ?? '' );
 	$previous_internal_url = nexus_sanitize_review_request_internal_url( $payload['previous_internal_url'] ?? '' );
 	$referrer_url          = nexus_sanitize_review_request_referrer_url( $payload['referrer_url'] ?? '' );
-	$resolved_domain = $page_url
-		? (string) wp_parse_url( $page_url, PHP_URL_HOST )
-		: nexus_get_review_request_domain_from_email( $email );
+	// Im Standard-Audit ist page_url ein Eingabefeld: die Seite des Interessenten.
+	// Der Hero-Marktcheck schickt dagegen immer die eigene Money-Page mit, sodass
+	// dort bislang in jedem Datensatz hasimuener.de als Firmendomain stand. Für
+	// diesen Pfad ist die geschäftliche E-Mail die einzige echte Domain-Quelle.
+	$derived_suffix = $is_b2b_system_intake ? ' (geschätzt)' : '';
+
+	$email_domain = nexus_get_review_request_domain_from_email( $email );
+
+	if ( $is_b2b_system_intake ) {
+		$resolved_domain = $email_domain
+			? $email_domain
+			: (string) wp_parse_url( $page_url, PHP_URL_HOST );
+	} else {
+		$resolved_domain = $page_url
+			? (string) wp_parse_url( $page_url, PHP_URL_HOST )
+			: $email_domain;
+	}
 
 	$lookup_label = static function( $group, $key ) use ( $field_options ) {
 		if ( '' === $key || ! isset( $field_options[ $group ][ $key ]['label'] ) ) {
@@ -1781,9 +1799,14 @@ function nexus_validate_energy_review_request_payload( $payload ) {
 		'portal_margin_loss'          => $portal_margin_loss,
 		'portal_margin_loss_label'    => $portal_margin_loss_options[ $portal_margin_loss ] ?? '',
 		'lead_volume'                 => $lead_volume,
-		'lead_volume_label'           => $lookup_label( 'lead_volume', $lead_volume ),
+		'lead_volume_label'           => $derived_suffix
+			? $lookup_label( 'lead_volume', $lead_volume ) . $derived_suffix
+			: $lookup_label( 'lead_volume', $lead_volume ),
 		'cpl_range'                   => $cpl_range,
-		'cpl_range_label'             => $lookup_label( 'cpl_range', $cpl_range ),
+		'cpl_range_label'             => $derived_suffix
+			? $lookup_label( 'cpl_range', $cpl_range ) . $derived_suffix
+			: $lookup_label( 'cpl_range', $cpl_range ),
+		'estimates_are_derived'       => $is_b2b_system_intake,
 		'primary_bottleneck'          => $primary_bottleneck,
 		'primary_bottleneck_label'    => $lookup_label( 'primary_bottleneck', $primary_bottleneck ),
 		'solution_focus'              => $solution_focus,
@@ -2158,7 +2181,13 @@ function nexus_get_review_request_detail_rows( $payload ) {
 					'value' => (string) ( $payload['phone'] ?? '' ),
 				],
 				[
-					'label' => 'Website',
+					// page_url ist hier die eigene Money-Page, nicht der Betrieb.
+					// Die Domain kommt aus der geschäftlichen E-Mail.
+					'label' => 'Firmen-Domain',
+					'value' => (string) ( $payload['domain'] ?? '' ),
+				],
+				[
+					'label' => 'Eingang über',
 					'value' => (string) ( $payload['page_url'] ?? '' ),
 				],
 			];


### PR DESCRIPTION
Drei Befunde aus der Codex-Analyse, jeweils am Code nachvollzogen. PR statt direkt auf `main`, weil alle drei beeinflussen, **was in den CRM-Datensatz geschrieben wird** — ein Code-Revert holt bereits geschriebene Datensätze nicht zurück.

## 1. AT und CH konnten den Marktcheck nicht absenden

`solar-leadgenerierung-solara.js` liess nur `/^[0-9]{5}$/` zu. Österreich und die Schweiz haben **vierstellige** PLZ — jede Anfrage von dort scheiterte an der Client-Validierung, während Hero-Eyebrow, Subline und Trust-Badge DACH versprechen und `docs/standards/BRAND_AND_COPY.md:14` den DACH-Raum als Positionierung führt.

Jetzt 4–5 Stellen. Warum das gefahrlos ist:

- Der Marktcheck-Pfad (`b2b_system_intake`) validiert das PLZ-Format **serverseitig gar nicht** — die 5-Stellen-Regel in `review-crm.php` liegt im `else`-Zweig des Standard-Audits und bleibt unangetastet.
- Es gibt keine nachgelagerte Logik, die auf DE-Format baut (keine PLZ→Region-Ableitung); die Region prüfst du manuell.

Getestet gegen `30159`, `10115` (DE), `1010`, `6020` (AT), `8001`, `3011` (CH) — alle akzeptiert; `123`, `123456`, `ABCD` weiter abgelehnt.

## 2. Firmendomain war in jedem Datensatz `hasimuener.de`

```php
$resolved_domain = $page_url ? host($page_url) : domainAusEmail($email);
```

Im Marktcheck ist `page_url` immer die eigene Money-Page, also griff der E-Mail-Fallback nie.

Wichtig: **einfach umdrehen wäre falsch gewesen.** Im Standard-Audit ist `page_url` ein Eingabefeld mit der Seite des Interessenten (`audit.js`, Platzhalter „z. B. https://example.de") — dort ist die bisherige Ableitung korrekt. Die Auflösung ist deshalb pro Pfad getrennt.

Ebenfalls geprüft und verworfen: `company_website` aus dem Payload ist ein **Honeypot**, keine Datenquelle.

Getestet:

| Fall | Ergebnis |
|---|---|
| Marktcheck, `chef@solar-mueller.de` | `solar-mueller.de` |
| Marktcheck, `office@pv-huber.at` | `pv-huber.at` |
| Marktcheck, Mail leer | `hasimuener.de` (Fallback) |
| Standard-Audit, Kundenseite | `kunde-beispiel.de` (unverändert) |

Die Benachrichtigung zeigt jetzt „Firmen-Domain" und „Eingang über" getrennt — vorher stand unter „Website" die eigene URL.

## 3. Lead-Volumen und CPL sind Schätzungen, sahen aber aus wie Angaben

`review-crm.php` leitet beide aus Vertriebsgrösse und subjektivem Margendruck ab. Im Datensatz landete dann z. B. „151–300 €", ohne dass das je jemand gesagt hat.

Einschränkung zur ursprünglichen Analyse: In der **Marktcheck-Benachrichtigung werden sie gar nicht angezeigt** — nur im Standard-Audit, wo sie echt abgefragt werden. Gespeichert und in den CRM-Payload exportiert werden sie aber in beiden Fällen. Die Labels tragen im Marktcheck-Pfad jetzt `(geschätzt)`, der Payload zusätzlich `estimates_are_derived`.

## Nicht in diesem PR

Bewusst offen, weil es Angebots- statt Code-Entscheidungen sind:

- **„Geschäftsführung verkauft selbst" → `nurture`** (`review-crm.php:918`). Die Option ist neutral-positiv beschriftet, sortiert aber unsichtbar aus. Ob ein inhabergeführter Betrieb dein Fit ist, entscheidest du.
- **Cal.com-Buchung für automatisch qualifizierte Leads**, während die Nachricht darüber eine persönliche Prüfung in 48 h verspricht.
- **Kein Tracking-Consumer**: 54 `data-track-*`-Hooks live, 0 GTM/gtag/dataLayer.

## Prüfung

PHP-Lint, `node --check`, E3-Canon-Guard, Canon-Drift, German Copy Guard, CSS-Motion-Guard, Architecture-Validation, Lead-Path-Smoke — alle grün.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WRigau19QMYNj6RF8zoEcE)_