### PR TITLE
Build light premium route footer

### DIFF
--- a/blocksy-child/assets/css/site-footer-modern.css
+++ b/blocksy-child/assets/css/site-footer-modern.css
@@ -1,0 +1,505 @@
+/*
+ * Light route footer
+ *
+ * The standard footer deliberately contrasts the mostly dark site surfaces:
+ * warm paper, dark type, copper details. Audit and Energy special footers keep
+ * their existing focused treatment and do not load this file.
+ */
+
+.ft--modern {
+	--ftm-paper: #f6f1e9;
+	--ftm-paper-elevated: #fbf8f3;
+	--ftm-ink: #171411;
+	--ftm-muted: #67605a;
+	--ftm-soft: #8a8179;
+	--ftm-line: rgba(23, 20, 17, 0.13);
+	--ftm-line-strong: rgba(23, 20, 17, 0.22);
+	--ftm-copper: #b46a3c;
+	--ftm-copper-dark: #7f4023;
+	--ftm-dark: #171411;
+	--ftm-dark-muted: #b8afa7;
+	position: relative;
+	isolation: isolate;
+	margin: 0;
+	padding: clamp(76px, 8vw, 116px) 0 0;
+	background: var(--ftm-paper);
+	color: var(--ftm-ink);
+	border-top: 1px solid var(--ftm-line);
+}
+
+.ft--modern::before {
+	content: '';
+	position: absolute;
+	z-index: -1;
+	top: 0;
+	left: 50%;
+	width: min(780px, 78vw);
+	height: 250px;
+	transform: translateX(-50%);
+	background: radial-gradient(circle at 50% 0%, rgba(180, 106, 60, 0.10), transparent 68%);
+	pointer-events: none;
+}
+
+.ft-modern__inner {
+	width: min(1240px, calc(100% - 40px));
+	margin-inline: auto;
+}
+
+.ft-modern__intro {
+	display: grid;
+	grid-template-columns: minmax(0, 1.2fr) minmax(280px, 0.58fr);
+	gap: clamp(32px, 6vw, 84px);
+	align-items: end;
+}
+
+.ft-modern__eyebrow {
+	display: inline-flex;
+	align-items: center;
+	gap: 10px;
+	margin: 0 0 18px;
+	font-size: 0.72rem;
+	font-weight: 800;
+	letter-spacing: 0.14em;
+	text-transform: uppercase;
+	color: var(--ftm-copper-dark);
+}
+
+.ft-modern__eyebrow::before {
+	content: '';
+	width: 28px;
+	height: 2px;
+	border-radius: 999px;
+	background: var(--ftm-copper);
+}
+
+.ft-modern__title {
+	max-width: 760px;
+	margin: 0;
+	font-size: clamp(2.6rem, 5vw, 5rem);
+	font-weight: 660;
+	letter-spacing: -0.045em;
+	line-height: 0.98;
+	color: var(--ftm-ink);
+}
+
+.ft-modern__intro-copy {
+	max-width: 430px;
+	margin: 0 0 4px;
+	font-size: clamp(1rem, 1.5vw, 1.18rem);
+	line-height: 1.66;
+	color: var(--ftm-muted);
+}
+
+.ft-modern__routes {
+	display: grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	gap: 14px;
+	margin-top: clamp(42px, 5vw, 64px);
+}
+
+.ft-modern__route {
+	position: relative;
+	display: grid;
+	grid-template-columns: auto minmax(0, 1fr) auto;
+	grid-template-rows: auto auto;
+	column-gap: 16px;
+	row-gap: 5px;
+	min-height: 154px;
+	padding: 24px;
+	border: 1px solid var(--ftm-line);
+	border-radius: 24px;
+	background: var(--ftm-paper-elevated);
+	color: var(--ftm-ink);
+	text-decoration: none;
+	box-shadow: 0 10px 30px rgba(23, 20, 17, 0.025);
+	transition:
+		transform 180ms ease-out,
+		border-color 180ms ease-out,
+		box-shadow 180ms ease-out,
+		background 180ms ease-out;
+}
+
+.ft-modern__route:hover,
+.ft-modern__route:focus-visible {
+	color: var(--ftm-ink);
+	transform: translateY(-4px);
+	border-color: rgba(180, 106, 60, 0.48);
+	background: #fffaf4;
+	box-shadow: 0 18px 42px rgba(53, 36, 25, 0.09);
+}
+
+.ft-modern__route:focus-visible {
+	outline: 3px solid rgba(180, 106, 60, 0.28);
+	outline-offset: 3px;
+}
+
+.ft-modern__route-icon {
+	grid-row: 1 / span 2;
+	display: inline-grid;
+	place-items: center;
+	width: 44px;
+	height: 44px;
+	border: 1px solid rgba(180, 106, 60, 0.28);
+	border-radius: 14px;
+	background: rgba(180, 106, 60, 0.08);
+	color: var(--ftm-copper-dark);
+}
+
+.ft-modern__route-icon svg {
+	width: 21px;
+	height: 21px;
+	fill: none;
+	stroke: currentColor;
+	stroke-width: 1.8;
+	stroke-linecap: round;
+	stroke-linejoin: round;
+}
+
+.ft-modern__route-label {
+	align-self: end;
+	font-size: 1.05rem;
+	font-weight: 790;
+	letter-spacing: -0.01em;
+}
+
+.ft-modern__route-copy {
+	align-self: start;
+	font-size: 0.82rem;
+	line-height: 1.45;
+	color: var(--ftm-muted);
+}
+
+.ft-modern__route-arrow {
+	grid-row: 1 / span 2;
+	align-self: center;
+	display: grid;
+	place-items: center;
+	width: 34px;
+	height: 34px;
+	border-radius: 50%;
+	border: 1px solid var(--ftm-line);
+	font-size: 1.08rem;
+	color: var(--ftm-copper-dark);
+	transition:
+		transform 180ms ease-out,
+		border-color 180ms ease-out,
+		background 180ms ease-out;
+}
+
+.ft-modern__route:hover .ft-modern__route-arrow,
+.ft-modern__route:focus-visible .ft-modern__route-arrow {
+	transform: translate(2px, -2px);
+	border-color: rgba(180, 106, 60, 0.44);
+	background: rgba(180, 106, 60, 0.08);
+}
+
+.ft-modern__cta-band {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) auto;
+	gap: 28px;
+	align-items: center;
+	margin-top: clamp(34px, 5vw, 58px);
+	padding: clamp(26px, 4vw, 42px);
+	border-radius: 28px;
+	background: var(--ftm-dark);
+	color: #fffaf4;
+	box-shadow: 0 20px 54px rgba(23, 20, 17, 0.16);
+}
+
+.ft-modern__cta-band--mobile-only {
+	display: none;
+}
+
+.ft-modern__cta-kicker {
+	margin: 0 0 6px;
+	font-size: 0.72rem;
+	font-weight: 800;
+	letter-spacing: 0.13em;
+	text-transform: uppercase;
+	color: #d79a73;
+}
+
+.ft-modern__cta-title {
+	margin: 0;
+	font-size: clamp(1.45rem, 2.5vw, 2.2rem);
+	font-weight: 680;
+	letter-spacing: -0.025em;
+	line-height: 1.08;
+	color: #fffaf4;
+}
+
+.ft-modern__cta-note {
+	margin: 10px 0 0;
+	font-size: 0.88rem;
+	line-height: 1.55;
+	color: var(--ftm-dark-muted);
+}
+
+.ft-modern__cta-button {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: 10px;
+	min-height: 52px;
+	padding: 0 22px;
+	border: 1px solid rgba(255, 250, 244, 0.76);
+	border-radius: 999px;
+	background: #fffaf4;
+	color: var(--ftm-ink);
+	font-size: 0.9rem;
+	font-weight: 800;
+	text-decoration: none;
+	white-space: nowrap;
+	transition:
+		transform 180ms ease-out,
+		background 180ms ease-out,
+		border-color 180ms ease-out;
+}
+
+.ft-modern__cta-button:hover,
+.ft-modern__cta-button:focus-visible {
+	color: var(--ftm-ink);
+	transform: translateY(-2px);
+	background: #f2e3d6;
+	border-color: #f2e3d6;
+}
+
+.ft-modern__cta-button:focus-visible {
+	outline: 3px solid rgba(215, 154, 115, 0.42);
+	outline-offset: 3px;
+}
+
+.ft-modern__directory {
+	display: grid;
+	grid-template-columns: minmax(230px, 1.15fr) repeat(3, minmax(0, 1fr));
+	gap: clamp(30px, 5vw, 68px);
+	margin-top: clamp(58px, 7vw, 88px);
+	padding: clamp(42px, 5vw, 58px) 0;
+	border-top: 1px solid var(--ftm-line);
+}
+
+.ft-modern__brand {
+	max-width: 310px;
+}
+
+.ft-modern__logo.site-logo {
+	display: inline-block;
+	margin: 0 0 16px;
+	font-size: 1rem;
+	font-weight: 790;
+	letter-spacing: 0.18em;
+	color: var(--ftm-ink) !important;
+	text-decoration: none;
+}
+
+.ft-modern__brand p {
+	margin: 0;
+	font-size: 0.9rem;
+	line-height: 1.65;
+	color: var(--ftm-muted);
+}
+
+.ft-modern__col h3 {
+	margin: 0 0 18px;
+	font-size: 0.7rem;
+	font-weight: 820;
+	letter-spacing: 0.12em;
+	text-transform: uppercase;
+	color: var(--ftm-soft);
+}
+
+.ft-modern__list {
+	display: grid;
+	gap: 11px;
+	margin: 0;
+	padding: 0;
+	list-style: none;
+}
+
+.ft-modern__list li {
+	margin: 0;
+}
+
+.ft-modern__list a {
+	display: inline-flex;
+	align-items: center;
+	gap: 7px;
+	color: #322d29;
+	font-size: 0.9rem;
+	font-weight: 560;
+	line-height: 1.45;
+	text-decoration: none;
+	text-underline-offset: 4px;
+	transition: color 160ms ease-out, transform 160ms ease-out;
+}
+
+.ft-modern__list a:hover,
+.ft-modern__list a:focus-visible {
+	color: var(--ftm-copper-dark);
+	transform: translateX(2px);
+	text-decoration: underline;
+}
+
+.ft-modern__list a:focus-visible,
+.ft-modern__meta a:focus-visible,
+.ft-modern__social a:focus-visible {
+	outline: 2px solid rgba(180, 106, 60, 0.34);
+	outline-offset: 3px;
+}
+
+.ft-modern__bottom {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) auto auto;
+	gap: 24px;
+	align-items: center;
+	padding: 24px 0 30px;
+	border-top: 1px solid var(--ftm-line);
+	font-size: 0.78rem;
+	color: var(--ftm-soft);
+}
+
+.ft-modern__bottom p {
+	margin: 0;
+}
+
+.ft-modern__meta,
+.ft-modern__social {
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	gap: 12px;
+}
+
+.ft-modern__meta a,
+.ft-modern__social a {
+	color: var(--ftm-muted);
+	text-decoration: none;
+}
+
+.ft-modern__meta a:hover,
+.ft-modern__meta a:focus-visible,
+.ft-modern__social a:hover,
+.ft-modern__social a:focus-visible {
+	color: var(--ftm-ink);
+}
+
+.ft-modern__meta span {
+	color: rgba(23, 20, 17, 0.26);
+}
+
+.ft-modern__social a {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	font-weight: 700;
+}
+
+.ft-modern__social svg {
+	width: 15px;
+	height: 15px;
+	fill: currentColor;
+}
+
+@media (max-width: 1040px) {
+	.ft-modern__intro {
+		grid-template-columns: 1fr;
+		gap: 20px;
+	}
+
+	.ft-modern__intro-copy {
+		max-width: 620px;
+	}
+
+	.ft-modern__routes {
+		grid-template-columns: 1fr 1fr;
+	}
+
+	.ft-modern__route:last-child {
+		grid-column: 1 / -1;
+	}
+
+	.ft-modern__directory {
+		grid-template-columns: 1fr 1fr;
+	}
+
+	.ft-modern__brand {
+		max-width: 520px;
+	}
+}
+
+@media (max-width: 700px) {
+	.ft--modern {
+		padding-top: 68px;
+	}
+
+	.ft-modern__inner {
+		width: min(100% - 28px, 1240px);
+	}
+
+	.ft-modern__title {
+		font-size: clamp(2.45rem, 12vw, 3.55rem);
+	}
+
+	.ft-modern__routes {
+		grid-template-columns: 1fr;
+		gap: 10px;
+		margin-top: 34px;
+	}
+
+	.ft-modern__route,
+	.ft-modern__route:last-child {
+		grid-column: auto;
+		min-height: 126px;
+		padding: 20px;
+		border-radius: 20px;
+	}
+
+	.ft-modern__cta-band,
+	.ft-modern__cta-band--mobile-only {
+		grid-template-columns: 1fr;
+		gap: 20px;
+		padding: 26px 22px;
+		border-radius: 22px;
+	}
+
+	.ft-modern__cta-band--mobile-only {
+		display: grid;
+	}
+
+	.ft-modern__cta-button {
+		width: 100%;
+	}
+
+	.ft-modern__directory {
+		grid-template-columns: 1fr;
+		gap: 34px;
+		margin-top: 52px;
+		padding: 38px 0;
+	}
+
+	.ft-modern__bottom {
+		grid-template-columns: 1fr;
+		gap: 16px;
+		padding-bottom: 26px;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.ft-modern__route,
+	.ft-modern__route-arrow,
+	.ft-modern__cta-button,
+	.ft-modern__list a {
+		transition: none;
+	}
+
+	.ft-modern__route:hover,
+	.ft-modern__route:focus-visible,
+	.ft-modern__route:hover .ft-modern__route-arrow,
+	.ft-modern__route:focus-visible .ft-modern__route-arrow,
+	.ft-modern__cta-button:hover,
+	.ft-modern__cta-button:focus-visible,
+	.ft-modern__list a:hover,
+	.ft-modern__list a:focus-visible {
+		transform: none;
+	}
+}

--- a/blocksy-child/template-parts/site-footer.php
+++ b/blocksy-child/template-parts/site-footer.php
@@ -15,32 +15,33 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 $current_year = wp_date( 'Y' );
 $primary_urls = function_exists( 'nexus_get_primary_public_url_map' ) ? nexus_get_primary_public_url_map() : [];
-$home_url     = $primary_urls['home'] ?? home_url( '/' );
-$energy_url   = $primary_urls['energy'] ?? home_url( '/solar-waermepumpen-leadgenerierung/' );
-$analysis_url = function_exists( 'hu_get_request_analysis_url' ) ? hu_get_request_analysis_url() : home_url( '/solar-waermepumpen-leadgenerierung/#marktcheck' );
+$routes       = function_exists( 'hu_get_commercial_route_map' ) ? hu_get_commercial_route_map() : [];
+$home_url     = $routes['home'] ?? ( $primary_urls['home'] ?? home_url( '/' ) );
+$energy_url   = $routes['energy'] ?? ( $primary_urls['energy'] ?? home_url( '/solar-waermepumpen-leadgenerierung/' ) );
+$analysis_url = $routes['marketcheck'] ?? ( function_exists( 'hu_get_request_analysis_url' ) ? hu_get_request_analysis_url() : home_url( '/solar-waermepumpen-leadgenerierung/#marktcheck' ) );
 $e3_url       = $primary_urls['e3'] ?? home_url( '/case-study-solar-leadgenerierung/' );
-$results_url  = $primary_urls['results'] ?? home_url( '/ergebnisse/' );
+$results_url  = $routes['results'] ?? ( $primary_urls['results'] ?? home_url( '/ergebnisse/' ) );
 $blog_url     = $primary_urls['blog'] ?? home_url( '/blog/' );
 $glossary_url = $primary_urls['glossary'] ?? home_url( '/glossar/' );
-$agentur_url  = $primary_urls['agentur'] ?? home_url( '/wordpress-agentur-hannover/' );
-$freelancer_url = home_url( '/wordpress-freelancer-hannover/' );
-$tracking_url   = home_url( '/server-side-tracking-b2b/' );
-$about_url    = $primary_urls['about'] ?? home_url( '/hasim-uener/' );
-$contact_url  = $primary_urls['contact'] ?? nexus_get_contact_url();
-$project_request_url = function_exists( 'hu_get_navigation_project_request_url' )
+$agentur_url  = $routes['agentur_local'] ?? ( $primary_urls['agentur'] ?? home_url( '/wordpress-agentur-hannover/' ) );
+$freelancer_url = $routes['freelancer'] ?? home_url( '/wordpress-freelancer-hannover/' );
+$tracking_url   = $routes['tracking_b2b'] ?? home_url( '/server-side-tracking-b2b/' );
+$about_url    = $routes['about'] ?? ( $primary_urls['about'] ?? home_url( '/hasim-uener/' ) );
+$contact_url  = $routes['contact'] ?? ( $primary_urls['contact'] ?? nexus_get_contact_url() );
+$project_request_url = $routes['project_request'] ?? ( function_exists( 'hu_get_navigation_project_request_url' )
 	? hu_get_navigation_project_request_url()
 	: add_query_arg(
 		[
 			'type'  => 'project',
-			'focus' => 'followup_scope',
+			'focus' => 'implementation_scope',
 		],
 		$contact_url
-	);
+	) );
 $imprint_url      = $primary_urls['impressum'] ?? home_url( '/impressum/' );
 $privacy_url      = $primary_urls['datenschutz'] ?? home_url( '/datenschutz/' );
-$whitelabel_url   = function_exists( 'nexus_get_whitelabel_page_url' ) ? nexus_get_whitelabel_page_url() : home_url( '/whitelabel-retainer/' );
+$whitelabel_url   = $routes['whitelabel'] ?? ( function_exists( 'nexus_get_whitelabel_page_url' ) ? nexus_get_whitelabel_page_url() : home_url( '/whitelabel-retainer/' ) );
 $hide_primary_cta = function_exists( 'nexus_should_hide_footer_primary_cta' ) && nexus_should_hide_footer_primary_cta();
-$footer_class     = $hide_primary_cta ? 'ft ft--no-primary-cta ft--mobile-cta' : 'ft';
+$footer_class     = $hide_primary_cta ? 'ft ft--modern ft--no-primary-cta ft--mobile-cta' : 'ft ft--modern';
 $request_url      = $project_request_url;
 $audit_cta_label  = 'Projekt anfragen';
 $audit_cta_microcopy = 'Scope · Ziel · nächster sinnvoller Schritt';
@@ -67,7 +68,7 @@ if ( $is_whitelabel_context ) {
 	$audit_cta_label     = 'WordPress-Projekt prüfen lassen';
 	$audit_cta_microcopy = 'Direkt mit mir · Scope und Preis vor Umsetzung';
 } else {
-	$brand_tagline  = 'WordPress, technisches SEO, Tracking und Conversion als zusammenhängendes System — direkt mit Haşim Üner.';
+	$brand_tagline  = 'WordPress, Tracking und Conversion als zusammenhängendes System — direkt mit Haşim Üner.';
 	$copyright_line = 'Haşim Üner - WordPress, Tracking & Conversion';
 }
 ?>
@@ -110,78 +111,144 @@ if ( $is_whitelabel_context ) {
 </footer>
 <?php return; endif; ?>
 
-<footer id="footer" class="<?php echo esc_attr( $footer_class ); ?>" aria-labelledby="ft-heading" role="contentinfo">
-	<h2 id="ft-heading" class="ft__sr">Footer-Navigation</h2>
+<?php
+/*
+ * The large standard footer sits below the useful page content. Load its
+ * dedicated stylesheet at that point instead of adding another render-blocking
+ * global asset to the document head. Audit and Energy footers stay untouched.
+ */
+$footer_style_path = get_stylesheet_directory() . '/assets/css/site-footer-modern.css';
+$footer_style_url  = get_stylesheet_directory_uri() . '/assets/css/site-footer-modern.css';
+if ( file_exists( $footer_style_path ) ) {
+	$footer_style_version = function_exists( 'hu_get_asset_version' )
+		? hu_get_asset_version( $footer_style_path )
+		: (string) filemtime( $footer_style_path );
+	$footer_style_url = add_query_arg( 'ver', $footer_style_version, $footer_style_url );
+}
+?>
+<link rel="stylesheet" id="nexus-site-footer-modern-css" href="<?php echo esc_url( $footer_style_url ); ?>" media="all">
 
-	<div class="ft__top">
-		<div class="ft__brand">
-			<a class="ft__logo site-logo site-logo--accent" href="<?php echo esc_url( $home_url ); ?>" aria-label="Startseite - HAŞIM ÜNER">HAŞIM ÜNER</a>
-			<p class="ft__tag"><?php echo esc_html( $brand_tagline ); ?></p>
-			<?php if ( ! $hide_primary_cta ) : ?>
-			<div class="ft__cta-group">
-				<a class="ft__cta" href="<?php echo esc_url( $request_url ); ?>" data-track-action="cta_footer_primary" data-track-category="lead_gen" data-track-section="footer" data-track-funnel-stage="footer_primary"><?php echo esc_html( $audit_cta_label ); ?></a>
-				<p class="ft__cta-note"><?php echo esc_html( $audit_cta_microcopy ); ?></p>
+<footer id="footer" class="<?php echo esc_attr( $footer_class ); ?>" aria-labelledby="ft-heading" role="contentinfo">
+	<div class="ft-modern__inner">
+		<div class="ft-modern__intro">
+			<div>
+				<p class="ft-modern__eyebrow">Drei Wege, ein technischer Partner</p>
+				<h2 id="ft-heading" class="ft-modern__title">Was soll als Nächstes funktionieren?</h2>
 			</div>
-			<?php else : ?>
-			<div class="ft__cta-group ft__cta-group--mobile-only">
-				<a class="ft__cta ft__cta--mobile-only" href="<?php echo esc_url( $request_url ); ?>" data-track-action="cta_footer_primary_mobile" data-track-category="lead_gen" data-track-section="footer" data-track-funnel-stage="footer_mobile"><?php echo esc_html( $audit_cta_label ); ?></a>
-				<p class="ft__cta-note ft__cta-note--mobile-only"><?php echo esc_html( $audit_cta_microcopy ); ?></p>
-			</div>
-			<?php endif; ?>
+			<p class="ft-modern__intro-copy">Website, Tracking oder Conversion — wir starten dort, wo gerade der größte Hebel liegt.</p>
 		</div>
 
-		<nav class="ft__cols" aria-label="Footer-Navigation">
-			<section class="ft__col" aria-labelledby="ft-leistungen">
+		<nav class="ft-modern__routes" aria-label="Hauptwege">
+			<a class="ft-modern__route" href="<?php echo esc_url( $freelancer_url ); ?>" data-track-action="cta_footer_route_freelancer" data-track-category="navigation" data-track-section="footer_routes">
+				<span class="ft-modern__route-icon" aria-hidden="true">
+					<svg viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="16" rx="2"></rect><path d="M3 9h18M7 6.5h.01M10 6.5h.01"></path></svg>
+				</span>
+				<span class="ft-modern__route-label">WordPress</span>
+				<span class="ft-modern__route-copy">Direkte Projekte · Entwicklung, Tracking &amp; Conversion</span>
+				<span class="ft-modern__route-arrow" aria-hidden="true">↗</span>
+			</a>
+
+			<a class="ft-modern__route" href="<?php echo esc_url( $whitelabel_url ); ?>" data-track-action="cta_footer_route_whitelabel" data-track-category="navigation" data-track-section="footer_routes">
+				<span class="ft-modern__route-icon" aria-hidden="true">
+					<svg viewBox="0 0 24 24"><path d="m12 3 8 5-8 5-8-5 8-5Z"></path><path d="m4 12 8 5 8-5M4 16l8 5 8-5"></path></svg>
+				</span>
+				<span class="ft-modern__route-label">Für Agenturen</span>
+				<span class="ft-modern__route-copy">White-Label · Umsetzung im Hintergrund</span>
+				<span class="ft-modern__route-arrow" aria-hidden="true">↗</span>
+			</a>
+
+			<a class="ft-modern__route" href="<?php echo esc_url( $energy_url ); ?>" data-track-action="cta_footer_route_energy" data-track-category="navigation" data-track-section="footer_routes">
+				<span class="ft-modern__route-icon" aria-hidden="true">
+					<svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="3.5"></circle><path d="M12 2v2.5M12 19.5V22M2 12h2.5M19.5 12H22M4.9 4.9l1.8 1.8M17.3 17.3l1.8 1.8M19.1 4.9l-1.8 1.8M6.7 17.3l-1.8 1.8"></path></svg>
+				</span>
+				<span class="ft-modern__route-label">Solar &amp; Wärmepumpen</span>
+				<span class="ft-modern__route-copy">Anfragesysteme · Marktcheck &amp; Leadgenerierung</span>
+				<span class="ft-modern__route-arrow" aria-hidden="true">↗</span>
+			</a>
+		</nav>
+
+		<?php if ( ! $hide_primary_cta ) : ?>
+		<section class="ft-modern__cta-band" aria-label="Projektanfrage">
+			<div>
+				<p class="ft-modern__cta-kicker">Nächster Schritt</p>
+				<h3 class="ft-modern__cta-title">Ein konkretes Projekt?</h3>
+				<p class="ft-modern__cta-note"><?php echo esc_html( $audit_cta_microcopy ); ?></p>
+			</div>
+			<a class="ft-modern__cta-button" href="<?php echo esc_url( $request_url ); ?>" data-track-action="cta_footer_primary" data-track-category="lead_gen" data-track-section="footer" data-track-funnel-stage="footer_primary">
+				<?php echo esc_html( $audit_cta_label ); ?> <span aria-hidden="true">↗</span>
+			</a>
+		</section>
+		<?php else : ?>
+		<section class="ft-modern__cta-band ft-modern__cta-band--mobile-only" aria-label="Projektanfrage">
+			<div>
+				<p class="ft-modern__cta-kicker">Nächster Schritt</p>
+				<h3 class="ft-modern__cta-title">Ein konkretes Projekt?</h3>
+				<p class="ft-modern__cta-note"><?php echo esc_html( $audit_cta_microcopy ); ?></p>
+			</div>
+			<a class="ft-modern__cta-button" href="<?php echo esc_url( $request_url ); ?>" data-track-action="cta_footer_primary_mobile" data-track-category="lead_gen" data-track-section="footer" data-track-funnel-stage="footer_mobile">
+				<?php echo esc_html( $audit_cta_label ); ?> <span aria-hidden="true">↗</span>
+			</a>
+		</section>
+		<?php endif; ?>
+
+		<div class="ft-modern__directory">
+			<div class="ft-modern__brand">
+				<a class="ft-modern__logo site-logo" href="<?php echo esc_url( $home_url ); ?>" aria-label="Startseite - HAŞIM ÜNER">HAŞIM ÜNER</a>
+				<p><?php echo esc_html( $brand_tagline ); ?></p>
+			</div>
+
+			<section class="ft-modern__col" aria-labelledby="ft-leistungen">
 				<h3 id="ft-leistungen">Leistungen</h3>
-				<ul class="ft__list">
-					<li><a href="<?php echo esc_url( $energy_url ); ?>" data-track-action="cta_footer_nav_energy" data-track-category="navigation" data-track-section="footer">Solar &amp; Wärmepumpen</a></li>
-					<li><a class="ft__link-strong" href="<?php echo esc_url( $freelancer_url ); ?>" data-track-action="cta_footer_nav_freelancer" data-track-category="navigation" data-track-section="footer">WordPress Freelancer</a></li>
+				<ul class="ft-modern__list">
+					<li><a href="<?php echo esc_url( $freelancer_url ); ?>" data-track-action="cta_footer_nav_freelancer" data-track-category="navigation" data-track-section="footer">WordPress Freelancer</a></li>
 					<li><a href="<?php echo esc_url( $tracking_url ); ?>" data-track-action="cta_footer_nav_tracking" data-track-category="navigation" data-track-section="footer">Server-Side Tracking B2B</a></li>
+					<li><a href="<?php echo esc_url( $energy_url ); ?>" data-track-action="cta_footer_nav_energy" data-track-category="navigation" data-track-section="footer">Solar &amp; Wärmepumpen</a></li>
 					<li><a href="<?php echo esc_url( $agentur_url ); ?>" data-track-action="cta_footer_nav_agentur" data-track-category="navigation" data-track-section="footer">WordPress Agentur Hannover</a></li>
 				</ul>
 			</section>
 
-			<section class="ft__col" aria-labelledby="ft-proof-wissen">
-				<h3 id="ft-proof-wissen">Proof &amp; Wissen</h3>
-				<ul class="ft__list">
-					<li><a class="ft__link-strong" href="<?php echo esc_url( $results_url ); ?>" data-track-action="cta_footer_nav_results" data-track-category="trust" data-track-section="footer">Ergebnisse &amp; Case Studies</a></li>
+			<section class="ft-modern__col" aria-labelledby="ft-proof-wissen">
+				<h3 id="ft-proof-wissen">Nachweise &amp; Wissen</h3>
+				<ul class="ft-modern__list">
+					<li><a href="<?php echo esc_url( $results_url ); ?>" data-track-action="cta_footer_nav_results" data-track-category="trust" data-track-section="footer">Ergebnisse &amp; Case Studies</a></li>
 					<li><a href="<?php echo esc_url( $e3_url ); ?>" data-track-action="cta_footer_nav_case_study_proof" data-track-category="trust" data-track-section="footer">Fallstudie: Solar Leadgenerierung</a></li>
 					<li><a href="<?php echo esc_url( $blog_url ); ?>" data-track-action="cta_footer_nav_insights" data-track-category="navigation" data-track-section="footer">Insights</a></li>
 					<li><a href="<?php echo esc_url( $glossary_url ); ?>" data-track-action="cta_footer_nav_glossary" data-track-category="navigation" data-track-section="footer">Glossar für SEO, Tracking und Anfragesysteme</a></li>
 				</ul>
 			</section>
 
-			<section class="ft__col" aria-labelledby="ft-zusammenarbeit">
+			<section class="ft-modern__col" aria-labelledby="ft-zusammenarbeit">
 				<h3 id="ft-zusammenarbeit">Zusammenarbeit</h3>
-				<ul class="ft__list">
-					<li><a class="ft__link-strong" href="<?php echo esc_url( $project_request_url ); ?>" data-track-action="cta_footer_nav_project" data-track-category="lead_gen" data-track-section="footer">Umsetzung besprechen</a></li>
+				<ul class="ft-modern__list">
+					<li><a href="<?php echo esc_url( $project_request_url ); ?>" data-track-action="cta_footer_nav_project" data-track-category="lead_gen" data-track-section="footer">Projekt anfragen</a></li>
 					<li><a href="<?php echo esc_url( $whitelabel_url ); ?>" data-track-action="cta_footer_nav_whitelabel" data-track-category="lead_gen" data-track-section="footer">Für Agenturen: White-Label</a></li>
 					<li><a href="<?php echo esc_url( $about_url ); ?>" data-track-action="cta_footer_nav_about" data-track-category="navigation" data-track-section="footer">Über Haşim</a></li>
 					<li><a href="<?php echo esc_url( $contact_url ); ?>" data-track-action="cta_footer_nav_contact" data-track-category="navigation" data-track-section="footer">Direktkontakt</a></li>
 				</ul>
-
-				<nav class="ft__legal" aria-label="Rechtliches">
-					<a href="<?php echo esc_url( $imprint_url ); ?>">Impressum</a>
-					<span aria-hidden="true">·</span>
-					<a href="<?php echo esc_url( $privacy_url ); ?>">Datenschutz</a>
-				</nav>
 			</section>
-		</nav>
-	</div>
+		</div>
 
-	<div class="ft__bottom">
-		<p>&copy; <time class="ft__year" datetime="<?php echo esc_attr( $current_year ); ?>"><?php echo esc_html( $current_year ); ?></time> <?php echo esc_html( $copyright_line ); ?></p>
-		<div class="ft__social" aria-label="Profile">
-			<a href="https://www.linkedin.com/in/hasim-uener/" aria-label="LinkedIn-Profil" rel="me noopener noreferrer" target="_blank">
-				<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20.5 2h-17A1.5 1.5 0 0 0 2 3.5v17A1.5 1.5 0 0 0 3.5 22h17a1.5 1.5 0 0 0 1.5-1.5v-17A1.5 1.5 0 0 0 20.5 2zM8 19H5v-9h3zM6.5 8.25A1.75 1.75 0 1 1 8.3 6.5a1.78 1.78 0 0 1-1.8 1.75zM19 19h-3v-4.74c0-1.42-.6-1.93-1.38-1.93A1.74 1.74 0 0 0 13 14.19V19h-3v-9h2.9v1.3a3.11 3.11 0 0 1 2.7-1.4c1.55 0 3.36.86 3.36 3.66z"/></svg>
-				LinkedIn
-			</a>
-			<?php if ( $is_whitelabel_context || $is_freelancer_context ) : ?>
-			<a href="https://github.com/Hasim-Uner/meine-wordpress-site-2fe6f514" aria-label="Öffentliches GitHub-Repository" rel="me noopener noreferrer" target="_blank" data-track-action="cta_footer_social_github" data-track-category="trust" data-track-section="footer">
-				<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.1.79-.25.79-.56v-2.06c-3.2.7-3.87-1.36-3.87-1.36-.52-1.33-1.27-1.68-1.27-1.68-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.75 2.68 1.25 3.34.96.1-.74.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.18 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.21-1.49 3.18-1.18 3.18-1.18.62 1.58.23 2.75.11 3.04.74.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.25 5.68.41.35.78 1.04.78 2.1v3.11c0 .31.21.66.79.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
-				GitHub
-			</a>
-			<?php endif; ?>
+		<div class="ft-modern__bottom">
+			<p>&copy; <time class="ft__year" datetime="<?php echo esc_attr( $current_year ); ?>"><?php echo esc_html( $current_year ); ?></time> <?php echo esc_html( $copyright_line ); ?></p>
+
+			<nav class="ft-modern__meta" aria-label="Rechtliches">
+				<a href="<?php echo esc_url( $imprint_url ); ?>">Impressum</a>
+				<span aria-hidden="true">·</span>
+				<a href="<?php echo esc_url( $privacy_url ); ?>">Datenschutz</a>
+			</nav>
+
+			<div class="ft-modern__social" aria-label="Profile">
+				<a href="https://www.linkedin.com/in/hasim-uener/" aria-label="LinkedIn-Profil" rel="me noopener noreferrer" target="_blank">
+					<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20.5 2h-17A1.5 1.5 0 0 0 2 3.5v17A1.5 1.5 0 0 0 3.5 22h17a1.5 1.5 0 0 0 1.5-1.5v-17A1.5 1.5 0 0 0 20.5 2zM8 19H5v-9h3zM6.5 8.25A1.75 1.75 0 1 1 8.3 6.5a1.78 1.78 0 0 1-1.8 1.75zM19 19h-3v-4.74c0-1.42-.6-1.93-1.38-1.93A1.74 1.74 0 0 0 13 14.19V19h-3v-9h2.9v1.3a3.11 3.11 0 0 1 2.7-1.4c1.55 0 3.36.86 3.36 3.66z"/></svg>
+					LinkedIn
+				</a>
+				<?php if ( $is_whitelabel_context || $is_freelancer_context ) : ?>
+				<a href="https://github.com/Hasim-Uner/meine-wordpress-site-2fe6f514" aria-label="Öffentliches GitHub-Repository" rel="me noopener noreferrer" target="_blank" data-track-action="cta_footer_social_github" data-track-category="trust" data-track-section="footer">
+					<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.1.79-.25.79-.56v-2.06c-3.2.7-3.87-1.36-3.87-1.36-.52-1.33-1.27-1.68-1.27-1.68-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.75 2.68 1.25 3.34.96.1-.74.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.18 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.21-1.49 3.18-1.18 3.18-1.18.62 1.58.23 2.75.11 3.04.74.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.25 5.68.41.35.78 1.04.78 2.1v3.11c0 .31.21.66.79.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
+					GitHub
+				</a>
+				<?php endif; ?>
+			</div>
 		</div>
 	</div>
 </footer>


### PR DESCRIPTION
## Ziel

Der globale Standard-Footer wird visuell als heller Abschlussraum neu gebaut und übernimmt dieselbe Drei-Wege-Logik wie der neue Header, ohne wichtige SEO- und Wissenslinks zu verlieren.

## Umsetzung
- warmer heller Footer statt weiterer dunkler Fläche
- große Abschlussfrage „Was soll als Nächstes funktionieren?“
- drei visuelle Route-Cards: WordPress, Für Agenturen, Solar & Wärmepumpen
- dunkle Projekt-CTA als bewusster Kontrast innerhalb des hellen Footers
- sekundäre Linkebene bleibt vollständig erhalten: Server-Side Tracking B2B, WordPress Agentur Hannover, Ergebnisse, Solar-Fallstudie, Insights, Glossar, White-Label, Über Haşim und Direktkontakt
- Commercial-Route-Map wird für die wichtigsten Ziele verwendet
- Audit- und Energy-Spezialfooter bleiben unverändert
- CTA-Ausblendungslogik bleibt erhalten; auf entsprechenden Seiten erscheint die CTA weiterhin nur mobil
- eigene Footer-CSS wird erst am Footer geladen, damit sie den Initial Render nicht blockiert

## Design
- warmes Off-White statt hartem Weiß
- sehr dunkle Typografie
- Kupfer nur als Akzent
- klare Kartenhierarchie und reduzierte Linknavigation
- responsive 3→2→1 Kartenstruktur
- prefers-reduced-motion berücksichtigt

## Prüfung
Vor Merge: vollständige CI inkl. Motion Guard, PHP-Syntax/PHPStan, Build sowie Link- und Copy-Checks.