### PR TITLE
Referenz conversionengine.de gegen e3-newenergy.de tauschen

### DIFF
--- a/blocksy-child/page-whitelabel-retainer.php
+++ b/blocksy-child/page-whitelabel-retainer.php
@@ -120,10 +120,15 @@ $proof_metrics = [
 ];
 
 // ── Prüfbare Arbeiten neben der anonymisierten Zahlenkachel ─────
-// Die Kennzahlen oben stammen aus einem Mandat unter NDA und sind für einen
-// Fremden nicht nachprüfbar. Diese drei Seiten sind es: eigene bzw. offene
-// Projekte, kein NDA steht dagegen. Beschrieben wird die technische
-// Schwierigkeit — nicht der Kunde und nicht der Inhalt.
+// Die Kennzahlen oben sind für einen Fremden nicht nachprüfbar. Diese drei
+// Seiten sind es. Beschrieben wird jeweils die Aufgabe, nicht der Kunde und
+// nicht der Inhalt; Kennzahlen bleiben ausdrücklich aus diesem Block heraus,
+// damit keine der Seiten als Beleg für die Zahlen oben gelesen wird.
+//
+// Der Block nennt bewusst keine Code-Ebene mehr ("Quelltext lesen"): nicht
+// jede der drei Seiten liegt auf einem individuellen Template, und die
+// Aufforderung stünde zwei Abschnitte unter dem Versprechen individueller
+// Templates.
 $proof_references = [
 	[
 		'label' => 'civaka-azad.org',
@@ -131,9 +136,13 @@ $proof_references = [
 		'note'  => 'Informationsarchitektur für einen großen, über Jahre gewachsenen redaktionellen Bestand: Navigation, Archive und interne Verweise so strukturiert, dass ältere Beiträge auffindbar bleiben.',
 	],
 	[
-		'label' => 'conversionengine.de',
-		'url'   => 'https://conversionengine.de/',
-		'note'  => 'Onepage mit durchgehender Vertriebslogik: eine einzige Seite, die Argumentation, Einwandbehandlung und Abschluss ohne Seitenwechsel trägt.',
+		'label' => 'e3-newenergy.de',
+		'url'   => 'https://e3-newenergy.de/',
+		// Bewusst ohne Kennzahlen und ohne Zuordnung zum Fallbeispiel oben: die
+		// Seite steht hier als Referenz, nicht als Beleg für die Zahlen. Auch
+		// bewusst ohne Aussage zur Code-Ebene — die Seite läuft heute auf einem
+		// Page-Builder, und der Block daneben wirbt mit individuellen Templates.
+		'note'  => 'Solar und Wärmepumpe mit erklärungsbedürftigem Angebot: eine Strecke, die Beratung, Angebotsanfrage und Kontakt zusammenführt, statt sie über die Seite zu verteilen.',
 	],
 	[
 		'label' => 'hasimuener.org',
@@ -776,8 +785,8 @@ $fitcheck_steps = [
 			<p class="wl-proof__disclaimer">Fallbeispiel aus 2024–2025 · eigenes Projekt, kein White-Label-Mandat · keine pauschale Übertragbarkeitsgarantie.</p>
 
 			<div class="wl-proof__refs nx-reveal">
-				<h3 class="wl-proof__refs-title">Direkt prüfbar: drei Live-Umsetzungen</h3>
-				<p class="wl-proof__refs-lede">Die Zahlen oben stammen aus einem Mandat, dessen Kunde anonym bleibt. Diese drei Seiten sind offen — anschauen, Quelltext lesen, Ladeverhalten messen.</p>
+				<h3 class="wl-proof__refs-title">Direkt prüfbar: drei Live-Referenzen</h3>
+				<p class="wl-proof__refs-lede">Drei Seiten, die offen einsehbar sind — anschauen und selbst beurteilen, ob das Niveau passt.</p>
 				<ul class="wl-proof__refs-list" role="list">
 					<?php foreach ( $proof_references as $reference ) : ?>
 						<li class="wl-proof__ref">


### PR DESCRIPTION
Tausch der zweiten Referenz im Proof-Block, plus zwei Anpassungen am Rahmen, ohne die der Block sich selbst widerspräche.

## Vorab geprüft

Die zuerst genannte Domain `e3-new-energy.de` (mit Bindestrich) löst nicht auf — weder lokal noch über den Proxy, während zwei Kontrolldomains über denselben Weg 200 liefern. Die korrekte Adresse ist `e3-newenergy.de`: löst auf 78.47.106.35 auf, liefert 200, `http://` leitet sauber auf `https://` weiter.

Alle drei Referenzen nach dem Tausch geprüft — `civaka-azad.org`, `e3-newenergy.de`, `hasimuener.org` liefern je 200.

## Warum der Rahmen mitgeändert wird

**„Quelltext lesen" entfällt.** Der Block forderte zum Lesen des Quelltexts auf. Nicht jede der drei Seiten liegt auf einem individuellen Template, und die Aufforderung stand zwei Abschnitte unter dem Versprechen individueller Templates und der Abgrenzung gegen Standard-Themes. Ein Leser, der ihr folgt, findet dort einen Page-Builder. Die Überschrift heißt entsprechend „drei Live-Referenzen" statt „drei Live-Umsetzungen".

**Die Anonymitätszeile entfällt.** „Die Zahlen oben stammen aus einem Mandat, dessen Kunde anonym bleibt" stünde jetzt unmittelbar über der Seite eines Kunden. Die NDA-Zusage selbst bleibt unberührt — sie steht im Lede der Sektion darüber, wo sie hingehört und wo sie das Verkaufsargument trägt.

Der neue Eintrag nennt keine Kennzahlen und stellt keine Verbindung zum Fallbeispiel her: die Seite steht als Referenz, nicht als Beleg für die Zahlen darüber. Die anonymisierten Kennzahlen und der Kanon bleiben unverändert.

## Verifikation

Guards gegen `origin/main` lokal grün: `validate-architecture.sh`, `smoke-lead-path-contract.sh`, `lint-e3-canon.sh`, `lint-canon-drift.sh`, `lint-css-motion.sh`, `lint-css-spacing.sh`, `check-german-copy.sh`, PHP-Syntaxprüfung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014385bLwQAgyLUEf9kiJUTG

---
_Generated by [Claude Code](https://claude.ai/code/session_014385bLwQAgyLUEf9kiJUTG)_