### PR TITLE
Centralize commercial routing and project intake

### DIFF
--- a/blocksy-child/inc/commercial-routing.php
+++ b/blocksy-child/inc/commercial-routing.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * Canonical commercial routing for public entry points and conversion paths.
+ *
+ * SEO query ownership and conversion routing are deliberately separate:
+ * a page may keep its own indexable search intent while its CTA routes to the
+ * commercially correct next step. This module is the source of truth for the
+ * three active commercial paths: direct projects, agency White-Label and the
+ * Solar/Wärmepumpe specialization.
+ *
+ * @package Blocksy_Child
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Build a contact URL for a typed direct-project intake.
+ *
+ * The existing contact form keys stay stable because CRM and automation may
+ * consume them. Positioning changes the public semantics, not the transport
+ * contract.
+ *
+ * @param string $type  Existing contact request type.
+ * @param string $focus Existing contact focus key.
+ * @return string
+ */
+function hu_get_contact_intake_url( $type = 'project', $focus = 'implementation_scope' ) {
+	$contact_url = function_exists( 'nexus_get_contact_url' ) ? nexus_get_contact_url() : home_url( '/kontakt/' );
+
+	return add_query_arg(
+		[
+			'type'  => sanitize_key( (string) $type ),
+			'focus' => sanitize_key( (string) $focus ),
+		],
+		$contact_url
+	);
+}
+
+/**
+ * Return the canonical commercial route map.
+ *
+ * Important: `agentur_local` is an SEO/local acquisition entry, not a global
+ * business pillar. `tracking_b2b` remains a dedicated query owner. The
+ * `marketcheck` belongs only to the Energy specialization and explicit Energy
+ * contexts.
+ *
+ * @return array<string, string>
+ */
+function hu_get_commercial_route_map() {
+	static $routes = null;
+
+	if ( is_array( $routes ) ) {
+		return $routes;
+	}
+
+	$routes = [
+		'home'            => home_url( '/' ),
+		'freelancer'      => function_exists( 'nexus_get_page_url' )
+			? nexus_get_page_url( [ 'wordpress-freelancer-hannover' ], home_url( '/wordpress-freelancer-hannover/' ) )
+			: home_url( '/wordpress-freelancer-hannover/' ),
+		'project_request' => hu_get_contact_intake_url( 'project', 'implementation_scope' ),
+		'contact'         => function_exists( 'nexus_get_contact_url' ) ? nexus_get_contact_url() : home_url( '/kontakt/' ),
+		'whitelabel'      => function_exists( 'nexus_get_whitelabel_page_url' )
+			? nexus_get_whitelabel_page_url()
+			: home_url( '/whitelabel-retainer/' ),
+		'energy'          => function_exists( 'nexus_get_energy_systems_url' )
+			? nexus_get_energy_systems_url()
+			: home_url( '/solar-waermepumpen-leadgenerierung/' ),
+		'marketcheck'     => function_exists( 'hu_get_request_analysis_url' )
+			? hu_get_request_analysis_url()
+			: home_url( '/solar-waermepumpen-leadgenerierung/#marktcheck' ),
+		'tracking_b2b'    => function_exists( 'nexus_get_page_url' )
+			? nexus_get_page_url( [ 'server-side-tracking-b2b' ], home_url( '/server-side-tracking-b2b/' ) )
+			: home_url( '/server-side-tracking-b2b/' ),
+		'agentur_local'   => function_exists( 'nexus_get_page_url' )
+			? nexus_get_page_url( [ 'wordpress-agentur-hannover', 'wordpress-agentur' ], home_url( '/wordpress-agentur-hannover/' ) )
+			: home_url( '/wordpress-agentur-hannover/' ),
+		'results'         => function_exists( 'nexus_get_results_url' )
+			? nexus_get_results_url()
+			: home_url( '/ergebnisse/' ),
+		'about'           => function_exists( 'nexus_get_page_url' )
+			? nexus_get_page_url( [ 'hasim-uener', 'uber-mich' ], home_url( '/hasim-uener/' ) )
+			: home_url( '/hasim-uener/' ),
+	];
+
+	return (array) apply_filters( 'hu_commercial_route_map', $routes );
+}
+
+/**
+ * Resolve one canonical commercial route.
+ *
+ * @param string $key      Route key.
+ * @param string $fallback Optional fallback URL.
+ * @return string
+ */
+function hu_get_commercial_route( $key, $fallback = '' ) {
+	$routes = hu_get_commercial_route_map();
+	$key    = sanitize_key( (string) $key );
+
+	if ( isset( $routes[ $key ] ) && '' !== (string) $routes[ $key ] ) {
+		return (string) $routes[ $key ];
+	}
+
+	return $fallback ? $fallback : home_url( '/' );
+}
+
+/**
+ * Return the one canonical global navigation contract.
+ *
+ * Both the directly rendered header and the stored WordPress menu use this
+ * sequence. This prevents theme switches or menu rebuilds from restoring the
+ * retired Agentur/Marktcheck-first navigation.
+ *
+ * @return array<int, array<string, mixed>>
+ */
+function hu_get_primary_navigation_contract() {
+	$routes = hu_get_commercial_route_map();
+
+	return [
+		[
+			'label'    => __( 'Solar & Wärmepumpen', 'blocksy-child' ),
+			'url'      => $routes['energy'],
+			'current'  => function_exists( 'nexus_is_energy_systems_context' ) && nexus_is_energy_systems_context(),
+			'class'    => 'nav-solar-link',
+			'track'    => 'nav_header_solar',
+			'category' => 'navigation',
+		],
+		[
+			'label'    => __( 'WordPress Freelancer', 'blocksy-child' ),
+			'url'      => $routes['freelancer'],
+			'current'  => is_page( 'wordpress-freelancer-hannover' ) || is_page_template( 'page-wordpress-freelancer-hannover.php' ),
+			'class'    => 'nav-freelancer-link',
+			'track'    => 'nav_header_freelancer',
+			'category' => 'navigation',
+		],
+		[
+			'label'    => __( 'Für Agenturen', 'blocksy-child' ),
+			'url'      => $routes['whitelabel'],
+			'current'  => function_exists( 'nexus_is_agency_nav_context' ) && nexus_is_agency_nav_context(),
+			'class'    => 'nav-agency-link',
+			'track'    => 'nav_header_whitelabel',
+			'category' => 'navigation',
+		],
+		[
+			'label'    => __( 'Ergebnisse', 'blocksy-child' ),
+			'url'      => $routes['results'],
+			'current'  => function_exists( 'nexus_is_results_context' ) && nexus_is_results_context(),
+			'class'    => 'nav-results-link',
+			'track'    => 'nav_header_results',
+			'category' => 'navigation',
+		],
+		[
+			'label'    => __( 'Über Haşim', 'blocksy-child' ),
+			'url'      => $routes['about'],
+			'current'  => is_page( 'hasim-uener' ) || is_page( 'uber-mich' ) || is_page_template( 'page-hasim-uener.php' ),
+			'class'    => 'nav-about-link',
+			'track'    => 'nav_header_about',
+			'category' => 'navigation',
+		],
+		[
+			'label'    => __( 'Projekt anfragen', 'blocksy-child' ),
+			'url'      => $routes['project_request'],
+			'current'  => false,
+			'class'    => 'nav-cta-button nav-project-link',
+			'track'    => 'nav_header_project',
+			'category' => 'lead_gen',
+		],
+	];
+}

--- a/blocksy-child/inc/menu-setup.php
+++ b/blocksy-child/inc/menu-setup.php
@@ -2,10 +2,12 @@
 /**
  * NEXUS MENU SETUP
  *
- * Erstellt das fokussierte Hauptmenü für die Neukunden-Navigation:
- * Solar & Wärmepumpen | WordPress Agentur | Ergebnisse | Über Haşim | Marktcheck · 48 h
+ * Persistiert dieselbe strategische Navigation, die der öffentliche Header
+ * direkt rendert. Das gespeicherte WordPress-Menü ist damit Fallback/Backend-
+ * Zustand und keine zweite Quelle der Informationsarchitektur mehr.
  *
- * Einmal-Setup: Wird beim Theme-Switch oder manuell via ?nexus_rebuild_menu=1 ausgelöst.
+ * Einmal-Setup: Wird beim Theme-Switch oder manuell via
+ * ?nexus_rebuild_menu=1 ausgelöst.
  *
  * @package Blocksy_Child
  */
@@ -15,7 +17,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Detect audit CTA items even if the stored WordPress menu label is outdated.
+ * Detect a legacy conversion CTA item.
+ *
+ * Der historische Funktionsname bleibt für interne Verbraucher stabil. Neue
+ * globale CTAs werden als Projektanfrage normalisiert; Marktcheck bleibt nur
+ * in expliziten Energy-Kontexten.
  *
  * @param WP_Post $item Menu item object.
  * @return bool
@@ -26,12 +32,11 @@ function nexus_is_audit_cta_menu_item( $item ) {
 	$url     = isset( $item->url ) ? (string) $item->url : '';
 	$path    = $url ? wp_parse_url( $url, PHP_URL_PATH ) : '';
 
-	if ( in_array( 'nav-cta-button', $classes, true ) ) {
+	if ( in_array( 'nav-cta-button', $classes, true ) || in_array( 'nav-project-link', $classes, true ) ) {
 		return true;
 	}
 
-	// Legacy paths stay here so older menu items are still normalized at render time.
-	$audit_paths = [
+	$legacy_paths = [
 		'/audit/',
 		'/customer-journey-audit/',
 		'/growth-audit/',
@@ -39,7 +44,7 @@ function nexus_is_audit_cta_menu_item( $item ) {
 		'/system-diagnose/',
 	];
 
-	if ( $path && in_array( trailingslashit( $path ), $audit_paths, true ) ) {
+	if ( $path && in_array( trailingslashit( $path ), $legacy_paths, true ) ) {
 		return true;
 	}
 
@@ -49,7 +54,8 @@ function nexus_is_audit_cta_menu_item( $item ) {
 		|| false !== strpos( $title, 'growth audit' )
 		|| false !== strpos( $title, 'free journey audit' )
 		|| false !== strpos( $title, 'system-diagnose' )
-		|| false !== strpos( $title, 'marktcheck' );
+		|| false !== strpos( $title, 'marktcheck' )
+		|| false !== strpos( $title, 'projekt anfragen' );
 }
 
 /**
@@ -88,14 +94,60 @@ function nexus_is_results_menu_item( $item ) {
 }
 
 /**
- * Hauptmenü programmatisch erstellen.
+ * Return a safe navigation fallback if the canonical routing module is absent.
+ *
+ * @return array<int, array<string, mixed>>
+ */
+function nexus_get_menu_setup_fallback_contract() {
+	$project_url = function_exists( 'hu_get_navigation_project_request_url' )
+		? hu_get_navigation_project_request_url()
+		: add_query_arg( [ 'type' => 'project', 'focus' => 'implementation_scope' ], home_url( '/kontakt/' ) );
+
+	return [
+		[
+			'label' => 'Solar & Wärmepumpen',
+			'url'   => home_url( '/solar-waermepumpen-leadgenerierung/' ),
+			'class' => 'nav-solar-link',
+		],
+		[
+			'label' => 'WordPress Freelancer',
+			'url'   => home_url( '/wordpress-freelancer-hannover/' ),
+			'class' => 'nav-freelancer-link',
+		],
+		[
+			'label' => 'Für Agenturen',
+			'url'   => home_url( '/whitelabel-retainer/' ),
+			'class' => 'nav-agency-link',
+		],
+		[
+			'label' => 'Ergebnisse',
+			'url'   => home_url( '/ergebnisse/' ),
+			'class' => 'nav-results-link',
+		],
+		[
+			'label' => 'Über Haşim',
+			'url'   => home_url( '/hasim-uener/' ),
+			'class' => 'nav-about-link',
+		],
+		[
+			'label' => 'Projekt anfragen',
+			'url'   => $project_url,
+			'class' => 'nav-cta-button nav-project-link',
+		],
+	];
+}
+
+/**
+ * Create the stored WordPress menu from the canonical navigation contract.
+ *
+ * @return void
  */
 function nexus_setup_main_menu() {
-
 	$menu_name = 'Nexus Hauptmenü';
-	$primary_urls = function_exists( 'nexus_get_primary_public_url_map' ) ? nexus_get_primary_public_url_map() : [];
+	$contract  = function_exists( 'hu_get_primary_navigation_contract' )
+		? hu_get_primary_navigation_contract()
+		: nexus_get_menu_setup_fallback_contract();
 
-	// Bestehendes Menü löschen falls vorhanden (Neuaufbau)
 	$existing = wp_get_nav_menu_object( $menu_name );
 	if ( $existing ) {
 		wp_delete_nav_menu( $existing->term_id );
@@ -106,91 +158,42 @@ function nexus_setup_main_menu() {
 		return;
 	}
 
-	// ── 1. Solar & Wärmepumpen (Top-Level) ────────────────────────
-	$solar_id = nexus_get_page_id( [ 'solar-waermepumpen-leadgenerierung' ] );
-	wp_update_nav_menu_item( $menu_id, 0, [
-		'menu-item-title'     => 'Solar & Wärmepumpen',
-		'menu-item-object'    => 'page',
-		'menu-item-object-id' => $solar_id,
-		'menu-item-type'      => $solar_id ? 'post_type' : 'custom',
-		'menu-item-url'       => $solar_id ? '' : home_url( '/solar-waermepumpen-leadgenerierung/' ),
-		'menu-item-status'    => 'publish',
-	] );
+	foreach ( $contract as $item ) {
+		$title   = trim( (string) ( $item['label'] ?? '' ) );
+		$url     = (string) ( $item['url'] ?? '' );
+		$classes = trim( (string) ( $item['class'] ?? '' ) );
 
-	// ── 2. WordPress Agentur (Top-Level) ───────────────────────────
-	$agentur_id = nexus_get_page_id( [ 'wordpress-agentur-hannover' ] );
-	wp_update_nav_menu_item( $menu_id, 0, [
-		'menu-item-title'     => 'WordPress Agentur',
-		'menu-item-object'    => 'page',
-		'menu-item-object-id' => $agentur_id,
-		'menu-item-type'      => $agentur_id ? 'post_type' : 'custom',
-		'menu-item-url'       => $agentur_id ? '' : ( $primary_urls['agentur'] ?? home_url( '/wordpress-agentur-hannover/' ) ),
-		'menu-item-status'    => 'publish',
-	] );
+		if ( '' === $title || '' === $url ) {
+			continue;
+		}
 
-	// ── 3. Ergebnisse (Top-Level) ──────────────────────────────────
-	$results_id  = nexus_get_page_id( [ 'ergebnisse' ] );
-	$results_url = $primary_urls['results'] ?? home_url( '/ergebnisse/' );
-	wp_update_nav_menu_item( $menu_id, 0, [
-		'menu-item-title'     => 'Ergebnisse',
-		'menu-item-object'    => 'page',
-		'menu-item-object-id' => $results_id,
-		'menu-item-type'      => $results_id ? 'post_type' : 'custom',
-		'menu-item-url'       => $results_id ? '' : $results_url,
-		'menu-item-status'    => 'publish',
-		'menu-item-classes'   => 'nav-results-link',
-	] );
+		wp_update_nav_menu_item(
+			$menu_id,
+			0,
+			[
+				'menu-item-title'   => $title,
+				'menu-item-object'  => 'custom',
+				'menu-item-type'    => 'custom',
+				'menu-item-url'     => $url,
+				'menu-item-status'  => 'publish',
+				'menu-item-classes' => $classes,
+			]
+		);
+	}
 
-	// ── 4. Über Haşim (Top-Level) ─────────────────────────────────
-	$about_id = nexus_get_page_id( [ 'hasim-uener', 'uber-mich' ] );
-	wp_update_nav_menu_item( $menu_id, 0, [
-		'menu-item-title'     => 'Über Haşim',
-		'menu-item-object'    => 'page',
-		'menu-item-object-id' => $about_id,
-		'menu-item-type'      => $about_id ? 'post_type' : 'custom',
-		'menu-item-url'       => $about_id ? '' : ( $primary_urls['about'] ?? home_url( '/hasim-uener/' ) ),
-		'menu-item-status'    => 'publish',
-	] );
-
-	// ── 5. Für Agenturen (Top-Level) ───────────────────────────────
-	$agency_id  = nexus_get_page_id( [ 'whitelabel-retainer' ] );
-	$agency_url = $primary_urls['whitelabel'] ?? home_url( '/whitelabel-retainer/' );
-	wp_update_nav_menu_item( $menu_id, 0, [
-		'menu-item-title'     => 'Für Agenturen',
-		'menu-item-object'    => 'page',
-		'menu-item-object-id' => $agency_id,
-		'menu-item-type'      => $agency_id ? 'post_type' : 'custom',
-		'menu-item-url'       => $agency_id ? '' : $agency_url,
-		'menu-item-status'    => 'publish',
-		'menu-item-classes'   => 'nav-agency-link',
-	] );
-
-	// ── 6. Marktcheck CTA (Top-Level) ──────────────────────────────
-	$analysis_url = function_exists( 'hu_get_request_analysis_url' ) ? hu_get_request_analysis_url() : home_url( '/solar-waermepumpen-leadgenerierung/#marktcheck' );
-	wp_update_nav_menu_item( $menu_id, 0, [
-		'menu-item-title'     => 'Marktcheck · 48 h',
-		'menu-item-object'    => 'custom',
-		'menu-item-object-id' => 0,
-		'menu-item-type'      => 'custom',
-		'menu-item-url'       => $analysis_url,
-		'menu-item-status'    => 'publish',
-		'menu-item-classes'   => 'nav-cta-button',
-	] );
-
-	// ── Menü den Header-Locations zuweisen ─────────────────────────
 	$locations = get_theme_mod( 'nav_menu_locations', [] );
 	$locations['primary']      = $menu_id;
 	$locations['primary-slim'] = $menu_id;
 	set_theme_mod( 'nav_menu_locations', $locations );
 }
 
-// Bei Theme-Aktivierung ausführen
 add_action( 'after_switch_theme', 'nexus_setup_main_menu' );
 
 /**
- * Create the proof hub pages that are routed via page-slug templates.
+ * Create proof/agency hub pages that are routed via page-slug templates.
  *
- * Triggered manually for admins so production content does not change unexpectedly.
+ * Triggered manually for admins so production content does not change
+ * unexpectedly.
  *
  * @return void
  */
@@ -236,16 +239,16 @@ function nexus_seed_results_pages() {
 	}
 }
 
-// Manuell auslösen: ?nexus_rebuild_menu=1 (nur für Admins)
+// Manual admin maintenance routes.
 add_action( 'admin_init', function () {
 	if (
 		isset( $_GET['nexus_rebuild_menu'] ) &&
-		$_GET['nexus_rebuild_menu'] === '1' &&
+		'1' === $_GET['nexus_rebuild_menu'] &&
 		current_user_can( 'manage_options' )
 	) {
 		nexus_setup_main_menu();
 		add_action( 'admin_notices', function () {
-			echo '<div class="notice notice-success is-dismissible"><p>Nexus Hauptmenü wurde erstellt.</p></div>';
+			echo '<div class="notice notice-success is-dismissible"><p>Nexus Hauptmenü wurde aus dem zentralen Routing-Contract erstellt.</p></div>';
 		} );
 	}
 
@@ -260,116 +263,4 @@ add_action( 'admin_init', function () {
 			echo '<div class="notice notice-success is-dismissible"><p>Ergebnisse- und Whitelabel-Seiten wurden angelegt bzw. aktualisiert.</p></div>';
 		} );
 	}
-
 } );
-
-/**
- * Normalize the primary nav CTA at render time.
- *
- * This keeps the live header label stable even if the stored menu item in
- * WordPress still carries an outdated title from an older setup.
- */
-add_filter( 'wp_nav_menu_objects', function ( $items, $args ) {
-	if ( empty( $items ) || empty( $args ) ) {
-		return $items;
-	}
-
-	$theme_location = isset( $args->theme_location ) ? (string) $args->theme_location : '';
-	$menu_name      = isset( $args->menu->name ) ? (string) $args->menu->name : '';
-	$is_primary_like_menu = in_array( $theme_location, [ 'primary', 'primary-slim' ], true )
-		|| in_array( $menu_name, [ 'Nexus Hauptmenü', 'Hauptmenü Slim' ], true );
-
-	$analysis_url = function_exists( 'hu_get_request_analysis_url' ) ? hu_get_request_analysis_url() : home_url( '/solar-waermepumpen-leadgenerierung/#marktcheck' );
-	$results_url = nexus_get_results_url();
-	$is_results_context = nexus_is_results_context();
-
-	foreach ( $items as $item ) {
-		if ( nexus_is_results_menu_item( $item ) ) {
-			$item->title = 'Ergebnisse';
-			$item->url   = $results_url;
-
-			if ( ! isset( $item->classes ) || ! is_array( $item->classes ) ) {
-				$item->classes = [];
-			}
-
-			if ( ! in_array( 'nav-results-link', $item->classes, true ) ) {
-				$item->classes[] = 'nav-results-link';
-			}
-
-			if ( $is_primary_like_menu && $is_results_context ) {
-				foreach ( [ 'current-menu-item', 'current_page_item' ] as $class_name ) {
-					if ( ! in_array( $class_name, $item->classes, true ) ) {
-						$item->classes[] = $class_name;
-					}
-				}
-			}
-
-			continue;
-		}
-
-		$item_title_raw = isset( $item->title ) ? wp_strip_all_tags( (string) $item->title ) : '';
-		if ( 'Über mich' === $item_title_raw ) {
-			$item->title = 'Über Haşim';
-			continue;
-		}
-
-		if ( ! nexus_is_audit_cta_menu_item( $item ) ) {
-			continue;
-		}
-
-		$item->title = 'Marktcheck · 48 h';
-		$item->url   = $analysis_url;
-
-		if ( ! isset( $item->classes ) || ! is_array( $item->classes ) ) {
-			$item->classes = [];
-		}
-
-		if ( ! in_array( 'nav-cta-button', $item->classes, true ) ) {
-			$item->classes[] = 'nav-cta-button';
-		}
-	}
-
-	return $items;
-}, 20, 2 );
-
-/**
- * Add data-track attributes to primary nav links.
- */
-add_filter( 'nav_menu_link_attributes', function ( $atts, $item ) {
-	if ( ! isset( $item->classes ) || ! is_array( $item->classes ) ) {
-		return $atts;
-	}
-
-	$title = isset( $item->title ) ? (string) $item->title : '';
-	if ( '' === $title ) {
-		return $atts;
-	}
-
-	$title_lower = strtolower( wp_strip_all_tags( $title ) );
-	$track_map   = [
-		'solar & wärmepumpen' => 'solar',
-		'wordpress agentur'   => 'agentur',
-		'ergebnisse'          => 'results',
-		'e3 proof'            => 'case_study_proof',
-		'e3 new energy'       => 'case_study_proof',
-		'case study'          => 'case_study_proof',
-		'über mich'           => 'about',
-		'über haşim'          => 'about',
-		'für agenturen'       => 'whitelabel',
-	];
-
-	foreach ( $track_map as $label => $track_key ) {
-		if ( $title_lower === $label ) {
-			$atts['data-track-action']   = 'nav_header_' . $track_key;
-			$atts['data-track-category'] = 'navigation';
-			return $atts;
-		}
-	}
-
-	if ( in_array( 'nav-cta-button', $item->classes, true ) ) {
-		$atts['data-track-action']   = 'nav_header_analysis';
-		$atts['data-track-category'] = 'lead_gen';
-	}
-
-	return $atts;
-}, 10, 2 );

--- a/blocksy-child/inc/snippets.php
+++ b/blocksy-child/inc/snippets.php
@@ -6,6 +6,11 @@
  */
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 
+$commercial_routing_path = __DIR__ . '/commercial-routing.php';
+if ( file_exists( $commercial_routing_path ) ) {
+    require_once $commercial_routing_path;
+}
+
 add_shortcode( 'nexus_header_btn', function() {
     $portal_page = get_page_by_path( 'portal' );
     $link = $portal_page ? get_permalink( $portal_page ) : home_url( '/portal' );
@@ -25,12 +30,25 @@ add_shortcode( 'nexus_header_btn', function() {
  * @return string
  */
 function hu_get_navigation_project_request_url() {
+    if ( function_exists( 'hu_get_commercial_route' ) ) {
+        return hu_get_commercial_route(
+            'project_request',
+            add_query_arg(
+                [
+                    'type'  => 'project',
+                    'focus' => 'implementation_scope',
+                ],
+                function_exists( 'nexus_get_contact_url' ) ? nexus_get_contact_url() : home_url( '/kontakt/' )
+            )
+        );
+    }
+
     $contact_url = function_exists( 'nexus_get_contact_url' ) ? nexus_get_contact_url() : home_url( '/kontakt/' );
 
     return add_query_arg(
         [
             'type'  => 'project',
-            'focus' => 'followup_scope',
+            'focus' => 'implementation_scope',
         ],
         $contact_url
     );
@@ -109,6 +127,24 @@ function hu_normalize_primary_strategy_navigation( $items, $args ) {
         || ! nexus_is_primary_header_menu_args( $args )
     ) {
         return $items;
+    }
+
+    if ( function_exists( 'hu_get_primary_navigation_contract' ) ) {
+        $normalized_items = [];
+
+        foreach ( hu_get_primary_navigation_contract() as $definition ) {
+            $classes = isset( $definition['class'] ) ? preg_split( '/\s+/', trim( (string) $definition['class'] ) ) : [];
+            $classes = is_array( $classes ) ? array_values( array_filter( $classes ) ) : [];
+
+            $normalized_items[] = hu_make_strategy_nav_item(
+                (string) ( $definition['label'] ?? '' ),
+                (string) ( $definition['url'] ?? home_url( '/' ) ),
+                $classes,
+                ! empty( $definition['current'] )
+            );
+        }
+
+        return $normalized_items;
     }
 
     $primary_urls   = function_exists( 'nexus_get_primary_public_url_map' ) ? nexus_get_primary_public_url_map() : [];
@@ -200,11 +236,15 @@ add_action( 'wp_body_open', function() {
     if ( ! is_page( 'wordpress-agentur-hannover' ) && ! is_page_template( 'page-wordpress-agentur.php' ) ) {
         return;
     }
+
+    $freelancer_url = function_exists( 'hu_get_commercial_route' )
+        ? hu_get_commercial_route( 'freelancer', home_url( '/wordpress-freelancer-hannover/' ) )
+        : home_url( '/wordpress-freelancer-hannover/' );
     ?>
     <aside class="hu-route-switch" aria-label="Passender WordPress-Einstieg">
         <div class="nx-container hu-route-switch__inner">
             <span>Direkte Zusammenarbeit statt Agentur-Setup?</span>
-            <a href="<?php echo esc_url( home_url( '/wordpress-freelancer-hannover/' ) ); ?>" data-track-action="link_agentur_to_freelancer" data-track-category="navigation" data-track-section="intent_switch">WordPress Freelancer Hannover →</a>
+            <a href="<?php echo esc_url( $freelancer_url ); ?>" data-track-action="link_agentur_to_freelancer" data-track-category="navigation" data-track-section="intent_switch">WordPress Freelancer Hannover →</a>
         </div>
     </aside>
     <?php

--- a/blocksy-child/template-parts/site-header.php
+++ b/blocksy-child/template-parts/site-header.php
@@ -12,10 +12,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 $brand_text   = function_exists( 'hu_get_site_wordmark_text' ) ? hu_get_site_wordmark_text() : 'HAŞIM ÜNER';
 $eyebrow_text = nexus_get_site_header_eyebrow();
 $panel_id     = 'nx-site-header-panel';
-$request_url  = function_exists( 'hu_get_request_analysis_url' ) ? hu_get_request_analysis_url() : home_url( '/solar-waermepumpen-leadgenerierung/#marktcheck' );
-$project_url  = function_exists( 'hu_get_navigation_project_request_url' )
+$routes       = function_exists( 'hu_get_commercial_route_map' ) ? hu_get_commercial_route_map() : [];
+$request_url  = $routes['marketcheck'] ?? ( function_exists( 'hu_get_request_analysis_url' ) ? hu_get_request_analysis_url() : home_url( '/solar-waermepumpen-leadgenerierung/#marktcheck' ) );
+$project_url  = $routes['project_request'] ?? ( function_exists( 'hu_get_navigation_project_request_url' )
 	? hu_get_navigation_project_request_url()
-	: add_query_arg( [ 'type' => 'project', 'focus' => 'followup_scope' ], home_url( '/kontakt/' ) );
+	: add_query_arg( [ 'type' => 'project', 'focus' => 'implementation_scope' ], home_url( '/kontakt/' ) ) );
 $audit_header_meta_items = function_exists( 'nexus_get_audit_header_meta_items' ) ? nexus_get_audit_header_meta_items() : [];
 $home_label = sprintf(
 	/* translators: %s: site or brand name. */
@@ -26,72 +27,53 @@ $home_label = sprintf(
 if ( empty( $audit_header_meta_items ) ) {
 	$audit_header_meta_items = [
 		'Manueller Marktcheck',
-		'WordPress- und B2B-Fokus',
+		'Solar- und Wärmepumpen-Fokus',
 	];
 }
 
 /*
- * Strategische Hauptnavigation direkt im tatsächlich gerenderten Header.
- * Das gespeicherte WordPress-Menü bleibt nur Legacy-/Backend-Zustand und kann
- * die öffentliche Informationsarchitektur nicht mehr überschreiben.
+ * Eine zentrale Navigationsquelle: derselbe Contract wird auch beim
+ * WordPress-Menü-Rebuild verwendet. So können Theme-Wechsel oder Altzustände
+ * nicht wieder "WordPress Agentur" bzw. den Marktcheck als globale CTA setzen.
  */
-$primary_urls   = function_exists( 'nexus_get_primary_public_url_map' ) ? nexus_get_primary_public_url_map() : [];
-$solar_url      = $primary_urls['energy'] ?? home_url( '/solar-waermepumpen-leadgenerierung/' );
-$freelancer_url = home_url( '/wordpress-freelancer-hannover/' );
-$whitelabel_url = function_exists( 'nexus_get_whitelabel_page_url' ) ? nexus_get_whitelabel_page_url() : home_url( '/whitelabel-retainer/' );
-$results_url    = function_exists( 'nexus_get_results_url' ) ? nexus_get_results_url() : ( $primary_urls['results'] ?? home_url( '/ergebnisse/' ) );
-$about_url      = $primary_urls['about'] ?? home_url( '/hasim-uener/' );
-
-$strategy_nav_items = [
-	[
-		'label'    => __( 'Solar & Wärmepumpen', 'blocksy-child' ),
-		'url'      => $solar_url,
-		'current'  => function_exists( 'nexus_is_energy_systems_context' ) && nexus_is_energy_systems_context(),
-		'class'    => 'nav-solar-link',
-		'track'    => 'nav_header_solar',
-		'category' => 'navigation',
-	],
-	[
-		'label'    => __( 'WordPress Freelancer', 'blocksy-child' ),
-		'url'      => $freelancer_url,
-		'current'  => is_page( 'wordpress-freelancer-hannover' ) || is_page_template( 'page-wordpress-freelancer-hannover.php' ),
-		'class'    => 'nav-freelancer-link',
-		'track'    => 'nav_header_freelancer',
-		'category' => 'navigation',
-	],
-	[
-		'label'    => __( 'Für Agenturen', 'blocksy-child' ),
-		'url'      => $whitelabel_url,
-		'current'  => function_exists( 'nexus_is_agency_nav_context' ) && nexus_is_agency_nav_context(),
-		'class'    => 'nav-agency-link',
-		'track'    => 'nav_header_whitelabel',
-		'category' => 'navigation',
-	],
-	[
-		'label'    => __( 'Ergebnisse', 'blocksy-child' ),
-		'url'      => $results_url,
-		'current'  => function_exists( 'nexus_is_results_context' ) && nexus_is_results_context(),
-		'class'    => 'nav-results-link',
-		'track'    => 'nav_header_results',
-		'category' => 'navigation',
-	],
-	[
-		'label'    => __( 'Über Haşim', 'blocksy-child' ),
-		'url'      => $about_url,
-		'current'  => is_page( 'hasim-uener' ) || is_page( 'uber-mich' ) || is_page_template( 'page-hasim-uener.php' ),
-		'class'    => 'nav-about-link',
-		'track'    => 'nav_header_about',
-		'category' => 'navigation',
-	],
-	[
-		'label'    => __( 'Projekt anfragen', 'blocksy-child' ),
-		'url'      => $project_url,
-		'current'  => false,
-		'class'    => 'nav-cta-button nav-project-link',
-		'track'    => 'nav_header_project',
-		'category' => 'lead_gen',
-	],
-];
+if ( function_exists( 'hu_get_primary_navigation_contract' ) ) {
+	$strategy_nav_items = hu_get_primary_navigation_contract();
+} else {
+	$strategy_nav_items = [
+		[
+			'label'    => __( 'WordPress Freelancer', 'blocksy-child' ),
+			'url'      => home_url( '/wordpress-freelancer-hannover/' ),
+			'current'  => false,
+			'class'    => 'nav-freelancer-link',
+			'track'    => 'nav_header_freelancer',
+			'category' => 'navigation',
+		],
+		[
+			'label'    => __( 'Für Agenturen', 'blocksy-child' ),
+			'url'      => home_url( '/whitelabel-retainer/' ),
+			'current'  => false,
+			'class'    => 'nav-agency-link',
+			'track'    => 'nav_header_whitelabel',
+			'category' => 'navigation',
+		],
+		[
+			'label'    => __( 'Solar & Wärmepumpen', 'blocksy-child' ),
+			'url'      => home_url( '/solar-waermepumpen-leadgenerierung/' ),
+			'current'  => false,
+			'class'    => 'nav-solar-link',
+			'track'    => 'nav_header_solar',
+			'category' => 'navigation',
+		],
+		[
+			'label'    => __( 'Projekt anfragen', 'blocksy-child' ),
+			'url'      => $project_url,
+			'current'  => false,
+			'class'    => 'nav-cta-button nav-project-link',
+			'track'    => 'nav_header_project',
+			'category' => 'lead_gen',
+		],
+	];
+}
 
 $render_strategy_navigation = static function ( string $context ) use ( $strategy_nav_items ): void {
 	$context    = sanitize_key( $context );
@@ -99,19 +81,19 @@ $render_strategy_navigation = static function ( string $context ) use ( $strateg
 
 	echo '<ul class="' . esc_attr( $menu_class ) . '">';
 	foreach ( $strategy_nav_items as $item ) {
-		$li_classes = 'menu-item ' . $item['class'];
-		if ( $item['current'] ) {
+		$li_classes = 'menu-item ' . (string) ( $item['class'] ?? '' );
+		if ( ! empty( $item['current'] ) ) {
 			$li_classes .= ' current-menu-item current_page_item';
 		}
 		?>
 		<li class="<?php echo esc_attr( $li_classes ); ?>">
 			<a
-				href="<?php echo esc_url( $item['url'] ); ?>"
-				<?php echo $item['current'] ? ' aria-current="page"' : ''; // raw-ok -- static attribute ?>
-				data-track-action="<?php echo esc_attr( $item['track'] ); ?>"
-				data-track-category="<?php echo esc_attr( $item['category'] ); ?>"
+				href="<?php echo esc_url( (string) ( $item['url'] ?? home_url( '/' ) ) ); ?>"
+				<?php echo ! empty( $item['current'] ) ? ' aria-current="page"' : ''; // raw-ok -- static attribute ?>
+				data-track-action="<?php echo esc_attr( (string) ( $item['track'] ?? 'nav_header' ) ); ?>"
+				data-track-category="<?php echo esc_attr( (string) ( $item['category'] ?? 'navigation' ) ); ?>"
 			>
-				<?php echo esc_html( $item['label'] ); ?>
+				<?php echo esc_html( (string) ( $item['label'] ?? '' ) ); ?>
 			</a>
 		</li>
 		<?php

--- a/docs/architecture/COMMERCIAL_ROUTING_PHASE_2.md
+++ b/docs/architecture/COMMERCIAL_ROUTING_PHASE_2.md
@@ -1,0 +1,52 @@
+# Commercial Routing Phase 2
+
+## Scope
+
+Diese Phase lässt den Blog bewusst außen vor und stabilisiert die aktive kommerzielle Architektur außerhalb redaktioneller Templates.
+
+## Source of truth
+
+`blocksy-child/inc/commercial-routing.php` ist die kanonische Quelle für öffentliche Geschäftswege und die globale Navigation.
+
+### Kommerzielle Routen
+
+- `freelancer`: direkte WordPress-Zusammenarbeit
+- `project_request`: neutrale Projektanfrage für direkte Unternehmen
+- `whitelabel`: Agentur-/White-Label-Einstieg
+- `energy`: Solar-/Wärmepumpen-Spezialisierung
+- `marketcheck`: diagnostischer Einstieg nur für den Energy-Kontext
+- `tracking_b2b`: eigener Tracking-Query-Owner
+- `agentur_local`: lokale SEO-Einstiegsseite, kein globaler Navigationspfeiler
+- `results`: Proof-Hub
+- `about`: Personen-/Vertrauensseite
+- `contact`: neutraler Kontakt
+
+## Navigation contract
+
+Die globale Reihenfolge ist:
+
+1. Solar & Wärmepumpen
+2. WordPress Freelancer
+3. Für Agenturen
+4. Ergebnisse
+5. Über Haşim
+6. Projekt anfragen
+
+Der direkt gerenderte Header und ein später neu aufgebautes WordPress-Menü beziehen sich auf denselben Contract. Ein Theme-Wechsel oder `?nexus_rebuild_menu=1` darf deshalb nicht mehr die alte Kombination `WordPress Agentur` + `Marktcheck` als globale Hauptnavigation wiederherstellen.
+
+## Conversion contract
+
+SEO-Query-Ownership und Conversion-Ziel bleiben getrennt. Eine indexierbare Fachseite muss nicht auf ihre SEO-Hub-Seite umgeleitet werden. Der CTA folgt dem Geschäftsweg:
+
+- allgemeine WordPress-/Tracking-/Conversion-Arbeit -> Projektanfrage
+- Agentur-Intent -> White-Label
+- Solar-/Wärmepumpen-Intent -> Marktcheck bzw. Energy-Hub
+- lokale Agentur-Suche -> Agentur-Seite bleibt indexierbar, verweist aber sichtbar auf direkte Freelancer-Zusammenarbeit
+
+Die bestehenden Kontakt-Keys (`type`, `focus`) bleiben stabil, damit CRM- und Automationsverträge nicht unnötig verändert werden. Die globale Projektanfrage nutzt `type=project&focus=implementation_scope`.
+
+## Bewusst außerhalb dieses Schritts
+
+- `single.php` und `category.php`
+- Blog-Kategorien und redaktionelle CTA-Bridges
+- vollständiger Refactor von `org-schema.php`


### PR DESCRIPTION
## Ziel

Phase 2 der Neupositionierung stabilisiert die aktive Architektur außerhalb des Blogs. Die öffentlichen Geschäftswege werden zentralisiert, damit Header, gespeichertes WordPress-Menü und Projekt-CTA nicht wieder in die alte Agentur-/Marktcheck-Logik zurückfallen.

## Änderungen

- neue kanonische Routing-Quelle `inc/commercial-routing.php`
- zentrale Routen für Freelancer, Projektanfrage, White-Label, Energy, Marktcheck, Tracking, lokale Agentur-Seite, Ergebnisse, Über Haşim und Kontakt
- globale Navigation aus einem einzigen Contract
- direkt gerenderter Header nutzt denselben Contract
- `nexus_rebuild_menu=1` baut künftig dieselbe Navigation statt `WordPress Agentur + Marktcheck`
- globale Projektanfrage nutzt stabil `type=project&focus=implementation_scope`
- lokale Agentur-Seite bleibt SEO-Einstieg und verweist auf die Freelancer-Route
- Dokumentation der Phase unter `docs/architecture/COMMERCIAL_ROUTING_PHASE_2.md`

## Bewusst nicht enthalten

- Blog (`single.php`, `category.php`) bleibt in dieser Phase unangetastet
- keine Redirects/Deindexierung von Money Pages
- kein vollständiger `org-schema.php`-Refactor
- Energy-Marktcheck bleibt erhalten und wird nicht zum generischen CTA

## Prüfstand

- German Copy Guard: ✅
- Linkprüfung: ✅
- CI: ✅
- Architekturprüfung: ✅
- PHP-Syntax: ✅
- PHPStan: ✅
- Theme-Build: ✅

Der PR bleibt vorerst bewusst Draft, bis die Änderungen einmal als Gesamtpaket geprüft wurden.