### PR TITLE
Reposition site around WordPress, tracking and conversion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,12 @@ Global contract for agents in this repo. Keep context small: read this file, the
    - Skill work: `agents/skills/CONTEXT.md`
 3. Only the files needed for the task.
 
+For positioning, public copy, offers, CTA routing, or schema identity work, also read:
+
+- `docs/standards/BRAND_AND_COPY.md`
+- `docs/architecture/CONVERSION_ROUTING.md`
+- `docs/seo/query-ownership.csv` when SEO ownership is touched
+
 ## Skill Routing
 
 - `agents/skills/` is the canonical skill source for every agent host.
@@ -64,13 +70,20 @@ These files cost more context than a whole task should. Locate the relevant line
 
 ## Product Defaults
 
-- Canonical public routes, entry points, and business positioning live in `llms.txt`; use it as the route index before adding or changing public URLs.
-- Diagnosis/analysis canon: `blocksy-child/inc/canon/diagnose-canon.php`
-- Analyse before implementation pitch. Clarity before feature count.
-- Do not reintroduce broad agency wording when it weakens the diagnosis-first funnel.
+- Canonical public routes and AI-facing route summaries live in `llms.txt`; use it as a route index before adding or changing public URLs.
+- Positioning and copy rules live in `docs/standards/BRAND_AND_COPY.md`.
+- CTA destination logic lives in `docs/architecture/CONVERSION_ROUTING.md`.
+- SEO query ownership lives in `docs/seo/query-ownership.csv`.
+- **Do not conflate SEO ownership with conversion routing.** A page can own a query and still send its CTA to a different next action.
+- Global fachliche Klammer: WordPress, technisches SEO, Tracking, Conversion.
+- Commercial entry paths:
+  - direct clients -> `/wordpress-freelancer-hannover/` / generic project request
+  - agencies -> `/whitelabel-retainer/`
+  - Solar / Wärmepumpe / Speicher -> `/solar-waermepumpen-leadgenerierung/` / Marktcheck
+- The Marktcheck is not a site-wide default CTA anymore. Use it only for the Energy cluster.
+- Diagnosis/analysis canon: `blocksy-child/inc/canon/diagnose-canon.php` remains valid for the Energy funnel.
 - Do not assume RankMath; use the custom WordPress SEO Cockpit where relevant.
-- Do not reintroduce Shopify as a current service focus unless the task is
-  explicitly about legacy cleanup.
+- Do not reintroduce Shopify as a current service focus unless the task is explicitly about legacy cleanup.
 
 ## Evidence and Measurement Defaults
 
@@ -91,7 +104,7 @@ These files cost more context than a whole task should. Locate the relevant line
   manual tasks separate when a request crosses workstreams.
 - Do not touch live-critical theme, deployment, hosting, or generated assets
   during planning-only work or without explicit scope.
-- Preserve the existing project language, positioning, and architecture.
+- Preserve the current project language, positioning, query ownership, and route contracts from the canonical docs above.
 - For repo audits, report findings under `Critical`, `High leverage`, `Polish`,
   `Manual WordPress tasks`, and `Agent tasks / repo tasks` as applicable.
 - In audits, distinguish repo fixes from editor, SEO Cockpit, WordPress admin,
@@ -121,24 +134,53 @@ These files cost more context than a whole task should. Locate the relevant line
 - Maintain the Hannover landing page layout and copy in `blocksy-child/page-wordpress-agentur.php`.
 - Do not duplicate Hannover page edits into the wrapper template.
 
-## Funnel Ladder
+## Funnel / Route Ladder
 
-1. Marktcheck: qualifier for fit, not a generic sale.
-2. Anfragesystem-Analyse: evidence-based fit and market check for suitable businesses.
-3. Anfragesystem-Umsetzung: build only after green/yellow fit.
-4. Optional performance and premium layers.
+There is no longer one universal funnel ladder for the whole site.
 
-Use `Umsetzungspartner` for a business that reaches the build stage. Do not reintroduce the retired `Founding Cohort 2026` frame, seat counters, or application deadlines — see `docs/decisions/0011-founding-cohort-2026-entfernt.md`. Customer-facing forbidden terms live in `blocksy-child/inc/canon/messaging-canon.php`.
+### Energy funnel
+
+1. Solar / Wärmepumpe / Speicher content or purchase intent
+2. Marktcheck
+3. Follow-up analysis if useful
+4. Implementation / continued optimization
+
+### Direct-project funnel
+
+1. WordPress / tracking / CRO / technical SEO intent
+2. Relevant specialist or Freelancer page
+3. `Projekt anfragen` / scope clarification
+4. Implementation / continued optimization
+
+### Agency funnel
+
+1. Agency / partner / White-Label intent
+2. White-Label page
+3. Fit-Check / scoped first project
+4. Optional retainer
+
+Use `Umsetzungspartner` for a business that reaches the Solar build stage. Do not reintroduce the retired `Founding Cohort 2026` frame, seat counters, or application deadlines — see `docs/decisions/0011-founding-cohort-2026-entfernt.md`. Customer-facing forbidden terms live in `blocksy-child/inc/canon/messaging-canon.php`.
 
 For any task that touches offer logic, marketcheck framing, proof architecture, qualification, CTA economics, or the WGOS public/delivery boundary, load `agents/skills/offer-funnel-intelligence/SKILL.md` before changing copy or templates.
 
 ## Required Patterns
 
-Internal URLs:
+Generic project request outside Energy and White-Label funnels:
 
 ```php
-$analysis_url = function_exists('hu_get_request_analysis_url') ? hu_get_request_analysis_url() : home_url('/');
-echo esc_url($analysis_url);
+$project_url = function_exists( 'hu_get_navigation_project_request_url' )
+    ? hu_get_navigation_project_request_url()
+    : home_url( '/kontakt/' );
+echo esc_url( $project_url );
+```
+
+Solar Marktcheck only inside Energy intent:
+
+```php
+$analysis_url = function_exists( 'hu_get_request_analysis_url' )
+    ? hu_get_request_analysis_url()
+    : home_url( '/solar-waermepumpen-leadgenerierung/#marktcheck' );
+echo esc_url( $analysis_url );
 ```
 
 Escaping:
@@ -165,11 +207,16 @@ data-track-section=""
 - Do not load or change n8n artifacts unless n8n is explicitly in scope.
 - Do not version editor-owned copy as if it were the live source of truth.
 - Do not write repetitive playbooks in `docs/`; create/update `agents/skills/<skill>/`.
+- Do not redirect or de-index a query-owning page just to simplify CTA routing.
+- Do not use `hu_get_request_analysis_url()` as a generic site-wide project CTA.
 
 ## Update Triggers
 
 - Runtime behavior, route status, or deploy scope changes: update `docs/architecture/LIVE_STATUS.md`.
 - Cross-system contracts or dependencies change: update `docs/architecture/SYSTEM_MAP.md`.
+- CTA-routing contract changes: update `docs/architecture/CONVERSION_ROUTING.md`.
+- Positioning or global public-copy rules change: update `docs/standards/BRAND_AND_COPY.md`.
+- Query ownership changes: update `docs/seo/query-ownership.csv` with evidence.
 - New repetitive workflow: add/update `agents/skills/<skill>/SKILL.md` plus scripts.
 - Skill added or removed: keep matching symlinks in both `.agents/skills/` and
   `.claude/skills/` synchronized with `agents/skills/`.

--- a/blocksy-child/functions.php
+++ b/blocksy-child/functions.php
@@ -51,6 +51,7 @@ $modules = [
 	'enqueue.php',        // CSS/JS Asset-Management
 	'homepage-wow.php',   // Noindex-Testseite fuer visuelle Homepage-Variante
 	'seo-meta.php',       // OG Tags, Canonical, Indexierungssteuerung
+	'positioning-meta.php', // Repositioning-Overrides für globale Homepage-/Blog-Metadaten
 	'seo-subpage-cluster-links.php', // Kontextuelle Querverlinkung des Solar/B2B-Clusters
 	'org-schema.php',     // JSON-LD Structured Data
 	'schema-positioning.php', // Repositioning-Normalisierung der kanonischen Schema-Entitäten

--- a/blocksy-child/functions.php
+++ b/blocksy-child/functions.php
@@ -53,6 +53,7 @@ $modules = [
 	'seo-meta.php',       // OG Tags, Canonical, Indexierungssteuerung
 	'seo-subpage-cluster-links.php', // Kontextuelle Querverlinkung des Solar/B2B-Clusters
 	'org-schema.php',     // JSON-LD Structured Data
+	'schema-positioning.php', // Repositioning-Normalisierung der kanonischen Schema-Entitäten
 	'shortcodes.php',     // Startseiten-Shortcodes
 	'client-portal.php',  // Client Portal Dashboard
 	'admin-manager.php',  // Backend-Felder für Portal

--- a/blocksy-child/inc/canon/messaging-canon.php
+++ b/blocksy-child/inc/canon/messaging-canon.php
@@ -11,12 +11,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define(
 	'HU_MESSAGE_VALUE_ANCHOR_ARCHITECTURE',
-	'Andere Agenturen verkaufen Optik. Wir bauen die Architektur, die Anfragen produziert. Das Design ist dabei.'
+	'WordPress, Tracking und Conversion gehören zusammen. Ich entwickle die technische Basis und messe, was daraus entsteht.'
 );
 
 define(
 	'HU_MESSAGE_VALUE_ANCHOR_PRICE',
-	'Sie würden bei einer WordPress-Agentur 15.000 € für Design ausgeben. Hier bekommen Sie für 9.900 € ein funktionierendes Anfragesystem. Das Design ist dabei.'
+	'Scope und Preis stehen vor dem Start fest. Kein Paketpreis ohne geklärten Umfang.'
 );
 
 /**
@@ -29,10 +29,11 @@ function hu_messaging_canon() {
 		'value_anchor_architecture' => HU_MESSAGE_VALUE_ANCHOR_ARCHITECTURE,
 		'value_anchor_price'        => HU_MESSAGE_VALUE_ANCHOR_PRICE,
 		'what_we_dont_sell'         => [
-			'Keine reine Design-Retusche ohne Anfragesystem.',
+			'Keine reine Design-Retusche ohne technischen oder messbaren Zweck.',
 			'Keine Reporting-Fassade ohne belastbare Datengrundlage.',
-			'Keine Anfrage-Volumengarantie ohne passendes Werbebudget und schriftliche Grundlage.',
+			'Keine Anfrage- oder Umsatzgarantie ohne belastbare Grundlage.',
 			'Keine Kundendaten-Blackbox, bei der Ownership unklar bleibt.',
+			'Kein Full-Service-Versprechen für Leistungen, die nicht zum vereinbarten Scope gehören.',
 		],
 		'forbidden_terms'           => [
 			'Pilotprojekt',
@@ -46,11 +47,14 @@ function hu_messaging_canon() {
 			'Modul',
 		],
 		'preferred_terms'           => [
+			'Projekt anfragen',
+			'direkte Zusammenarbeit',
+			'White-Label',
 			'Umsetzungspartner',
 			'Baustein',
 		],
 		'term_definitions'          => [
-			'Umsetzungspartner' => 'Betrieb, für den nach dem Marktcheck ein eigenes Anfragesystem gebaut wird; kein Mitgründer, kein Anteilseigner und keine gesellschaftsrechtliche Partnerschaft.',
+			'Umsetzungspartner' => 'Betrieb, für den im Solar-/Wärmepumpen-Funnel nach dem Marktcheck ein eigenes Anfragesystem umgesetzt wird; kein Mitgründer, kein Anteilseigner und keine gesellschaftsrechtliche Partnerschaft.',
 		],
 	];
 }

--- a/blocksy-child/inc/llms-txt.php
+++ b/blocksy-child/inc/llms-txt.php
@@ -30,16 +30,24 @@ function nexus_is_llms_txt_request() {
 /**
  * Normalize a public URL into the markdown path used inside llms.txt.
  *
+ * Query arguments are preserved because the generic project route uses them to
+ * distinguish a scoped project request from an unspecific contact visit.
+ *
  * @param string $url Absolute public URL.
  * @return string
  */
 function nexus_get_llms_txt_markdown_path( $url ) {
 	$url      = (string) $url;
 	$path     = wp_parse_url( $url, PHP_URL_PATH );
+	$query    = wp_parse_url( $url, PHP_URL_QUERY );
 	$fragment = wp_parse_url( $url, PHP_URL_FRAGMENT );
 	$path     = is_string( $path ) && '' !== $path ? $path : '/';
 
 	$markdown_path = '/' === $path ? '/' : trailingslashit( '/' . ltrim( $path, '/' ) );
+
+	if ( is_string( $query ) && '' !== $query ) {
+		$markdown_path .= '?' . $query;
+	}
 
 	if ( is_string( $fragment ) && '' !== $fragment ) {
 		$markdown_path .= '#' . ltrim( $fragment, '#' );
@@ -56,6 +64,22 @@ function nexus_get_llms_txt_markdown_path( $url ) {
 function nexus_get_llms_txt_sections() {
 	$urls = function_exists( 'nexus_get_primary_public_url_map' ) ? nexus_get_primary_public_url_map() : [];
 
+	$freelancer_url = $urls['freelancer'] ?? home_url( '/wordpress-freelancer-hannover/' );
+	$whitelabel_url = $urls['whitelabel'] ?? (
+		function_exists( 'nexus_get_whitelabel_page_url' )
+			? nexus_get_whitelabel_page_url()
+			: home_url( '/whitelabel-retainer/' )
+	);
+	$project_url = function_exists( 'hu_get_navigation_project_request_url' )
+		? hu_get_navigation_project_request_url()
+		: add_query_arg(
+			[
+				'type'  => 'project',
+				'focus' => 'followup_scope',
+			],
+			$urls['contact'] ?? home_url( '/kontakt/' )
+		);
+
 	return [
 		[
 			'heading' => 'Primäre Einstiege',
@@ -63,22 +87,57 @@ function nexus_get_llms_txt_sections() {
 				[
 					'label'       => 'Startseite',
 					'url'         => $urls['home'] ?? home_url( '/' ),
-					'description' => 'Überblick über Positionierung, Proof und primäre Einstiege.',
+					'description' => 'Fachliche Klammer und Verteiler auf direkte Projekte, White-Label und Solar/Wärmepumpe.',
+				],
+				[
+					'label'       => 'WordPress Freelancer Hannover',
+					'url'         => $freelancer_url,
+					'description' => 'Direkter Einstieg für WordPress-Projekte mit Entwicklung, Tracking, Funnel/CRO und technischer SEO.',
+				],
+				[
+					'label'       => 'Für Agenturen: White-Label',
+					'url'         => $whitelabel_url,
+					'description' => 'Umsetzungskapazität für Agenturen: WordPress, Tracking, CRO und technische SEO im Hintergrund.',
 				],
 				[
 					'label'       => 'Solar- und Wärmepumpen-Leadgenerierung',
 					'url'         => $urls['energy'] ?? home_url( '/solar-waermepumpen-leadgenerierung/' ),
-					'description' => 'Branchen-Landingpage für eigene Anfragesysteme gegen Portal-Abhängigkeit: Website, Vorqualifizierung, Tracking und steuerbare Werbekanäle.',
+					'description' => 'Spezialisierte Branchen-Landingpage für eigene Anfragesysteme statt Portal-Abhängigkeit.',
+				],
+				[
+					'label'       => 'Projekt anfragen',
+					'url'         => $project_url,
+					'description' => 'Generischer Anfragepfad für direkte WordPress-, Tracking-, CRO- und technische SEO-Projekte.',
 				],
 				[
 					'label'       => 'Marktcheck',
 					'url'         => $urls['audit'] ?? home_url( '/solar-waermepumpen-leadgenerierung/#marktcheck' ),
-					'description' => 'Primärer Einstieg für kalten Solar-/SHK-Traffic: händische Einordnung von Region, Anfragebremsen, Datenlage und nächstem sinnvollen Schritt.',
+					'description' => 'Diagnostischer Einstieg ausschließlich für Solar-, Wärmepumpen- und Speicher-Intent.',
+				],
+			],
+		],
+		[
+			'heading' => 'Fachseiten und kommerzielle Suchintents',
+			'links'   => [
+				[
+					'label'       => 'Server-Side Tracking einrichten lassen',
+					'url'         => $urls['solar_tracking'] ?? home_url( '/server-side-tracking-b2b/' ),
+					'description' => 'Money Page für Server-Side Tracking, Server-GTM, GA4, Google Ads und Meta CAPI; direkter Projektpfad statt Solar-Marktcheck.',
 				],
 				[
-					'label'       => 'Kontakt',
-					'url'         => $urls['contact'] ?? home_url( '/kontakt/' ),
-					'description' => 'Direkter Kontakt für Analyse, Umsetzung und Weiterentwicklung nach Marktcheck-Fit.',
+					'label'       => 'WordPress Agentur Hannover',
+					'url'         => $urls['agentur'] ?? home_url( '/wordpress-agentur-hannover/' ),
+					'description' => 'Lokale SEO-Seite für den Agentur-Intent; direkte Zusammenarbeit wird zur Freelancer-Route weitergeführt.',
+				],
+				[
+					'label'       => 'WordPress Freelancer Hannover',
+					'url'         => $freelancer_url,
+					'description' => 'Lokaler Freelancer-Intent für direkte Zusammenarbeit.',
+				],
+				[
+					'label'       => 'White-Label für Agenturen',
+					'url'         => $whitelabel_url,
+					'description' => 'Agentur-/Partner-Intent mit Fit-Check und scoped Erstprojekt.',
 				],
 			],
 		],
@@ -86,29 +145,29 @@ function nexus_get_llms_txt_sections() {
 			'heading' => 'Proof und zitierfähige Quellen',
 			'links'   => [
 				[
-					'label'       => 'Solar Case Study',
-					'url'         => $urls['e3'] ?? home_url( '/case-study-solar-leadgenerierung/' ),
-					'description' => 'Kaufnaher Proof-Case: eigenes Anfragesystem, Vorqualifizierung, Tracking und Conversion statt Portal-Lead-Abhängigkeit.',
-				],
-				[
-					'label'       => 'Was kosten Solar-Leads? (Marktstudie)',
-					'url'         => $urls['solar_leads_cost_study'] ?? home_url( '/solar-leads-kosten-studie/' ),
-					'description' => 'Zitierfähige Marktstudie zu Lead-Kosten im DACH-Raum: Preisspannen je Modell, Cost-per-Order, Methodik und Case-Study-Benchmark.',
-				],
-				[
 					'label'       => 'Ergebnisse',
 					'url'         => $urls['results'] ?? home_url( '/ergebnisse/' ),
 					'description' => 'Kuratierter Proof-Hub mit Cases, Kennzahlen und Einordnung.',
 				],
 				[
+					'label'       => 'Solar Case Study',
+					'url'         => $urls['e3'] ?? home_url( '/case-study-solar-leadgenerierung/' ),
+					'description' => 'Proof-Case für Nachfrageaufbau, Vorqualifizierung, Tracking und Conversion.',
+				],
+				[
+					'label'       => 'Was kosten Solar-Leads? (Marktstudie)',
+					'url'         => $urls['solar_leads_cost_study'] ?? home_url( '/solar-leads-kosten-studie/' ),
+					'description' => 'Marktstudie zu Lead-Kosten im DACH-Raum: Preisspannen je Modell, Cost-per-Order, Methodik und Case-Study-Benchmark.',
+				],
+				[
 					'label'       => 'Haşim Üner',
 					'url'         => $urls['about'] ?? home_url( '/hasim-uener/' ),
-					'description' => 'Personenprofil des Autors und Betreibers: Stationen, Kompetenzen und Arbeitsweise.',
+					'description' => 'Personenprofil des Betreibers: Arbeitsweise und fachliche Kompetenz.',
 				],
 			],
 		],
 		[
-			'heading' => 'Solar- und Wärmepumpen-Leadgenerierung: Themen-Cluster',
+			'heading' => 'Solar- und Wärmepumpen-Cluster',
 			'links'   => [
 				[
 					'label'       => 'Photovoltaik & Solar Leads kaufen – Alternative',
@@ -118,12 +177,12 @@ function nexus_get_llms_txt_sections() {
 				[
 					'label'       => 'Aroundhome Kosten für Handwerker',
 					'url'         => home_url( '/aroundhome-solar-einordnung/' ),
-					'description' => 'Anbieterunabhängiger Kosten-, Vertrags- und Portal-Fit-Entscheid mit CPO-Rechner auf Basis eigener Betriebswerte.',
+					'description' => 'Kosten-, Vertrags- und Portal-Fit-Entscheid mit CPO-Rechner auf Basis eigener Betriebswerte.',
 				],
 				[
 					'label'       => 'Wärmepumpen Leads kaufen – Alternative',
 					'url'         => home_url( '/waermepumpen-leads/' ),
-					'description' => 'Intercept-Page für Wärmepumpen-Lead-Kauf: Marktmodelle, wärmepumpen-spezifische Vorqualifizierung und eigenes Anfragesystem als Alternative.',
+					'description' => 'Intercept-Page für Wärmepumpen-Lead-Kauf und eigenes Anfragesystem als Alternative.',
 				],
 				[
 					'label'       => 'Eigene Leadgenerierung vs. Portale',
@@ -133,29 +192,17 @@ function nexus_get_llms_txt_sections() {
 				[
 					'label'       => 'Cost per Lead Photovoltaik',
 					'url'         => $urls['solar_cpl'] ?? home_url( '/cost-per-lead-photovoltaik/' ),
-					'description' => 'CPL-Analyse mit Szenarienvergleich, versteckten Kostentreibern und Marktcheck-Anschluss.',
+					'description' => 'CPL-Analyse mit Szenarienvergleich und versteckten Kostentreibern.',
 				],
 				[
 					'label'       => 'Qualifizierte PV-Anfragen',
 					'url'         => home_url( '/qualifizierte-pv-anfragen/' ),
-					'description' => 'Vier-Merkmale-Modell für hochwertige Solar-Anfragen mit Warnsignalen und Messmethoden.',
+					'description' => 'Merkmale hochwertiger Solar-Anfragen, Warnsignale und Messmethoden.',
 				],
 				[
 					'label'       => 'Lead-Funnel Solar',
 					'url'         => $urls['solar_funnel'] ?? home_url( '/lead-funnel-solar/' ),
 					'description' => 'Funnel-Architektur von Erstkontakt bis Sales-Anschluss für Photovoltaik- und Wärmepumpen-Anbieter.',
-				],
-				[
-					'label'       => 'Server-Side Tracking einrichten lassen',
-					'url'         => $urls['solar_tracking'] ?? home_url( '/server-side-tracking-b2b/' ),
-					'description' => sprintf(
-						// Preis aus dem Tracking-Kanon statt als Literal: die Zahl stand
-						// hier zuletzt eine Anhebung lang falsch im Routen-Index.
-						'Server-GTM, GA4, Google Ads und Meta CAPI über eine eigene Tracking-Subdomain: Einrichtung, Testbetrieb und laufende Kontrolle mit Preisen ab %s netto.',
-						function_exists( 'hu_tracking_price' )
-							? hu_tracking_price( 'standard', 'setup', 'display', '1.290 €' )
-							: '1.290 €'
-					),
 				],
 				[
 					'label'       => 'B2B Solar Leads für Gewerbe',
@@ -165,17 +212,17 @@ function nexus_get_llms_txt_sections() {
 				[
 					'label'       => 'Kunden gewinnen für Solarteure',
 					'url'         => home_url( '/kunden-gewinnen-solarteure/' ),
-					'description' => 'Pillar-Page mit Mythen-Aufklärung und fünf systematischen Hebeln für Solar-Betriebe im DACH-Mittelstand.',
+					'description' => 'Pillar-Page mit systematischen Hebeln für Solar-Betriebe im DACH-Mittelstand.',
 				],
 			],
 		],
 		[
-			'heading' => 'Sekundäre Einstiege und Wissen',
+			'heading' => 'Wissen',
 			'links'   => [
 				[
 					'label'       => 'Blog',
 					'url'         => $urls['blog'] ?? home_url( '/blog/' ),
-					'description' => 'Artikel zu SEO, Tracking, WordPress-Performance und Anfragesystemen.',
+					'description' => 'Artikel zu SEO, Tracking, WordPress-Performance, Conversion und Anfragesystemen.',
 				],
 				[
 					'label'       => 'Glossar',
@@ -185,12 +232,7 @@ function nexus_get_llms_txt_sections() {
 				[
 					'label'       => 'Stack Solar',
 					'url'         => home_url( '/stack-solar/' ),
-					'description' => 'Technischer Unterbau für Solar- und Wärmepumpen-Anbieter: Frontend, Hosting, Server-Side Tracking, CRM-Übergabe und projektspezifische Vorqualifizierung.',
-				],
-				[
-					'label'       => 'WordPress Agentur Hannover',
-					'url'         => $urls['agentur'] ?? home_url( '/wordpress-agentur-hannover/' ),
-					'description' => 'Sekundäre lokale B2B-Seite für WordPress-Systeme, technisches SEO, Tracking und CRO in Hannover.',
+					'description' => 'Technischer Unterbau für Solar- und Wärmepumpen-Anbieter: Frontend, Hosting, Server-Side Tracking, CRM-Übergabe und Vorqualifizierung.',
 				],
 			],
 		],
@@ -206,7 +248,7 @@ function nexus_get_llms_txt_content() {
 	$lines = [
 		'# Haşim Üner',
 		'',
-		'> Architekt für eigene Anfragesysteme für Solar- und Wärmepumpen-Anbieter im DACH-Raum. Ablösung von Portal-Abhängigkeit durch Website, Tracking, Vorqualifizierung und Werbekanal-Steuerung als ein verbundenes System. Primärer Einstieg ist der Marktcheck auf der Solar- und Wärmepumpen-Seite.',
+		'> WordPress, Tracking und Conversion als zusammenhängendes System. Direkte Projekte laufen über den WordPress-Freelancer-/Projektpfad, Agenturen über White-Label. Solar, Wärmepumpe und Speicher bleiben eine spezialisierte Vertikale mit eigenem Marktcheck.',
 	];
 
 	foreach ( nexus_get_llms_txt_sections() as $section ) {

--- a/blocksy-child/inc/positioning-meta.php
+++ b/blocksy-child/inc/positioning-meta.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Positioning-specific SEO copy overrides.
+ *
+ * `seo-meta.php` remains the canonical title/description engine. Its public
+ * filters are used here so the repositioning can be reviewed independently of
+ * the large route-level SEO registry and without changing existing query
+ * ownership for specialist money pages.
+ *
+ * @package Blocksy_Child
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Global homepage title: fachliche Klammer, not a duplicate local Freelancer
+ * or Solar money-page query.
+ *
+ * @return string
+ */
+function hu_positioned_homepage_seo_title() : string {
+	return 'WordPress, Tracking & Conversion | Haşim Üner';
+}
+add_filter( 'hu_homepage_seo_title', 'hu_positioned_homepage_seo_title', 20 );
+
+/**
+ * Global homepage description covering the three commercial entry paths.
+ *
+ * @return string
+ */
+function hu_positioned_homepage_seo_description() : string {
+	return 'WordPress-Entwicklung, technisches SEO, Tracking und Conversion aus Pattensen bei Hannover. Für direkte Projekte, Agenturen und Solar-/Wärmepumpen-Anbieter.';
+}
+add_filter( 'hu_homepage_seo_description', 'hu_positioned_homepage_seo_description', 20 );
+
+/**
+ * Blog index title: broaden the knowledge hub beyond the Energy vertical.
+ *
+ * @return string
+ */
+function hu_positioned_blog_seo_title() : string {
+	return 'Blog: WordPress, Tracking, SEO & Conversion | Haşim Üner';
+}
+add_filter( 'hu_blog_archive_seo_title', 'hu_positioned_blog_seo_title', 20 );
+
+/**
+ * Blog index description: broad technical-marketing knowledge hub with the
+ * Energy cluster retained as one specialization.
+ *
+ * @return string
+ */
+function hu_positioned_blog_seo_description() : string {
+	return 'Analysen zu WordPress, technischem SEO, Tracking, Conversion und Performance. Dazu Praxiswissen zu Anfragesystemen für Solar und Wärmepumpe.';
+}
+add_filter( 'hu_blog_archive_seo_description', 'hu_positioned_blog_seo_description', 20 );

--- a/blocksy-child/inc/schema-positioning.php
+++ b/blocksy-child/inc/schema-positioning.php
@@ -27,15 +27,13 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return array<string, mixed>
  */
 function hu_get_positioned_schema_offer_catalog() : array {
-	$project_url = function_exists( 'hu_get_navigation_project_request_url' )
-		? hu_get_navigation_project_request_url()
-		: home_url( '/kontakt/' );
 	$marketcheck_url = function_exists( 'hu_get_request_analysis_url' )
 		? hu_get_request_analysis_url()
 		: home_url( '/solar-waermepumpen-leadgenerierung/#marktcheck' );
 	$whitelabel_url = function_exists( 'nexus_get_whitelabel_page_url' )
 		? nexus_get_whitelabel_page_url()
 		: home_url( '/whitelabel-retainer/' );
+	$freelancer_url = home_url( '/wordpress-freelancer-hannover/' );
 
 	return [
 		'@type'           => 'OfferCatalog',
@@ -45,7 +43,7 @@ function hu_get_positioned_schema_offer_catalog() : array {
 				'@type'       => 'Offer',
 				'name'        => 'WordPress-Entwicklung',
 				'description' => 'WordPress-Websites und Landingpages mit technischer SEO, Performance und sauberer Weiterentwicklung.',
-				'url'         => home_url( '/wordpress-freelancer-hannover/' ),
+				'url'         => $freelancer_url,
 			],
 			[
 				'@type'       => 'Offer',
@@ -57,7 +55,7 @@ function hu_get_positioned_schema_offer_catalog() : array {
 				'@type'       => 'Offer',
 				'name'        => 'Conversion-Optimierung',
 				'description' => 'Optimierung von Landingpages, Funnels, Proof und Anfragewegen mit Fokus auf messbare Conversion.',
-				'url'         => $project_url,
+				'url'         => $freelancer_url,
 			],
 			[
 				'@type'       => 'Offer',

--- a/blocksy-child/inc/schema-positioning.php
+++ b/blocksy-child/inc/schema-positioning.php
@@ -1,0 +1,243 @@
+<?php
+/**
+ * Positioning normalization for the site-wide schema graph.
+ *
+ * `org-schema.php` still owns route-specific schema generation. This module
+ * changes only the canonical Person, Organization and WebSite identity nodes
+ * plus the direct Freelancer service node. Keeping the normalization separate
+ * makes the repositioning reviewable without rewriting the large schema
+ * registry in one risky change.
+ *
+ * Once the migration is proven in production, these canonical values can be
+ * folded back into org-schema.php in a dedicated refactor.
+ *
+ * @package Blocksy_Child
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Return the global offer catalog that reflects the current commercial routes.
+ *
+ * SEO query ownership stays on the destination pages; this catalog describes
+ * what the business offers and does not redirect or replace those pages.
+ *
+ * @return array<string, mixed>
+ */
+function hu_get_positioned_schema_offer_catalog() {
+	$project_url = function_exists( 'hu_get_navigation_project_request_url' )
+		? hu_get_navigation_project_request_url()
+		: home_url( '/kontakt/' );
+	$marketcheck_url = function_exists( 'hu_get_request_analysis_url' )
+		? hu_get_request_analysis_url()
+		: home_url( '/solar-waermepumpen-leadgenerierung/#marktcheck' );
+	$whitelabel_url = function_exists( 'nexus_get_whitelabel_page_url' )
+		? nexus_get_whitelabel_page_url()
+		: home_url( '/whitelabel-retainer/' );
+
+	return [
+		'@type'           => 'OfferCatalog',
+		'name'            => 'WordPress, Tracking, Conversion und spezialisierte Anfragesysteme',
+		'itemListElement' => [
+			[
+				'@type'       => 'Offer',
+				'name'        => 'WordPress-Entwicklung',
+				'description' => 'WordPress-Websites und Landingpages mit technischer SEO, Performance und sauberer Weiterentwicklung.',
+				'url'         => home_url( '/wordpress-freelancer-hannover/' ),
+			],
+			[
+				'@type'       => 'Offer',
+				'name'        => 'Server-Side Tracking & Attribution',
+				'description' => 'Server-GTM, GA4, Google Ads, Meta CAPI und nachvollziehbare Messkonzepte für belastbare Conversion-Signale.',
+				'url'         => home_url( '/server-side-tracking-b2b/' ),
+			],
+			[
+				'@type'       => 'Offer',
+				'name'        => 'Conversion-Optimierung',
+				'description' => 'Optimierung von Landingpages, Funnels, Proof und Anfragewegen mit Fokus auf messbare Conversion.',
+				'url'         => $project_url,
+			],
+			[
+				'@type'       => 'Offer',
+				'name'        => 'White-Label für Agenturen',
+				'description' => 'WordPress-, Tracking-, CRO- und technische SEO-Umsetzung im Hintergrund für Agenturprojekte.',
+				'url'         => $whitelabel_url,
+			],
+			[
+				'@type'       => 'Offer',
+				'name'        => 'Anfragesysteme für Solar & Wärmepumpe',
+				'description' => 'Spezialisierte Nachfrage- und Anfragewege für Solar-, Wärmepumpen- und Speicher-Anbieter.',
+				'url'         => home_url( '/solar-waermepumpen-leadgenerierung/' ),
+			],
+			[
+				'@type'       => 'Offer',
+				'name'        => 'Marktcheck für Solar & Wärmepumpe',
+				'description' => 'Diagnostischer Einstieg für den Energie-Cluster: Region, Anfragequalität, Datenlage und nächster sinnvoller Schritt.',
+				'url'         => $marketcheck_url,
+			],
+		],
+	];
+}
+
+/**
+ * Normalize one JSON-LD node emitted by the existing schema generator.
+ *
+ * @param array<string, mixed> $schema Schema node.
+ * @return array<string, mixed>
+ */
+function hu_normalize_positioned_schema_node( $schema ) {
+	$id = isset( $schema['@id'] ) ? (string) $schema['@id'] : '';
+
+	if ( home_url( '/#organization' ) === $id ) {
+		$schema['name']        = 'Haşim Üner';
+		$schema['description'] = 'WordPress-Entwicklung, technisches SEO, Tracking und Conversion für Unternehmen und Agenturen. Solar- und Wärmepumpen-Anfragesysteme bleiben eine spezialisierte Vertikale mit eigenem Marktcheck.';
+		$schema['knowsAbout']  = [
+			'WordPress-Entwicklung',
+			'Technisches SEO',
+			'Tracking & Attribution',
+			'Server-Side Tracking',
+			'Conversion Rate Optimization',
+			'Landingpages & Funnel',
+			'Core Web Vitals',
+			'Performance Marketing',
+			'Solar- und Wärmepumpen-Leadgenerierung',
+		];
+		$schema['hasOfferCatalog'] = hu_get_positioned_schema_offer_catalog();
+	}
+
+	if ( home_url( '/#website' ) === $id ) {
+		$schema['name']        = 'Haşim Üner';
+		$schema['description'] = 'WordPress, technisches SEO, Tracking und Conversion als zusammenhängendes System. Direkte Projekte, White-Label für Agenturen und eine spezialisierte Solar-/Wärmepumpen-Vertikale.';
+	}
+
+	if ( function_exists( 'hu_person_schema_id' ) && hu_person_schema_id() === $id ) {
+		$schema['jobTitle']    = 'WordPress Freelancer und Tracking-Spezialist';
+		$schema['description'] = 'Haşim Üner verbindet WordPress-Entwicklung, technisches SEO, Tracking und Conversion für direkte Projekte und White-Label-Agenturarbeit. Anfragesysteme für Solar- und Wärmepumpen-Anbieter sind eine spezialisierte Vertikale.';
+		$schema['knowsAbout']  = [
+			'WordPress-Entwicklung',
+			'Technisches SEO',
+			'Tracking & Attribution',
+			'Server-Side Tracking',
+			'Conversion Rate Optimization',
+			'Landingpages & Funnel',
+			'Core Web Vitals',
+			'Performance Marketing',
+			'Solar- und Wärmepumpen-Leadgenerierung',
+		];
+	}
+
+	$freelancer_webpage_id = home_url( '/wordpress-freelancer-hannover/#webpage' );
+	if ( $freelancer_webpage_id === $id ) {
+		$schema['mainEntity'] = [ '@id' => home_url( '/wordpress-freelancer-hannover/#service' ) ];
+		$schema['about']      = [ '@id' => home_url( '/#organization' ) ];
+	}
+
+	return $schema;
+}
+
+/**
+ * Build the Service node for the direct Freelancer money page.
+ *
+ * @return array<string, mixed>
+ */
+function hu_get_wordpress_freelancer_service_schema() {
+	return [
+		'@context'      => 'https://schema.org',
+		'@type'         => 'Service',
+		'@id'           => home_url( '/wordpress-freelancer-hannover/#service' ),
+		'url'           => home_url( '/wordpress-freelancer-hannover/' ),
+		'name'          => 'WordPress Freelancer Hannover',
+		'description'   => 'Direkte WordPress-Zusammenarbeit mit Entwicklung, technischer SEO, Tracking und Conversion-Optimierung aus Pattensen bei Hannover.',
+		'provider'      => [ '@id' => home_url( '/#organization' ) ],
+		'serviceType'   => 'WordPress-Entwicklung',
+		'serviceOutput' => 'Technisch saubere WordPress-Websites und Landingpages mit messbaren Conversion-Pfaden, Tracking und kontrollierter Weiterentwicklung.',
+		'areaServed'    => [
+			[
+				'@type' => 'AdministrativeArea',
+				'name'  => 'Region Hannover',
+			],
+			[
+				'@type' => 'AdministrativeArea',
+				'name'  => 'DACH',
+			],
+		],
+		hasOfferCatalog' => [
+			'@type'           => 'OfferCatalog',
+			'name'            => 'Leistungsfelder der direkten WordPress-Zusammenarbeit',
+			'itemListElement' => [
+				[
+					'@type' => 'Offer',
+					'name'  => 'WordPress-Entwicklung',
+				],
+				[
+					'@type' => 'Offer',
+					'name'  => 'Tracking & Attribution',
+				],
+				[
+					'@type' => 'Offer',
+					'name'  => 'Conversion-Optimierung',
+				],
+				[
+					'@type' => 'Offer',
+					'name'  => 'Technisches SEO',
+				],
+			],
+		],
+	];
+}
+
+/**
+ * Render the existing route-specific graph after normalizing only the canonical
+ * identity nodes. This deliberately preserves all page-specific FAQ, Article,
+ * Breadcrumb and Service logic already owned by org-schema.php.
+ *
+ * @return void
+ */
+function hu_output_positioned_schema() {
+	if ( ! function_exists( 'hu_output_schema' ) ) {
+		return;
+	}
+
+	ob_start();
+	hu_output_schema();
+	$markup = (string) ob_get_clean();
+
+	$markup = preg_replace_callback(
+		'#<script type="application/ld\+json">(.*?)</script>#s',
+		static function ( $match ) {
+			$decoded = json_decode( (string) $match[1], true );
+
+			if ( ! is_array( $decoded ) ) {
+				return (string) $match[0];
+			}
+
+			$decoded = hu_normalize_positioned_schema_node( $decoded );
+			$json    = wp_json_encode( $decoded, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT );
+
+			if ( ! is_string( $json ) || '' === $json ) {
+				return (string) $match[0];
+			}
+
+			return '<script type="application/ld+json">' . $json . '</script>';
+		},
+		$markup
+	);
+
+	if ( is_string( $markup ) ) {
+		echo $markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- JSON-LD generated from wp_json_encode.
+	}
+
+	if ( is_page( 'wordpress-freelancer-hannover' ) || is_page_template( 'page-wordpress-freelancer-hannover.php' ) ) {
+		$freelancer_schema = hu_get_wordpress_freelancer_service_schema();
+		$json              = wp_json_encode( $freelancer_schema, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT );
+
+		if ( is_string( $json ) && '' !== $json ) {
+			echo '<script type="application/ld+json">' . $json . '</script>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- JSON-LD generated from wp_json_encode.
+		}
+	}
+}
+
+remove_action( 'wp_head', 'hu_output_schema', 10 );
+add_action( 'wp_head', 'hu_output_positioned_schema', 10 );

--- a/blocksy-child/inc/schema-positioning.php
+++ b/blocksy-child/inc/schema-positioning.php
@@ -26,7 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @return array<string, mixed>
  */
-function hu_get_positioned_schema_offer_catalog() {
+function hu_get_positioned_schema_offer_catalog() : array {
 	$project_url = function_exists( 'hu_get_navigation_project_request_url' )
 		? hu_get_navigation_project_request_url()
 		: home_url( '/kontakt/' );
@@ -87,7 +87,7 @@ function hu_get_positioned_schema_offer_catalog() {
  * @param array<string, mixed> $schema Schema node.
  * @return array<string, mixed>
  */
-function hu_normalize_positioned_schema_node( $schema ) {
+function hu_normalize_positioned_schema_node( array $schema ) : array {
 	$id = isset( $schema['@id'] ) ? (string) $schema['@id'] : '';
 
 	if ( home_url( '/#organization' ) === $id ) {
@@ -142,7 +142,7 @@ function hu_normalize_positioned_schema_node( $schema ) {
  *
  * @return array<string, mixed>
  */
-function hu_get_wordpress_freelancer_service_schema() {
+function hu_get_wordpress_freelancer_service_schema() : array {
 	return [
 		'@context'      => 'https://schema.org',
 		'@type'         => 'Service',
@@ -195,7 +195,7 @@ function hu_get_wordpress_freelancer_service_schema() {
  *
  * @return void
  */
-function hu_output_positioned_schema() {
+function hu_output_positioned_schema() : void {
 	if ( ! function_exists( 'hu_output_schema' ) ) {
 		return;
 	}
@@ -206,7 +206,7 @@ function hu_output_positioned_schema() {
 
 	$markup = preg_replace_callback(
 		'#<script type="application/ld\+json">(.*?)</script>#s',
-		static function ( $match ) {
+		static function ( array $match ) : string {
 			$decoded = json_decode( (string) $match[1], true );
 
 			if ( ! is_array( $decoded ) ) {

--- a/blocksy-child/inc/schema-positioning.php
+++ b/blocksy-child/inc/schema-positioning.php
@@ -163,7 +163,7 @@ function hu_get_wordpress_freelancer_service_schema() {
 				'name'  => 'DACH',
 			],
 		],
-		hasOfferCatalog' => [
+		'hasOfferCatalog' => [
 			'@type'           => 'OfferCatalog',
 			'name'            => 'Leistungsfelder der direkten WordPress-Zusammenarbeit',
 			'itemListElement' => [

--- a/blocksy-child/template-parts/footer-cta.php
+++ b/blocksy-child/template-parts/footer-cta.php
@@ -5,9 +5,13 @@
  * Wiederverwendbarer Bottom-CTA-Block für Service- und Blog-Seiten.
  * Tracking-ready mit data-track-* Attributen.
  *
- * Usage:
+ * Default = generische Projektanfrage. Spezialisierte Funnels müssen ihren
+ * Zielpfad und ihre Copy explizit übergeben. So kann der Solar-Marktcheck nicht
+ * versehentlich auf fachfremden WordPress-/Tracking-/CRO-Seiten erscheinen.
+ *
+ * Energy-Beispiel:
  *   set_query_var( 'cta_heading', 'Passt Ihr Betrieb für ein eigenes Anfragesystem?' );
- *   set_query_var( 'cta_text', 'Die Analyse prüft Fit, Marktbild und nächsten Schritt.' );
+ *   set_query_var( 'cta_text', 'Der Marktcheck prüft Fit, Marktbild und nächsten Schritt.' );
  *   set_query_var( 'cta_url', '/solar-waermepumpen-leadgenerierung/#marktcheck' );
  *   set_query_var( 'cta_button_text', 'Marktcheck mit Fit-Entscheid starten' );
  *   set_query_var( 'cta_action', 'cta_footer_analysis' );
@@ -22,11 +26,21 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-$heading     = get_query_var( 'cta_heading', __( 'Passt Ihr Betrieb für ein eigenes Anfragesystem?', 'blocksy-child' ) );
-$text        = get_query_var( 'cta_text', __( 'Die Analyse prüft Fit, Marktbild und den nächsten sinnvollen Schritt.', 'blocksy-child' ) );
-$url         = get_query_var( 'cta_url', function_exists( 'hu_get_request_analysis_url' ) ? hu_get_request_analysis_url() : home_url( '/solar-waermepumpen-leadgenerierung/#marktcheck' ) );
-$button_text = get_query_var( 'cta_button_text', __( 'Marktcheck mit Fit-Entscheid starten', 'blocksy-child' ) );
-$action      = get_query_var( 'cta_action', 'cta_footer_analysis' );
+$project_url = function_exists( 'hu_get_navigation_project_request_url' )
+	? hu_get_navigation_project_request_url()
+	: add_query_arg(
+		[
+			'type'  => 'project',
+			'focus' => 'followup_scope',
+		],
+		home_url( '/kontakt/' )
+	);
+
+$heading     = get_query_var( 'cta_heading', __( 'Sie haben ein konkretes Projekt?', 'blocksy-child' ) );
+$text        = get_query_var( 'cta_text', __( 'Schicken Sie mir kurz Ziel, Ausgangslage und Scope. Ich sage Ihnen, ob und wie ich sinnvoll unterstützen kann.', 'blocksy-child' ) );
+$url         = get_query_var( 'cta_url', $project_url );
+$button_text = get_query_var( 'cta_button_text', __( 'Projekt anfragen', 'blocksy-child' ) );
+$action      = get_query_var( 'cta_action', 'cta_footer_project' );
 $imprint_url = nexus_get_page_url( [ 'impressum' ], home_url( '/impressum/' ) );
 $privacy_url = nexus_get_page_url( [ 'datenschutz' ], home_url( '/datenschutz/' ) );
 

--- a/docs/architecture/CONVERSION_ROUTING.md
+++ b/docs/architecture/CONVERSION_ROUTING.md
@@ -1,0 +1,167 @@
+# Conversion Routing Architecture
+
+Status: active decision, 2026-08-18
+
+This document separates **SEO ownership** from **conversion routing**. It exists to prevent a recurring failure mode: sending every page to the same funnel or moving a ranking query owner merely because another page has the preferred CTA.
+
+## Core rule
+
+**Search intent -> owning page -> next best action.**
+
+Not:
+
+**Search intent -> whichever landing page is currently the main sales focus.**
+
+A page can remain the canonical SEO destination for its query while its CTA routes to a different next step.
+
+## Commercial routes
+
+| Route | Primary audience / intent | Page role | Primary CTA | Secondary CTA / bridge |
+| --- | --- | --- | --- | --- |
+| `/` | Brand / mixed / undecided | Global hub and fachliche Klammer | Choose one of the three paths or `Projekt anfragen` | Solar / Freelancer / White-Label |
+| `/wordpress-freelancer-hannover/` | Direct clients seeking one freelancer | Direct WordPress money page | `Projekt anfragen` / scope clarification | Proof / tracking specialist pages |
+| `/whitelabel-retainer/` | Agencies seeking delivery capacity | Agency money page | White-Label Fit-Check / scoped first project | Proof / direct contact |
+| `/solar-waermepumpen-leadgenerierung/` | Solar, heat-pump and storage businesses | Energy vertical money page | Marktcheck | Solar proof / case study |
+| `/server-side-tracking-b2b/` | Server-Side Tracking commercial intent | Specialist tracking money page | Tracking project request / scope clarification | White-Label bridge for agencies |
+| `/wordpress-agentur-hannover/` | Local `wordpress agentur hannover` search intent | Local SEO acquisition page | Project request | Explicit bridge to Freelancer page |
+| `/ergebnisse/` | Proof / evaluation | Proof hub | Context-dependent project request | Relevant case / route |
+| `/case-study-solar-leadgenerierung/` | Solar proof | Evidence page | Solar Marktcheck | Energy money page |
+
+## Cluster rules
+
+### 1. Energy cluster -> Marktcheck
+
+Use the Marktcheck as primary next action when the page is clearly about:
+
+- Solar / Photovoltaik / PV leads
+- Wärmepumpen leads
+- Speicher lead generation
+- lead portals / lead buying / portal dependency
+- provider comparisons such as Aroundhome, Checkfox, Wattfox, DAA
+- Solar lead costs, CPO/CPL and own lead generation versus portals
+- Solar-specific funnel architecture and qualification
+
+Examples:
+
+- `/solar-leads-kaufen-alternative/`
+- `/solar-leads-kosten-studie/`
+- `/cost-per-lead-photovoltaik/`
+- `/eigene-leadgenerierung-vs-portale/`
+- `/waermepumpen-leads/`
+- `/lead-funnel-solar/`
+- `/qualifizierte-pv-anfragen/`
+- `/kunden-gewinnen-solarteure/`
+- `/b2b-solar-leads/`
+- `/aroundhome-solar-einordnung/`
+- `/checkfox-solar-waermepumpe-einordnung/`
+- `/wattfox-solar-leads-einordnung/`
+- `/daa-photovoltaik-leads-einordnung/`
+
+### 2. Direct WordPress / tracking / CRO -> project request
+
+Use the generic project route when the visitor is evaluating an implementation problem rather than the energy vertical.
+
+Typical topics:
+
+- WordPress development
+- Landingpages / funnel pages
+- Server-Side Tracking
+- GA4 / GTM / attribution
+- Conversion optimization
+- technical SEO
+- WordPress performance / Core Web Vitals
+
+Do **not** route these pages to the Solar Marktcheck merely because `hu_get_request_analysis_url()` exists as a shared helper.
+
+### 3. Agency intent -> White-Label
+
+Use White-Label as primary route when intent explicitly involves:
+
+- agency delivery capacity
+- implementation under the agency brand
+- NDA / invisible delivery
+- partner / subcontractor / external implementation
+- repeatable client project support
+
+A specialist page may show a **secondary** White-Label bridge when the topic is relevant to agencies, but it should not lose its own SEO intent.
+
+### 4. Local Agentur search intent stays separate
+
+`/wordpress-agentur-hannover/` owns `wordpress agentur hannover` and related local variants. This SEO route must not be redirected to the Freelancer page.
+
+The visible route switch to `/wordpress-freelancer-hannover/` is an intent correction for visitors who actually want direct collaboration.
+
+## SEO ownership is independent
+
+`docs/seo/query-ownership.csv` remains the authoritative query registry.
+
+Changing a CTA does **not** automatically change:
+
+- canonical URL
+- page title / H1 owner
+- internal SEO anchor ownership
+- sitemap inclusion
+- redirects
+
+Changing query ownership requires separate evidence and a separate decision.
+
+## Primary CTA destinations
+
+### Generic project request
+
+Canonical helper: `hu_get_navigation_project_request_url()`
+
+Expected destination:
+
+`/kontakt/?type=project&focus=followup_scope`
+
+Use outside the dedicated Solar and White-Label funnels.
+
+### Solar Marktcheck
+
+Canonical helper: `hu_get_request_analysis_url()`
+
+Expected destination:
+
+`/solar-waermepumpen-leadgenerierung/#marktcheck`
+
+Use only for Energy-cluster purchase / diagnosis intent.
+
+### White-Label
+
+Canonical page helper where available: `nexus_get_whitelabel_page_url()`
+
+Expected route:
+
+`/whitelabel-retainer/`
+
+The page owns its own local Fit-Check CTA.
+
+## Migration checklist
+
+When auditing an existing page:
+
+1. Identify its query owner from `docs/seo/query-ownership.csv`.
+2. Classify audience: Energy, direct project, agency, proof/information, mixed.
+3. Keep the owning URL unless there is separate SEO evidence for a migration.
+4. Replace only the CTA destination / copy that conflicts with this routing contract.
+5. Preserve tracking attributes and give new actions explicit event names.
+6. Check footer, sticky CTA, reusable partials and helper-generated links, not only the hero button.
+7. Run repo drift checks before merge.
+
+## Known migration hotspots
+
+These areas must be audited because the old architecture used the Marktcheck broadly:
+
+- `hu_get_request_analysis_url()` call sites outside Energy pages
+- `nexus_get_primary_public_url_map()` keys whose names imply generic actions but currently resolve to the Marktcheck
+- `template-parts/footer-cta.php`
+- `template-parts/seo-subpage-sticky-cta.php`
+- `single.php` and category/archive CTAs
+- specialist service pages such as Server-Side Tracking
+- `llms.txt` and dynamic `inc/llms-txt.php`
+- Organization / WebSite / Service schema descriptions and offer catalogs
+
+## Guardrail
+
+If intent is unclear, do not guess based on the current business priority. Keep the page's SEO owner stable and prefer a neutral `Projekt anfragen` route until the page is explicitly classified.

--- a/docs/standards/BRAND_AND_COPY.md
+++ b/docs/standards/BRAND_AND_COPY.md
@@ -5,44 +5,93 @@ Skills reference this file instead of duplicating brand rules.
 
 ## Identity
 
-- Role: **Architekt für eigene Anfragesysteme**
-- Entity: Haşim Üner, hasimuener.de
-- Not: WordPress-Agentur, B2B-Generalist, Performance-Marketing-Agentur, Webdesign-Dienstleister
+- Entity / Marke: **Haşim Üner**, hasimuener.de
+- Fachliche Klammer: **WordPress · Tracking · Conversion**
+- Öffentliche Rolle: direkter technischer Marketing-Freelancer für Unternehmen; für Agenturen zusätzlich White-Label-Partner
+- Kernkompetenzen: WordPress-Entwicklung, technisches SEO, Tracking/Attribution, Server-Side Tracking, Landingpages/Funnel, Conversion-Optimierung
+- Performance-Marketing ist eine vorhandene Kompetenz und kann als Leistung sichtbar sein, ist aber **nicht** der globale Rollen-Claim
+- Solar, Wärmepumpe und Speicher bleiben eine **spezialisierte Vertikale mit eigenem Funnel und starkem Proof**, nicht mehr die einzige globale Positionierung
+- Nicht: reine Webdesign-Agentur, reine Performance-Marketing-Agentur, reine Beratung, allgemeiner Full-Service-Bauchladen
 
 ## Positioning
 
-**Ich baue Solar- und Wärmepumpen-Anbietern im DACH-Raum eigene Anfragesysteme, die Portal-Abhängigkeit ablösen und Leadkosten messbar senken.**
+**Haşim Üner verbindet WordPress-Entwicklung, Tracking und Conversion so, dass Websites, Landingpages und Anfragesysteme technisch zusammenpassen und messbar werden.**
 
-- Zielgruppe: Solar-, Wärmepumpen-, Speicher- und Energie-Anbieter mit eigenem Vertrieb, hohen Projektwerten und klarem Zielgebiet
-- Wettbewerb: Lead-Portale (Aroundhome, Check24, DAA) — nicht Webdesign-Agenturen
-- Website, Tracking, Vorqualifizierung und Werbekanal-Steuerung sind ein verbundenes System
-- Eigene Nachfrage-Infrastruktur vor Portal-Zukauf
-- Diagnose vor Pitch
-- Klarheit vor Feature-Count
+Die Website hat drei gleichberechtigte kommerzielle Einstiege mit unterschiedlicher Zielgruppe und unterschiedlichem nächsten Schritt:
 
-## Offer Ladder
+1. **Direkte Unternehmen / WordPress-Projekte** → `/wordpress-freelancer-hannover/` bzw. generische Projektanfrage
+2. **Agenturen** → `/whitelabel-retainer/` bzw. White-Label-Fit-Check
+3. **Solar / Wärmepumpe / Speicher** → `/solar-waermepumpen-leadgenerierung/` bzw. Marktcheck
 
-```
-Marktcheck -> Anfragesystem-Analyse -> Umsetzung / Retainer
-```
+Die Startseite ist die fachliche Klammer und der Verteiler. Sie soll **keinen der drei Wege künstlich zum universellen Hauptfunnel machen**.
 
-- Primary CTA: Marktcheck (`/solar-waermepumpen-leadgenerierung/#marktcheck`)
-- Retired Pfade: `/growth-audit/`, `/anfrage-system-analyse/` und alte Audit-Aliasse leiten auf den Marktcheck; alte Tool-/ROI-/Service-Slugs liefern 410 statt als Redirect-Netz betrieben zu werden. WGOS-Altpfade bleiben noindex/access-protected, solange sie intern noch gebraucht werden
-- Der Marktcheck ist diagnostischer Einstieg, kein gimmicky Gratis-Tool
+## Commercial Architecture
+
+### Globaler Einstieg
+
+- `/` = fachliche Klammer + Verteiler
+- Globale sichtbare Kompetenz: WordPress, technisches SEO, Tracking, Conversion
+- Globaler generischer CTA außerhalb der Spezialfunnel: **Projekt anfragen**
+
+### Direkte Zusammenarbeit
+
+- `/wordpress-freelancer-hannover/` = Money Page für `wordpress freelancer hannover`, `wordpress freelancer` und unterstützend `wordpress experte hannover`
+- Zielgruppe: direkte Auftraggeber, die mit der ausführenden Person arbeiten wollen
+- Differenzierung: Entwicklung + Tracking/Attribution + Server-Side Tracking + Funnel/CRO + technisches SEO + Performance/Accessibility
+- Primärer nächster Schritt: Projektanfrage / Scope klären
+
+### White-Label für Agenturen
+
+- `/whitelabel-retainer/` = eigener Agentur-Einstieg
+- Zielgruppe: Performance-, Web-, SEO- und Full-Service-Agenturen mit Umsetzungsbedarf
+- Lieferfelder: WordPress, Tracking, CRO, technische SEO, Landingpages/Funnel
+- Primärer nächster Schritt: Fit-Check / Erstprojekt mit klarem Scope
+- Keine erfundenen Agentur-Referenzen; keine Akquise im Kundenstamm der Partner
+
+### Solar / Wärmepumpe / Speicher
+
+- `/solar-waermepumpen-leadgenerierung/` = spezialisierte Branchen-Money-Page
+- Der Marktcheck bleibt **ausschließlich der primäre Einstieg für den Energie-Cluster**
+- Solar-/SHK-Unterseiten, Portalvergleiche und Lead-Kauf-Intent dürfen weiterhin auf den Marktcheck führen
+- E3 bleibt der wichtigste fachliche Proof für Nachfrageaufbau, Tracking, Vorqualifizierung und Conversion
+
+## CTA- und Routing-Regeln
+
+**Suchintention, Seitenrolle und Conversion-Ziel sind getrennte Entscheidungen.** Eine Seite darf ihre Query besitzen und trotzdem auf einen anderen nächsten Schritt führen.
+
+- Energie-/Portal-/PV-/Wärmepumpen-Intent → Marktcheck
+- Agentur-/White-Label-/Partner-Intent → White-Label-Fit-Check
+- Direkter WordPress-, Tracking-, CRO-, technischer SEO- oder Landingpage-Intent → Projektanfrage; eine Fachseite bleibt dabei selbst Query-Owner
+- Startseite / unspezifischer Brand-Traffic → Wahl zwischen den drei Einstiegen bzw. generische Projektanfrage
+- Eine rankende Fachseite **nicht** auf eine andere Money Page umleiten, nur weil deren CTA besser passt
+- `/server-side-tracking-b2b/` bleibt z. B. Query-Owner für Server-Side-Tracking-Intent; der CTA muss deshalb nicht zum Solar-Marktcheck führen
+- `/wordpress-agentur-hannover/` bleibt Query-Owner für den lokalen Agentur-Intent, ist aber **keine globale Rollenbeschreibung** und braucht keinen Header-Slot
+
+Details und konkrete Zuordnung: `docs/architecture/CONVERSION_ROUTING.md`.
 
 ## Tone
 
-- Klar, direkt, handwerklich, entscheidungssicher
-- Sprache für Geschäftsführer und Vertriebsleiter, nicht für Marketing-Abteilungen
-- Technische Klarheit vor kosmetischer Politur
+- Klar, direkt, technisch verständlich, entscheidungssicher
+- Keine aufgeblasene Agentur-Sprache
+- Konkrete Wirkung vor Feature-Listen
+- Technik und Marketing zusammen erklären, nicht als künstlich getrennte Disziplinen
+- Proof vor Behauptung
+- Kein Rollen-Claim, der mehr verspricht als Website und Leistungen tatsächlich abbilden
 
 ## Preferred Terms
 
+Global bevorzugt:
+
+`WordPress`, `Tracking`, `Conversion`, `Conversion-Optimierung`, `technisches SEO`,
+`Server-Side Tracking`, `Landingpage`, `Funnel`, `Projekt`, `direkte Zusammenarbeit`,
+`White-Label`, `messbare Anfragen`, `Tracking & Attribution`, `Performance`, `Core Web Vitals`
+
+Im Energie-Cluster zusätzlich:
+
 `Anfragesystem`, `eigene Anfragen`, `Portal-Abhängigkeit`, `Leadkosten`,
 `Kosten pro Anfrage`, `qualifizierte Anfragen`, `Abschlussquote`,
-`Vorqualifizierung`, `Tracking`, `Nachfrage-Infrastruktur`,
-`System-Diagnose`, `Potenzial-Check`, `priorisierte Hebel`,
-`Solar`, `Photovoltaik`, `PV`, `Wärmepumpe`, `Speicher`, `Energie-Anbieter`, `Handwerk`
+`Vorqualifizierung`, `Marktcheck`, `Solar`, `Photovoltaik`, `PV`,
+`Wärmepumpe`, `Speicher`, `Energie-Anbieter`, `Handwerk`
 
 `Founding Cohort 2026`, `Founding-Partner` und `Founding-Konditionen` sind
 zurückgezogen und dürfen nicht mehr in Kundencopy auftauchen — ebenso wenig
@@ -53,143 +102,80 @@ gesellschaftsrechtliche Partnerschaft.
 
 ## Solar / Photovoltaik / PV
 
-Die drei Begriffe sind keine Synonyme und haben feste Rollen. Sie stehen
-absichtlich nebeneinander — wer sie gegeneinander austauscht, verliert
-entweder den Suchbegriff oder die Präzision.
+Die drei Begriffe sind keine Synonyme und haben feste Rollen innerhalb des Energie-Clusters.
 
 | Begriff | Rolle | Wo |
 | --- | --- | --- |
-| `Solar` | Zielgruppen- und Marken-Rahmen: **wen** wir ansprechen | Slug, Header-Nav, Footer, Positionierung, Site-Title |
-| `Photovoltaik` | Produkt- und Suchbegriff: **worum** es geht | H1, Fließtext, Meta-Titles, Anchor-Texte |
-| `PV` | Branchenkürzel der Betriebe, Insider-Ton | Nur in Komposita: `PV-Anfragen`, `PV-Projekte`, `PV-Termine`, `Gewerbe-PV` |
+| `Solar` | Zielgruppen-/Cluster-Rahmen | Solar-Navigation, Branchen-Landingpage, Footer, Clustertexte |
+| `Photovoltaik` | Produkt- und Suchbegriff | H1, Fließtext, Meta-Titles, Anchor-Texte |
+| `PV` | Branchenkürzel | Komposita wie `PV-Anfragen`, `PV-Projekte`, `PV-Termine`, `Gewerbe-PV` |
 
 Regeln:
 
-- **Nicht `Solar` schreiben, wenn konkret die PV-Anlage gemeint ist.** `Solar`
-  ist der Oberbegriff und führt Solarthermie mit — ein anderes Gewerk, das nicht
-  Zielgruppe ist. (`Solarthermie` kommt im Theme bewusst 0× vor.)
-- `Wärmepumpe` bleibt **gleichrangig** neben `Photovoltaik`, nicht nachgeordnet.
-  `/waermepumpen-leads/` besitzt die Query `wärmepumpen leads` und wird nicht
-  durch PV-lastige Copy auf anderen Seiten verwässert.
-- Zielgruppen-Rahmen über Produktaussage ist die gewollte Schichtung, z. B. auf
-  der Money Page: Tag „Für Solar- & Wärmepumpen-Betriebe" über der H1
-  „… Photovoltaik-Anfragen …".
-
-Belege (nicht raten, nachschlagen):
-
-- `seo-research/2026-07/reports/gsc-verlauf-2026-07-20.md`,
-  Kannibalisierungs-Karte: „**Money-Page besitzt die Query**
-  `leadgenerierung photovoltaik`" → deshalb trägt die Money-Page-H1
-  `Photovoltaik` und nicht nur `Solar`.
-- `seo-research/2026-07/data/keywords-master.csv`, Cluster `a-money`:
-  Photovoltaik-Terme tragen das größte Volumen, `PV` folgt, `Solar` liegt
-  darunter. Zahlen dort nachsehen statt hier duplizieren.
+- Nicht `Solar` schreiben, wenn konkret die PV-Anlage gemeint ist; Solarthermie ist ein anderes Gewerk und kein Angebotsschwerpunkt.
+- `Wärmepumpe` bleibt gleichrangig neben `Photovoltaik`.
+- `/waermepumpen-leads/` besitzt weiterhin die Query `wärmepumpen leads` und wird nicht durch PV-lastige Copy verwässert.
+- Bestehende Query-Ownership aus `docs/seo/query-ownership.csv` bleibt bestehen, solange neue GSC-Daten keine andere Entscheidung belegen.
 
 ## Anti-Patterns (Hard Bans)
 
-- `Growth Audit` als user-facing Label (interne URL/IDs dürfen bleiben)
-- `WGOS` und `WordPress Growth Operating System` — Legacy-Framework, wird nicht mehr aktiv verkauft, zugehörige Seite ist noindex
-- `KI-Integration` als Angebot — Legacy-Thema, zugehörige Seite ist noindex
-- `WordPress` als Angebot oder Rolle (nur als Technologie im Nebensatz erlaubt)
-- `B2B` als Positionierung (zu generisch — wir sprechen Solar/Wärmepumpe)
-- `WordPress Specialist`, `WordPress-Agentur`, `Webdesign`, `Leistungen`
-- `Growth Architect`, generische Growth-/Marketing-Blasen-Begriffe
+- `Architekt für eigene Anfragesysteme` als globaler Rollen- oder Entity-Claim
+- Solar/Wärmepumpe als angeblich einzige Zielgruppe auf globalen Seiten
+- Marktcheck als globaler CTA auf fachfremden WordPress-/Tracking-/CRO-Seiten
+- `Growth Audit` als user-facing Label
+- `WGOS` und `WordPress Growth Operating System` als öffentliches Angebot
+- `KI-Integration` als eigenständiges Angebot
+- `Growth Architect` und generische Growth-Blasen-Begriffe
+- `Performance-Marketing-Agentur` als Unternehmensidentität
 - `Shopify` als Live-Positionierung
 - `kostenlos` als alleiniges Wertversprechen
-- `Founding Cohort 2026`, `Founding-Partner`, `Founding-Konditionen` — Detail
-  oben unter Preferred Terms
-- `Solarthermie` — anderes Gewerk, nicht Zielgruppe; Detail unten unter Solar / Photovoltaik / PV
-- Tool-artige Rahmung der Diagnose
-- Überhöhte Umsatzversprechen
-- Gleichgewichtiger Leistungskatalog statt Diagnose-first-Funnel
-- Copy, die Taktik vor Diagnose verkauft
+- erfundene Rankings, Referenzen, Umsatzversprechen oder Rich-Result-Versprechen
+- SEO-Query-Owner löschen oder umleiten, nur um Conversion-Pfade zu vereinfachen
+- gleicher CTA auf jeder Seite unabhängig von Suchintent und Zielgruppe
+- Service-Kataloge, die Fähigkeiten nur stapeln, ohne den konkreten Projektkontext zu erklären
 
-## Nebenpfad: White-Label für Agenturen
+## Route: WordPress Agentur Hannover
 
-`/whitelabel-retainer/` ist ein eigener Agentur-Einstieg außerhalb der
-Kern-Positionierung: indexierbar, in der Sitemap und über den Navigationspunkt
-„Für Agenturen“ erreichbar, aber weiterhin nicht in `llms.txt`. Für diese
-eine Route gelten kontrollierte Ausnahmen:
+`/wordpress-agentur-hannover/` bleibt eine bewusste lokale SEO-Route für den **Agentur-Intent** `wordpress agentur hannover`.
 
-- Zielgruppe: Agenturen (Performance, Webdesign, Full-Service) — Anrede „ihr/euch“
-- Rolle dort: White-Label-Partner / „die System-Ebene hinter euren Kundenprojekten“
-- WordPress, SEO, Tracking, CRO dürfen als Lieferfelder benannt werden,
-  WordPress bleibt Technologie-Nennung, nie Rollen-Claim
-- Kein gleichgewichtiger Leistungskatalog: Einstieg immer über Erstprojekt
-  mit fixem Scope und Preis vorab, danach Retainer; Fit-Check vor Call
-- Proof: ausschließlich anonymisierte Arbeitsprobe (E3-Canon) mit dem
-  expliziten Hinweis, dass es kein White-Label-Mandat war; keine erfundenen
-  Agentur-Referenzen, keine Akquise im Kundenstamm der Partner
-- Schreibweise sichtbar immer „White-Label“ (Slug/interne Keys bleiben)
+- Sie ist **kein globaler Rollen-Claim** und kein primärer Navigationspunkt.
+- Der getrennte Freelancer-Intent gehört auf `/wordpress-freelancer-hannover/`.
+- Der Begriff `WordPress Agentur Hannover` darf im SEO-Title/H1 dieser Route stehen, weil er die Suchintention besitzt.
+- Die Seite darf direkte Zusammenarbeit als Alternative sichtbar zur Freelancer-Route weiterführen.
+- Benachbarte Kategoriebegriffe nicht wahllos ergänzen. Der Versuch mit `Webdesign-Agentur`, `Internetagentur` und `Webagentur` verschlechterte 2026 die Money-Query ohne belegten Zusatznutzen.
+- Regressionen auf dieser Route prüft `agents/skills/seo-drift/scripts/drift-report.sh`.
 
-Diese Ausnahmen gelten nur auf Whitelabel-Routen und rechtfertigen keine
-Aufweichung der Solar-/SHK-Kernpositionierung an anderer Stelle.
+## Route: WordPress Freelancer Hannover
 
-## Nebenpfad: Lokale WordPress-Route Hannover
+`/wordpress-freelancer-hannover/` ist der zentrale direkte WordPress-Einstieg.
 
-`/wordpress-agentur-hannover/` trägt die H1 „WordPress Agentur Hannover" und
-steht damit sichtbar gegen die Identity-Zeile „Not: WordPress-Agentur". Das ist
-eine bewusste Ausnahme, keine Drift:
+- Primärer Query-Owner: `wordpress freelancer hannover`
+- Sekundär: `wordpress freelancer`; unterstützend `wordpress experte hannover`
+- Targetet nicht `wordpress agentur hannover`
+- Targetet keine White-Label-Queries
+- `WordPress Freelancer` darf auf dieser Route in SEO-Title, H1 und Rollenbeschreibung stehen
+- GitHub, versionierter Code, Staging, Review und kontrollierte Deployments dürfen als Workflow-/Qualitätsbeleg sichtbar erklärt werden
+- Lighthouse-Werte nur als Labtest bezeichnen; kein Ersatz für CrUX-/Felddaten
+- Öffentliche Referenzen müssen direkt prüfbar sein
 
-- Die Route existiert für eine lokale Suchanfrage, die genau diesen Begriff
-  benutzt. Ohne ihn rankt sie nicht. Sie besitzt den **Agentur-Intent**
-  `wordpress agentur hannover`; der getrennte Freelancer-Intent gehört nicht
-  auf diese URL.
-- Der Begriff wird immer qualifiziert („für messbare B2B-Anfragen"), nie allein
-  als Rollen-Claim gesetzt. Im Fließtext bleibt die Rolle `Spezialist für
-  WordPress als Anfragesystem`, ausdrücklich abgegrenzt gegen die lokale
-  Allround-Agentur.
-- **Benachbarte Kategoriebegriffe bleiben draußen.** Am 2026-07-09 wurden
-  `Webdesign-Agentur`, `Internetagentur` und `Webagentur` über zwei FAQ-Items
-  ergänzt, um lokale Zweitbegriffe mitzunehmen. Ergebnis: die Money-Query fiel
-  von Position 11 auf 35, die Zielbegriffe bekamen keine einzige Impression.
-  Zurückgenommen am 2026-08-08.
-- Die Lehre daraus gilt über diese Route hinaus: Der Hard-Ban-Check lässt
-  gesperrte Begriffe in der Abgrenzung durch, weil „Architektur statt
-  Webdesign" positionierungsseitig ein Gegen-Claim ist. Eine Suchmaschine liest
-  denselben Satz ohne Verneinung. Grün im Guard heißt hier nicht unschädlich.
+## Route: Server-Side Tracking
 
-Regressionen auf dieser Route findet
-`agents/skills/seo-drift/scripts/drift-report.sh`.
+`/server-side-tracking-b2b/` bleibt die fachliche Money Page für nicht ortsqualifizierte Tracking-Queries.
 
-## Nebenpfad: WordPress Freelancer Hannover
+- Query-Ownership bleibt bei der Fachseite
+- Primärer CTA: direkte Projektanfrage / Tracking-Scope klären
+- Sekundärer Agentur-Hinweis ist erlaubt, wenn der Besucher erkennbar White-Label-Kapazität sucht
+- Kein automatisches Routing in den Solar-Marktcheck
 
-`/wordpress-freelancer-hannover/` ist eine zweite, bewusst eng geführte lokale
-WordPress-Ausnahme. Sie richtet sich an **direkte Auftraggeber**, die gezielt mit
-einem einzelnen Freelancer arbeiten wollen. Sie ist weder eine zweite
-Agentur-Seite noch eine versteckte White-Label-Seite.
+## Route: White-Label
 
-- Primärer Query-Owner: `wordpress freelancer hannover`; der allgemeinere
-  Begriff `wordpress freelancer` darf als sekundärer Suchbegriff mitgeführt
-  werden. `wordpress experte hannover` kann diese Route unterstützen.
-- `WordPress Freelancer` darf auf **dieser Route** in SEO-Title, H1 und sichtbarer
-  Rollenbeschreibung stehen. Die globale Hard-Ban-Regel bleibt für alle anderen
-  Akquise-Routen bestehen.
-- Die Route **targetet nicht** `wordpress agentur hannover`. Dieser Begriff
-  bleibt bei `/wordpress-agentur-hannover/` und darf auf der Freelancer-Seite nur
-  als klarer Abgrenzungs-/Routing-Link vorkommen.
-- Die Route **targetet keine White-Label-Queries**. `White-Label` darf nur als
-  Verweis auf `/whitelabel-retainer/` erscheinen; Agenturen bleiben Zielgruppe
-  des separaten Agentur-Nebenpfads.
-- Differenzierung ist nicht „noch ein WordPress-Techniker“, sondern die
-  Verbindung aus Entwicklung, Tracking/Attribution, Server-Side Tracking,
-  Funnel/CRO, technischer SEO, Performance und Accessibility.
-- GitHub, versionierter Code, Staging, Review und kontrollierte Deployments
-  dürfen als Workflow-/Qualitätsbeleg sichtbar erklärt werden. KI-Unterstützung
-  ist Produktionsmittel, nicht das Wertversprechen.
-- Elementor und andere Page Builder sind zulässige Werkzeuge, aber kein
-  Rollen-Claim und kein Standardversprechen. Das Werkzeug folgt Wartbarkeit,
-  Performance und redaktionellem Bedarf des Projekts.
-- Lighthouse-Werte dürfen nur als **Labtest** bezeichnet werden. Sie sind kein
-  Ersatz für CrUX-/Felddaten und dürfen nicht als bestätigte Core Web Vitals
-  ausgegeben werden.
-- Öffentliche Referenzen müssen direkt prüfbar sein. White-Label-Kundennamen
-  bleiben unveröffentlicht, solange keine ausdrückliche Freigabe vorliegt.
-- Die Seite bleibt schlank: wenige fachliche Ebenen, starker Proof und klare
-  Zusammenarbeit statt eines gleichgewichtigen 15-Punkte-Leistungskatalogs.
+`/whitelabel-retainer/` ist ein eigenständiger Agentur-Einstieg und Teil der **globalen kommerziellen Architektur**.
 
-Diese Ausnahme erweitert die öffentliche Solar-/SHK-Kernpositionierung nicht.
-Sie ist ein eigenständiger SEO-/Akquise-Nebenpfad für direkte WordPress-Projekte.
+- sichtbar in der Hauptnavigation als `Für Agenturen`
+- Rolle dort: White-Label-Partner / Umsetzung im Hintergrund
+- WordPress, SEO, Tracking und CRO sind Lieferfelder
+- Erstprojekt mit Scope und Preis vor Start; danach optional Retainer
+- Schreibweise sichtbar immer `White-Label`
 
 ## Brand Colors (Project Override)
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,34 +1,39 @@
 # Haşim Üner
 
-> Architekt für eigene Anfragesysteme für Solar-, Wärmepumpen- und Speicher-Anbieter im DACH-Raum. Fokus: Portal-Abhängigkeit durch eigene Website, Vorqualifizierung, Tracking und steuerbare Werbekanäle ersetzen. Primärer Einstieg ist der Marktcheck.
+> WordPress, Tracking und Conversion als zusammenhängendes System. Direkte Projekte laufen über den WordPress-Freelancer-/Projektpfad, Agenturen über White-Label. Solar, Wärmepumpe und Speicher bleiben eine spezialisierte Vertikale mit eigenem Marktcheck.
 
 ## Primäre Einstiege
-- [Startseite](/) - Überblick über Positionierung, Proof und aktuelle Einstiege.
-- [Solar- und Wärmepumpen-Leadgenerierung](/solar-waermepumpen-leadgenerierung/) - Branchen-Landingpage für eigene Anfragesysteme gegen Portal-Abhängigkeit.
-- [Marktcheck](/solar-waermepumpen-leadgenerierung/#marktcheck) - primärer Einstieg für kalten Solar-/SHK-Traffic.
-- [Kontakt](/kontakt/) - Anfragepfad für Analyse, Umsetzung und Weiterentwicklung nach Marktcheck-Fit.
+- [Startseite](/) - Fachliche Klammer und Verteiler auf direkte Projekte, White-Label und Solar/Wärmepumpe.
+- [WordPress Freelancer Hannover](/wordpress-freelancer-hannover/) - direkter Einstieg für WordPress-Projekte mit Entwicklung, Tracking, Funnel/CRO und technischer SEO.
+- [Für Agenturen: White-Label](/whitelabel-retainer/) - Umsetzungskapazität für Agenturen: WordPress, Tracking, CRO und technische SEO im Hintergrund.
+- [Solar- und Wärmepumpen-Leadgenerierung](/solar-waermepumpen-leadgenerierung/) - spezialisierte Branchen-Landingpage für eigene Anfragesysteme statt Portal-Abhängigkeit.
+- [Projekt anfragen](/kontakt/?type=project&focus=followup_scope) - generischer Anfragepfad für direkte WordPress-, Tracking-, CRO- und technische SEO-Projekte.
+- [Marktcheck](/solar-waermepumpen-leadgenerierung/#marktcheck) - diagnostischer Einstieg ausschließlich für Solar-, Wärmepumpen- und Speicher-Intent.
+
+## Fachseiten und kommerzielle Suchintents
+- [Server-Side Tracking einrichten lassen](/server-side-tracking-b2b/) - Money Page für Server-Side Tracking, Server-GTM, GA4, Google Ads und Meta CAPI; direkter Projektpfad statt Solar-Marktcheck.
+- [WordPress Agentur Hannover](/wordpress-agentur-hannover/) - lokale SEO-Seite für den Agentur-Intent; direkte Zusammenarbeit wird zur Freelancer-Route weitergeführt.
+- [WordPress Freelancer Hannover](/wordpress-freelancer-hannover/) - lokaler Freelancer-Intent für direkte Zusammenarbeit.
+- [White-Label für Agenturen](/whitelabel-retainer/) - Agentur-/Partner-Intent mit Fit-Check und scoped Erstprojekt.
 
 ## Proof und zitierfähige Quellen
-- [Solar Case Study](/case-study-solar-leadgenerierung/) - kaufnaher Proof-Case für Nachfrageaufbau, Vorqualifizierung, Tracking und Conversion.
-- [Was kosten Solar-Leads? Marktstudie](/solar-leads-kosten-studie/) - zitierfähige Marktstudie zu Lead-Kosten im DACH-Raum: Preisspannen, Cost-per-Order, Methodik und Case-Study-Benchmark.
 - [Ergebnisse](/ergebnisse/) - kuratierter Proof-Hub mit Cases, Kennzahlen und Kontext.
-- [Haşim Üner](/hasim-uener/) - Personenprofil des Autors und Betreibers.
+- [Solar Case Study](/case-study-solar-leadgenerierung/) - Proof-Case für Nachfrageaufbau, Vorqualifizierung, Tracking und Conversion.
+- [Was kosten Solar-Leads? Marktstudie](/solar-leads-kosten-studie/) - Marktstudie zu Lead-Kosten im DACH-Raum: Preisspannen, Cost-per-Order, Methodik und Case-Study-Benchmark.
+- [Haşim Üner](/hasim-uener/) - Personenprofil des Betreibers, Arbeitsweise und fachliche Kompetenz.
 
-## Solar- und Wärmepumpen-Leadgenerierung: Themen-Cluster
+## Solar- und Wärmepumpen-Cluster
 - [Solar Leads kaufen Alternative](/solar-leads-kaufen-alternative/) - Intercept-Page für Kauf-Suchintent und Alternative zu Lead-Anbietern.
-- [Aroundhome Kosten für Handwerker](/aroundhome-solar-einordnung/) - anbieterunabhängiger Kosten-, Vertrags- und Portal-Fit-Entscheid mit CPO-Rechner.
-- [Wärmepumpen Leads kaufen – Alternative](/waermepumpen-leads/) - Intercept-Page für Wärmepumpen-Lead-Kauf: Marktmodelle, wärmepumpen-spezifische Vorqualifizierung und eigenes Anfragesystem als Alternative.
+- [Aroundhome Kosten für Handwerker](/aroundhome-solar-einordnung/) - Kosten-, Vertrags- und Portal-Fit-Entscheid mit CPO-Rechner.
+- [Wärmepumpen Leads kaufen – Alternative](/waermepumpen-leads/) - Intercept-Page für Wärmepumpen-Lead-Kauf und eigene Anfragesysteme als Alternative.
 - [Eigene Leadgenerierung vs. Portale](/eigene-leadgenerierung-vs-portale/) - Vergleich von Portal-Leads und eigenem Anfragesystem.
 - [Cost per Lead Photovoltaik](/cost-per-lead-photovoltaik/) - CPL-Analyse mit Szenarienvergleich und versteckten Kostentreibern.
 - [Qualifizierte PV-Anfragen](/qualifizierte-pv-anfragen/) - Merkmale hochwertiger Solar-Anfragen und Warnsignale.
 - [Lead-Funnel Solar](/lead-funnel-solar/) - Funnel-Architektur für Photovoltaik- und Wärmepumpen-Anbieter.
-- [Server-Side Tracking einrichten lassen](/server-side-tracking-b2b/) - Server-GTM, GA4, Google Ads und Meta CAPI über eine eigene Tracking-Subdomain, mit Paketpreisen.
 - [B2B Solar Leads](/b2b-solar-leads/) - gewerbliche PV-Anfragen und Buying-Center-Logik.
 - [Kunden gewinnen für Solarteure](/kunden-gewinnen-solarteure/) - systematische Nachfragegewinnung für Solarteure.
 
-## Sekundäre Einstiege und Wissen
-- [Blog](/blog/) - Artikel zu SEO, Tracking, WordPress-Performance und Anfragesystemen.
+## Wissen
+- [Blog](/blog/) - Artikel zu SEO, Tracking, WordPress-Performance, Conversion und Anfragesystemen.
 - [Glossar](/glossar/) - Begriffe und Definitionen für SEO, Tracking, CRO und Demand-Architektur.
-- [Stack Solar](/stack-solar/) - Technischer Unterbau für Solar- und Wärmepumpen-Anbieter: Frontend, Hosting, Server-Side Tracking, CRM-Übergabe und projektspezifische Vorqualifizierung.
-- [WordPress Agentur Hannover](/wordpress-agentur-hannover/) - sekundäre lokale B2B-Service-Seite für den Agentur-Intent.
-- [WordPress Freelancer Hannover](/wordpress-freelancer-hannover/) - separater lokaler Freelancer-Einstieg für direkte WordPress-Projekte mit Entwicklung, Tracking, Funnel und technischer SEO.
+- [Stack Solar](/stack-solar/) - technischer Unterbau für Solar- und Wärmepumpen-Anbieter: Frontend, Hosting, Server-Side Tracking, CRM-Übergabe und Vorqualifizierung.


### PR DESCRIPTION
## Ziel

Die globale Positionierung wird von einer Solar-/Wärmepumpen-only-Identität auf die fachliche Klammer **WordPress · Tracking · Conversion** umgestellt. Solar/Wärmepumpe/Speicher bleibt als spezialisierte Vertikale mit eigenem Marktcheck erhalten.

## In diesem Stand

- Brand- und Copy-Contract auf drei kommerzielle Wege umgestellt: direkte Projekte, White-Label, Energy-Vertikale
- SEO-Query-Ownership explizit von Conversion-Routing getrennt
- neue Conversion-Routing-Matrix dokumentiert
- Homepage- und Blog-Metadaten von Solar-only auf die neue globale Klammer umgestellt
- statische und dynamische `llms.txt`-Ausgabe an neue Architektur angepasst
- gemeinsamer Footer-CTA ist standardmäßig projektneutral; Energy-Seiten können den Marktcheck weiterhin explizit setzen
- Messaging-Canon von der alten Solar-/Anfragesystem-Identität gelöst
- kanonische Organization-/WebSite-/Person-Schema-Entitäten werden auf die neue Positionierung normalisiert
- Freelancer-Money-Page erhält einen eigenen Service-Knoten

## Bewusst nicht gemacht

- keine Redirects oder Deindexierung bestehender Money Pages
- keine Änderung der bestehenden Query-Ownership
- Solar-Marktcheck bleibt für den Energy-Cluster bestehen
- Server-Side-Tracking-Page bleibt eigener Query-Owner und behält ihren direkten Projektpfad

## Prüfstand

- German Copy Guard: ✅
- Linkprüfung: ✅
- CI inkl. Architektur, Canon-Drift, PHP-Syntax, PHPStan und Theme-Build: ✅

## Noch vor Merge zu prüfen / Phase 2

- `single.php`: ältere generische Blog-Kontext- und Inline-CTAs hängen teilweise noch pauschal am Solar-Marktcheck. Diese müssen nach Kategorie/Intent getrennt werden, ohne Energy-Beiträge zu beschädigen.
- `category.php`: technische Kategorien (`seo`, `tracking`, `wordpress-performance`, `strategie`) enthalten noch einzelne alte Marktcheck-/Agentur-Brücken; ebenfalls intentbasiert neu routen.
- danach Schema-Normalisierung ggf. in `org-schema.php` zurückfalten (separater Refactor nach Produktionsprüfung)

Der PR bleibt deshalb bewusst **Draft** und wird noch nicht nach `main` gemergt.