### PR TITLE
CTA-Zusage auf den Wortlaut der Seite zurückführen

### DIFF
--- a/blocksy-child/page-whitelabel-retainer.php
+++ b/blocksy-child/page-whitelabel-retainer.php
@@ -27,10 +27,18 @@ $mailto_url          = 'mailto:hallo@hasimuener.de';
 // neue Datenverarbeitung, kein REST-Endpunkt — die Core Web Vitals der Route
 // bleiben unangetastet.
 //
-// Das 4-Stunden-Versprechen steht ohnehin zweimal auf der Seite (Kontrakt-
-// Karte 02, FAQ "kapazitaet"). Hier trägt es zum ersten Mal einen CTA statt
-// als Fußnote zu enden.
-$task_brief_response = 'Einschätzung innerhalb von 4 Stunden werktags';
+// Das 4-Stunden-Versprechen steht ohnehin an vier Stellen der Seite
+// (Kontrakt-Karte 02 samt Bullet, Founder-Chip, FAQ "kapazitaet"). Hier trägt
+// es zum ersten Mal einen CTA statt als Fußnote zu enden.
+//
+// Bewusst "Antwort" und nicht "Einschätzung": eine Einschätzung zu Machbarkeit,
+// Aufwand und Preisrichtung ist auf eine freitextliche Aufgabenbeschreibung hin
+// in vier Stunden oft gar nicht möglich, ohne vorher Rückfragen zu stellen.
+// Zwei verschiedene Versprechen unter derselben Zahl wären genau der
+// Widerspruch, den der Test-Sprint-Block gerade losgeworden ist — und ein
+// Versprechen, das auf den ersten Bildschirm wandert, muss die haltbarste
+// Fassung sein, nicht die kühnste.
+$task_brief_response = 'Antwort innerhalb von 4 Stunden werktags';
 $task_brief_url      = $mailto_url . '?subject=' . rawurlencode( 'White-Label: konkrete Aufgabe' )
 	. '&body=' . rawurlencode(
 		"Aufgabe:\n\n\nGewünschter Zeitraum:\n\n\nZugänge vorhanden (WordPress, GA4, GTM):\n\n"


### PR DESCRIPTION
Nachtrag zu #194. Der dort gemergte PR ist abgeschlossen und kann diese Änderung nicht mehr tragen, deshalb ein eigener PR auf dem neu von `main` aufgesetzten Branch.

## Problem — aktuell live

Der mit #194 eingeführte zweite CTA verspricht an drei Stellen:

> Aufgabe beschreiben — **Einschätzung** innerhalb von 4 Stunden werktags

Die Seite sagt an vier anderen Stellen etwas anderes zu — Kontrakt-Karte 02, deren Bullet, Founder-Chip und FAQ „kapazitaet":

> **Antwort** innerhalb von 4 Stunden werktags

Eine Antwort ist eine Rückmeldung. Eine Einschätzung ist eine Aussage zu Machbarkeit, Aufwand und Preisrichtung — auf eine freitextliche Aufgabenbeschreibung hin in vier Stunden oft gar nicht möglich, ohne vorher Rückfragen zu stellen.

Damit steht dieselbe Zahl mit zwei verschiedenen Versprechen auf einer Seite. Das ist genau das Muster, das Finding 5 im Test-Sprint-Block gerade beseitigt hat, und es streift Regel F.4 („keine absoluten Versprechen") stärker als nötig.

Erschwerend: Das Versprechen ist mit #194 vom Fußnoten-Rang auf den ersten Bildschirm gewandert. Ein Versprechen an dieser Position ist das, an dem gemessen wird — es muss die haltbarste Fassung sein, nicht die kühnste.

## Änderung

Das Label liegt zentral in `$task_brief_response`, daher eine Stelle für alle drei CTAs:

```
- $task_brief_response = 'Einschätzung innerhalb von 4 Stunden werktags';
+ $task_brief_response = 'Antwort innerhalb von 4 Stunden werktags';
```

Der Conversion-Treiber ist die Geschwindigkeit, nicht das Wort. Die Zusage bleibt gleich stark, wird deckungsgleich mit den vier anderen Stellen — und ist tatsächlich haltbar.

Das Briefing gibt das Label wörtlich mit „Einschätzung" vor; es kollidiert dort mit dem eigenen Kanon der Seite. Diese Abweichung vom Briefing ist bewusst und mit dem Auftraggeber abgestimmt.

## Verifikation

Live-Abruf beider Routen nach dem Deploy von #194 bestätigt: GitHub-Link entfernt, alle vier White-Label-Preise korrekt, Referenz-Links vorhanden, „Historisches Fallbeispiel" entfernt, Endkunden-Setup-Preise angehoben, Monatsbeiträge unverändert, keine Preisinversion zwischen den beiden indexierten Seiten. Einzig offen war die hier korrigierte CTA-Zusage.

Guards gegen `origin/main` lokal grün: `validate-architecture.sh`, `smoke-lead-path-contract.sh`, `lint-e3-canon.sh`, `lint-canon-drift.sh`, `lint-css-motion.sh`, `lint-css-spacing.sh`, `check-german-copy.sh`, PHP-Syntaxprüfung über `blocksy-child/`.

## Weiterhin offen

Punkt 8 (`?page_id=`-Links, liegt in der WordPress-Menüverwaltung) und Punkt 9 (Retainer-Untergrenze). Zu Punkt 9: der vorgeschlagene Betrag von 1.500 € / Monat entspricht `HU_PERFORMANCE_RETAINER_PRICE` und widerspräche damit der 30-%-Regel der White-Label-Leiter — Klärung steht aus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014385bLwQAgyLUEf9kiJUTG

---
_Generated by [Claude Code](https://claude.ai/code/session_014385bLwQAgyLUEf9kiJUTG)_