### PR TITLE
Retainer-Untergrenze ergänzen

### DIFF
--- a/blocksy-child/inc/canon/pricing-canon.php
+++ b/blocksy-child/inc/canon/pricing-canon.php
@@ -313,6 +313,17 @@ define( 'HU_WHITELABEL_TRACKING_AUDIT_MIN', 690 );
 define( 'HU_WHITELABEL_SERVER_SIDE_MIN', 1290 );
 define( 'HU_WHITELABEL_LANDINGPAGE_MIN', 1900 );
 
+// Der Retainer ist die versprochene Zielstufe des Partner-Funnels und trug
+// keine Zahl — damit war er eine Absichtserklaerung. Eine Untergrenze macht
+// ihn real, ohne dass eine Obergrenze jemanden verschreckt.
+//
+// 1.000 statt der zuerst vorgeschlagenen 1.500: HU_PERFORMANCE_RETAINER_PRICE
+// oben ist der Endkunden-Retainer und steht ebenfalls bei 1.500. Derselbe
+// Betrag hiesse, die Agentur zahlt so viel wie ein Endkunde — das bricht die
+// 30-%-Regel, die auf jeder anderen Sprosse dieser Leiter gilt. 1.000 haelt
+// sie und entspricht HU_PERFORMANCE_FOUNDING_RETAINER.
+define( 'HU_WHITELABEL_RETAINER_MIN', 1000 );
+
 /**
  * Return the canonical White-Label pricing model.
  *
@@ -339,6 +350,10 @@ function hu_whitelabel_pricing_canon() {
 		'landingpage'      => [
 			'value'   => HU_WHITELABEL_LANDINGPAGE_MIN,
 			'display' => 'ab ' . hu_format_eur( HU_WHITELABEL_LANDINGPAGE_MIN ) . ' netto',
+		],
+		'retainer'         => [
+			'value'   => HU_WHITELABEL_RETAINER_MIN,
+			'display' => 'ab ' . hu_format_eur( HU_WHITELABEL_RETAINER_MIN ) . ' / Monat netto',
 		],
 	];
 }

--- a/blocksy-child/inc/helpers.php
+++ b/blocksy-child/inc/helpers.php
@@ -994,6 +994,9 @@ function nexus_get_whitelabel_faq_items() {
 	$landingpage_price  = function_exists( 'hu_whitelabel_price' )
 		? hu_whitelabel_price( 'landingpage', 'display', 'einem Festpreis nach Umfangsklärung' )
 		: 'einem Festpreis nach Umfangsklärung';
+	$retainer_price     = function_exists( 'hu_whitelabel_price' )
+		? hu_whitelabel_price( 'retainer', 'display', 'einem vorab vereinbarten Monatsbeitrag' )
+		: 'einem vorab vereinbarten Monatsbeitrag';
 
 	return [
 		[
@@ -1003,7 +1006,7 @@ function nexus_get_whitelabel_faq_items() {
 			// hier nur "Festpreis nach Umfangsklaerung", widerspraeche die FAQ den
 			// Karten direkt darueber — und die FAQ geht zusaetzlich als FAQPage-
 			// Schema raus.
-			'answer'   => sprintf( 'Der WordPress-Test-Sprint ist mit %1$s der kleinste Einstieg und hat einen vorab schriftlich abgegrenzten Umfang. Die größeren Erstprojekte starten beim Tracking-Audit %2$s, beim Server-Side-Setup %3$s und bei der Landingpage %4$s; der verbindliche Festpreis wird nach der Umfangsklärung schriftlich vereinbart. Ein Retainer entsteht erst nach einem erfolgreichen Erstprojekt und erhält einen vorab vereinbarten Leistungsrahmen.', $test_sprint_price, $audit_price, $server_side_price, $landingpage_price ),
+			'answer'   => sprintf( 'Der WordPress-Test-Sprint ist mit %1$s der kleinste Einstieg und hat einen vorab schriftlich abgegrenzten Umfang. Die größeren Erstprojekte starten beim Tracking-Audit %2$s, beim Server-Side-Setup %3$s und bei der Landingpage %4$s; der verbindliche Festpreis wird nach der Umfangsklärung schriftlich vereinbart. Ein Retainer entsteht erst nach einem erfolgreichen Erstprojekt, startet %5$s und erhält einen vorab vereinbarten Leistungsrahmen.', $test_sprint_price, $audit_price, $server_side_price, $landingpage_price, $retainer_price ),
 		],
 		[
 			'key'      => 'sprint-scope',

--- a/blocksy-child/page-whitelabel-retainer.php
+++ b/blocksy-child/page-whitelabel-retainer.php
@@ -102,6 +102,7 @@ $test_sprint_price_card = hu_whitelabel_price( 'test_sprint', 'display_fixed', $
 $tracking_audit_price   = hu_whitelabel_price( 'tracking_audit', 'display', 'Festpreis nach Umfangsklärung' );
 $server_side_price      = hu_whitelabel_price( 'server_side', 'display', 'Festpreis nach Umfangsklärung' );
 $landingpage_price      = hu_whitelabel_price( 'landingpage', 'display', 'Festpreis nach Umfangsklärung' );
+$retainer_price         = hu_whitelabel_price( 'retainer', 'display' );
 
 $proof_metrics = [
 	[
@@ -593,7 +594,7 @@ $fitcheck_steps = [
 				<a href="<?php echo esc_url( $task_brief_url ); ?>" class="nx-btn wl-btn--task" data-track-action="cta_whitelabel_entry_task_brief" data-track-category="lead_gen" data-track-section="entry">
 					Aufgabe beschreiben — <?php echo esc_html( $task_brief_response ); ?>
 				</a>
-				<p class="wl-entry__retainer-note">Wenn das Erstprojekt erfolgreich abgeschlossen ist, kann daraus ein Monats-Retainer mit vorab vereinbartem Leistungsrahmen entstehen.</p>
+				<p class="wl-entry__retainer-note">Wenn das Erstprojekt erfolgreich abgeschlossen ist, kann daraus ein Monats-Retainer mit vorab vereinbartem Leistungsrahmen entstehen<?php echo $retainer_price ? ' — ' . esc_html( $retainer_price ) : ''; ?>.</p>
 			</div>
 		</div>
 	</section>


### PR DESCRIPTION
Punkt 9 der Umsetzungsreihenfolge. Letzter offener Repo-Punkt aus dem CRO-Befund.

## Warum nicht die vorgeschlagenen 1.500 €

Der Befund schlägt „ab 1.500 € / Monat netto" vor. Im Kanon steht bereits `HU_PERFORMANCE_RETAINER_PRICE = 1500` — der Endkunden-Retainer. Derselbe Betrag hieße: die Agentur zahlt so viel wie ein Endkunde.

Das bricht die 30-%-Regel, die auf jeder anderen Sprosse der White-Label-Leiter gilt, und ist dieselbe Inversion, die Abschnitt C.1 bei den Setup-Preisen gerade beseitigt hat — nur eine Ebene höher.

**Gewählt: 1.000 € / Monat netto.** Hält die Regel bei 33 % und entspricht `HU_PERFORMANCE_FOUNDING_RETAINER`, ist also keine erfundene Zahl.

Die Alternative wäre gewesen, 1.500 € zu behalten und die beiden Retainer als verschiedene Produkte kenntlich zu machen. Das hätte neue Copy gebraucht, die erklärt, warum eine Agentur so viel zahlt wie ein Endkunde — mehr Seitenfläche und ein schwererer Verkauf, gegen die Auflage „kein Redesign".

## Änderung

Neue Kanon-Konstante plus Anzeige an den beiden Stellen, die den Retainer bisher ohne Zahl versprachen:

- Abschluss des Einstiegs-Blocks („… kann daraus ein Monats-Retainer … entstehen")
- Abrechnungs-FAQ, die zusätzlich ins FAQPage-Schema geht

Weiterhin kein Stundensatz auf der Seite. „ab" statt Spanne wie auf allen anderen Sprossen.

## Verifikation

Preislogik gegengerechnet: White-Label-Retainer 1.000 € liegt 33 % unter dem Endkunden-Retainer von 1.500 € — keine Inversion.

Guards gegen `origin/main` lokal grün: `validate-architecture.sh`, `smoke-lead-path-contract.sh`, `lint-e3-canon.sh`, `lint-canon-drift.sh`, `lint-css-motion.sh`, `lint-css-spacing.sh`, `check-german-copy.sh`, PHP-Syntaxprüfung über `blocksy-child/`, Pre-Deploy-Smoke.

Zusätzlich: Sichtprüfung der mit #194 und #195 ausgelieferten Flächen ist nachgeholt. Live-Seite gespiegelt und in 1440 px und 390 px gerendert — kein horizontaler Überlauf in beiden Breiten, Preiskarten bündig, Proof-Kacheln in gleicher Schriftgröße, Referenz-Links stapeln mobil einspaltig, beide Hero-CTAs optisch gleichrangig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014385bLwQAgyLUEf9kiJUTG

---
_Generated by [Claude Code](https://claude.ai/code/session_014385bLwQAgyLUEf9kiJUTG)_