### PR TITLE
Restore performant freelancer system motion

### DIFF
--- a/blocksy-child/assets/css/wordpress-freelancer-hannover-polish.css
+++ b/blocksy-child/assets/css/wordpress-freelancer-hannover-polish.css
@@ -5,8 +5,8 @@
  * die beiden visuellen Schwerpunktmomente der Route.
  *
  * Lighthouse-Follow-up 2026-08-17: Code-Texte im Git-Workflow erhalten
- * explizit maximale Kontrastreserve. Die SVG-Daueranimation bleibt statisch,
- * weil Lighthouse sie als nicht-kompositierte Animation meldete.
+ * explizit maximale Kontrastreserve. Die Systemgrafik startet Motion nur,
+ * wenn sie im Viewport sichtbar ist; offscreen bleibt sie komplett ruhig.
  */
 
 .hu-fr__hero {
@@ -120,14 +120,15 @@ body.hu-wordpress-freelancer-page .hu-fr .hu-fr-git__rows strong {
 }
 
 /*
- * Performance: statische Signal-Linie statt endloser stroke-dashoffset-
- * Animation. Die Grafik bleibt als visuelles System erhalten, ohne den von
- * Lighthouse gemeldeten nicht-kompositierten Animationspfad.
+ * Motion bleibt absichtlich JavaScript-gesteuert: kein Dauerlauf beim Laden,
+ * kein Offscreen-Paint. Sobald die Grafik sichtbar wird, bewegt der kleine
+ * Kupfer-Impuls sich entlang der Strecke; ausserhalb des Viewports pausiert er.
  */
 .hu-fr-system__signal {
 	animation: none !important;
-	stroke-dasharray: none;
-	stroke-opacity: 0.92;
+	stroke-dasharray: 44 340;
+	stroke-dashoffset: 0;
+	stroke-opacity: 0.96;
 }
 
 @media (max-width: 980px) {
@@ -167,5 +168,7 @@ body.hu-wordpress-freelancer-page .hu-fr .hu-fr-git__rows strong {
 @media (prefers-reduced-motion: reduce) {
 	.hu-fr-system__signal {
 		animation: none !important;
+		stroke-dasharray: none;
+		stroke-dashoffset: 0;
 	}
 }

--- a/blocksy-child/assets/js/wordpress-freelancer-hannover.js
+++ b/blocksy-child/assets/js/wordpress-freelancer-hannover.js
@@ -3,23 +3,111 @@
 
 	const accordion = document.querySelector('[data-fr-accordion]');
 
-	if (!accordion) {
+	if (accordion) {
+		const items = Array.from(accordion.querySelectorAll('details.hu-fr__faq-item'));
+
+		items.forEach((item) => {
+			item.addEventListener('toggle', () => {
+				if (!item.open) {
+					return;
+				}
+
+				items.forEach((otherItem) => {
+					if (otherItem !== item && otherItem.open) {
+						otherItem.open = false;
+					}
+				});
+			});
+		});
+	}
+
+	const system = document.querySelector('.hu-fr-system');
+	const signal = system ? system.querySelector('.hu-fr-system__signal') : null;
+
+	if (!system || !signal || !('IntersectionObserver' in window) || typeof signal.animate !== 'function') {
 		return;
 	}
 
-	const items = Array.from(accordion.querySelectorAll('details.hu-fr__faq-item'));
+	const motionPreference = window.matchMedia('(prefers-reduced-motion: reduce)');
+	let signalAnimation = null;
+	let systemVisible = false;
 
-	items.forEach((item) => {
-		item.addEventListener('toggle', () => {
-			if (!item.open) {
-				return;
+	const stopSignal = (reset = false) => {
+		if (!signalAnimation) {
+			return;
+		}
+
+		if (reset) {
+			signalAnimation.cancel();
+			signalAnimation = null;
+			return;
+		}
+
+		signalAnimation.pause();
+	};
+
+	const startSignal = () => {
+		if (motionPreference.matches || document.hidden || !systemVisible) {
+			return;
+		}
+
+		if (signalAnimation) {
+			signalAnimation.play();
+			return;
+		}
+
+		// Eine komplette Dash-Periode: nahtloser Loop ohne Layout-Aenderung.
+		// Der Effekt wird erst im Viewport erzeugt und offscreen sofort pausiert.
+		signalAnimation = signal.animate(
+			[
+				{ strokeDashoffset: '0px' },
+				{ strokeDashoffset: '-384px' },
+			],
+			{
+				duration: 3200,
+				iterations: Infinity,
+				easing: 'linear',
 			}
+		);
+	};
 
-			items.forEach((otherItem) => {
-				if (otherItem !== item && otherItem.open) {
-					otherItem.open = false;
+	const syncSignalMotion = () => {
+		if (motionPreference.matches) {
+			stopSignal(true);
+			return;
+		}
+
+		if (document.hidden || !systemVisible) {
+			stopSignal();
+			return;
+		}
+
+		startSignal();
+	};
+
+	const observer = new IntersectionObserver(
+		(entries) => {
+			entries.forEach((entry) => {
+				if (entry.target !== system) {
+					return;
 				}
+
+				systemVisible = entry.isIntersecting && entry.intersectionRatio >= 0.2;
+				syncSignalMotion();
 			});
-		});
-	});
+		},
+		{
+			threshold: [0, 0.2],
+			rootMargin: '0px 0px -8% 0px',
+		}
+	);
+
+	observer.observe(system);
+	document.addEventListener('visibilitychange', syncSignalMotion);
+
+	if (typeof motionPreference.addEventListener === 'function') {
+		motionPreference.addEventListener('change', syncSignalMotion);
+	} else if (typeof motionPreference.addListener === 'function') {
+		motionPreference.addListener(syncSignalMotion);
+	}
 })();


### PR DESCRIPTION
## Ziel

Die Systemgrafik auf `/wordpress-freelancer-hannover/` soll wieder sichtbar dynamisch sein, ohne die frühere dauerhafte SVG-Animation schon beim Seitenladen zurückzubringen.

## Umsetzung

- Kupfer-Signal erhält wieder das ursprüngliche Dash-Muster
- Motion wird per `IntersectionObserver` erst ab 20 % Sichtbarkeit gestartet
- ausserhalb des Viewports und in Hintergrund-Tabs wird die Animation pausiert
- `prefers-reduced-motion` bleibt vollständig respektiert
- die bestehende FAQ-Logik bleibt erhalten und ist nicht mehr Voraussetzung für die Systemgrafik
- kein Layout-/Markup-Umbau der Freelancer-Seite

## Performance-Entscheidung

Die SVG-Bewegung ist paint-basiert, läuft aber nicht beim Initial Load und nicht offscreen. Damit bleibt der Lighthouse-kritische Dauerlauf vermieden, während echte Nutzer beim Scrollen den dynamischen Signalweg sehen.

## Prüfziel

Vor Merge müssen insbesondere Motion Guard, PHP/Theme-CI und Linkprüfung grün sein.