### PR TITLE
Fix freelancer Lighthouse accessibility and hero copy

### DIFF
--- a/blocksy-child/assets/css/wordpress-freelancer-hannover-polish.css
+++ b/blocksy-child/assets/css/wordpress-freelancer-hannover-polish.css
@@ -3,6 +3,10 @@
  * Verdichtet den bestehenden Light-Mode-Aufbau, ohne neue Effekte oder
  * Komponenten einzufuehren. Die Systemgrafik und der Git-Workflow bleiben
  * die beiden visuellen Schwerpunktmomente der Route.
+ *
+ * Lighthouse-Follow-up 2026-08-16: Kontraste der kleinen Code-/Footer-Texte
+ * absichtlich mit deutlicher Reserve ueber AA; die SVG-Daueranimation bleibt
+ * statisch, weil Lighthouse sie als nicht-kompositierte Animation meldete.
  */
 
 .hu-fr__hero {
@@ -80,6 +84,42 @@
 	font-size: 0.76rem;
 	line-height: 1.6;
 	color: var(--fr-muted);
+}
+
+/* Accessibility: explicit high-contrast values for Lighthouse findings. */
+.hu-fr-git__topbar code {
+	color: #e2d9cf;
+}
+
+.hu-fr-git__rows code {
+	color: #e0ad8b;
+}
+
+.hu-fr__lab-note {
+	color: #6b625b;
+}
+
+.hu-fr__final .hu-fr__kicker {
+	color: #6a321b;
+}
+
+.hu-fr__final-action > p:first-child {
+	color: #463f39;
+}
+
+.hu-fr__route-links {
+	color: #4f4740 !important;
+}
+
+/*
+ * Performance: statische Signal-Linie statt endloser stroke-dashoffset-
+ * Animation. Die Grafik bleibt als visuelles System erhalten, ohne den von
+ * Lighthouse gemeldeten nicht-kompositierten Animationspfad.
+ */
+.hu-fr-system__signal {
+	animation: none !important;
+	stroke-dasharray: none;
+	stroke-opacity: 0.92;
 }
 
 @media (max-width: 980px) {

--- a/blocksy-child/assets/css/wordpress-freelancer-hannover-polish.css
+++ b/blocksy-child/assets/css/wordpress-freelancer-hannover-polish.css
@@ -155,3 +155,9 @@
 		padding: 72px 0;
 	}
 }
+
+@media (prefers-reduced-motion: reduce) {
+	.hu-fr-system__signal {
+		animation: none !important;
+	}
+}

--- a/blocksy-child/page-wordpress-freelancer-hannover.php
+++ b/blocksy-child/page-wordpress-freelancer-hannover.php
@@ -170,7 +170,7 @@ get_header();
 				<div class="hu-fr__hero-grid">
 					<div class="hu-fr__hero-copy">
 						<h1 id="hu-fr-title" class="hu-fr__seo-title">WordPress Freelancer Hannover</h1>
-						<p class="hu-fr__hero-title">Technik, Tracking und Funnel — ohne technische Übergaben.</p>
+						<p class="hu-fr__hero-title">Technik, Tracking und Funnel aus einer Hand.</p>
 						<p class="hu-fr__lede">Ich entwickle WordPress-Websites und Landingpages so, dass Code, Messung und Conversion-Logik zusammenpassen. Direkt mit mir — vom Scope bis zum Deployment.</p>
 
 						<ul class="hu-fr__hero-capabilities" role="list" aria-label="Schwerpunkte">
@@ -194,10 +194,10 @@ get_header();
 
 				<ul class="hu-fr__proofline" role="list" aria-label="Kurzbelege">
 					<li><strong>8+ Jahre</strong><span>WordPress &amp; Web</span></li>
-					<li><strong>99/100</strong><span>Mobile Performance*</span></li>
-					<li><strong>100/100</strong><span>Accessibility*</span></li>
+					<li><strong>92/100</strong><span>Mobile Performance*</span></li>
+					<li><strong>97/100</strong><span>Accessibility*</span></li>
 				</ul>
-				<p class="hu-fr__lab-note">* Lighthouse-Labtest auf hasimuener.de, August 2026. Kein Ersatz für CrUX-Felddaten.</p>
+				<p class="hu-fr__lab-note">* Lighthouse Mobile-Labtest dieser Seite, 16.08.2026, 23:25 MESZ. Werte können variieren; keine CrUX-Felddaten.</p>
 			</div>
 		</section>
 


### PR DESCRIPTION
## Anlass
Lighthouse Mobile vom 16.08.2026, 23:25 MESZ: Performance 92, Accessibility 97, Best Practices 100, SEO 100. Der Accessibility-Abzug kommt aus Kontrastfehlern; Lighthouse meldet außerdem eine nicht-kompositierte Daueranimation.

## Änderungen
- Hero: „Technik, Tracking und Funnel aus einer Hand.“
- aktuelle Lighthouse-Baseline statt veralteter 99/100- bzw. 100/100-Angabe
- stärkere Kontraste für Git-Codezeilen, Lab-Hinweis und finalen Routing-Text
- SVG-Signallinie bleibt visuell erhalten, aber ohne endlose `stroke-dashoffset`-Animation
- keine neue JS-Abhängigkeit, keine neue Route, keine SEO-Ownership-Änderung

## Bewusst
Die Seite behauptet noch nicht 100/100 Accessibility. Erst nach dem Live-Deploy und einem neuen Lighthouse-Lauf wird ein neuer Wert als Proof übernommen. Lighthouse-Labwerte sind keine CrUX-/CWV-Felddaten.