### PR TITLE
Give the mobile header a visible action

### DIFF
--- a/blocksy-child/assets/css/site-header-premium.css
+++ b/blocksy-child/assets/css/site-header-premium.css
@@ -243,6 +243,15 @@
     transform: translate(1px, -1px);
 }
 
+/*
+ * Der Mobile-CTA existiert im Markup immer, ist auf Desktop aber aus, weil dort
+ * derselbe CTA am Ende der Nav steht. Genau eine der beiden Instanzen ist
+ * sichtbar; display:none nimmt die andere auch aus dem Accessibility-Baum.
+ */
+.nx-site-header--premium .nx-site-header__mobile-cta {
+    display: none;
+}
+
 .nx-site-header--premium .nx-site-header__panel-intro,
 .nx-site-header--premium .nx-site-header__panel-signature {
     display: none;
@@ -326,6 +335,68 @@
      * Zeile und überlagern die Wortmarke.
      */
     .nx-site-header--premium .nx-site-header__nav {
+        display: none;
+    }
+
+    /*
+     * Wortmarke | Anfragen | Burger. Der Burger bleibt, der Vollbild-
+     * Routenwaehler dahinter ist die richtige Loesung fuer drei
+     * gleichrangige Wege — er war nur die einzige Handlung der Leiste, und
+     * eine versteckte Handlung ist auf dem Telefon keine.
+     */
+    .nx-site-header--premium .nx-site-header__actions {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+    }
+
+    .nx-site-header--premium .nx-site-header__mobile-cta {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        min-height: 46px;
+        padding: 0 14px;
+        border: 1px solid transparent;
+        border-radius: 14px;
+        background: linear-gradient(180deg, var(--accent-hover) 0%, var(--accent) 100%);
+        box-shadow: 0 10px 22px hsl(var(--accent-hsl) / 0.22);
+        color: var(--text-inverse);
+        font-size: 0.82rem;
+        font-weight: 700;
+        letter-spacing: -0.01em;
+        line-height: 1;
+        text-decoration: none;
+        white-space: nowrap;
+        transition:
+            background var(--nx-duration-fast) var(--nx-ease),
+            box-shadow var(--nx-duration-fast) var(--nx-ease),
+            transform var(--nx-duration-fast) var(--nx-ease);
+    }
+
+    .nx-site-header--premium .nx-site-header__mobile-cta:hover,
+    .nx-site-header--premium .nx-site-header__mobile-cta:focus-visible {
+        background: linear-gradient(180deg, color-mix(in srgb, var(--accent-hover) 82%, white) 0%, var(--accent-hover) 100%);
+        box-shadow: 0 12px 26px hsl(var(--accent-hsl) / 0.26);
+        color: var(--text-inverse);
+    }
+
+    .nx-site-header--premium .nx-site-header__mobile-cta:active {
+        transform: translateY(1px);
+    }
+
+    /* Das Kurzlabel greift erst, wenn das lange die Leiste sprengen wuerde. */
+    .nx-site-header--premium .nx-site-header__mobile-cta-short {
+        display: none;
+    }
+
+    .nx-site-header--premium .nx-site-header__mobile-cta-arrow {
+        display: inline-grid;
+        place-items: center;
+    }
+
+    /* Bei geoeffnetem Routenwaehler traegt der Panel-CTA die Handlung; zwei
+       gleiche Buttons uebereinander waeren nur Rauschen. */
+    .nx-site-header--premium.is-open .nx-site-header__mobile-cta {
         display: none;
     }
 
@@ -554,6 +625,28 @@
         font-weight: 650;
         letter-spacing: 0.12em;
         text-transform: uppercase;
+    }
+}
+
+/*
+ * Wortmarke, volles Label und Burger passen gemessen erst ab etwa 380px in die
+ * Leiste — und dort mit 2px Rest. Das ist keine Reserve, sondern Zufall: in
+ * Produktion laeuft eine andere Schrift als im Pruefstand. Die Schwelle liegt
+ * deshalb bei 430px, wo rund 30px Puffer bleiben. Darunter traegt der Button
+ * das kurze Label; das vollstaendige "Projekt anfragen" steht im
+ * Vollbild-Routenwaehler und im aria-label.
+ */
+@media (max-width: 429px) {
+    .nx-site-header--premium .nx-site-header__mobile-cta {
+        padding: 0 12px;
+    }
+
+    .nx-site-header--premium .nx-site-header__mobile-cta-full {
+        display: none;
+    }
+
+    .nx-site-header--premium .nx-site-header__mobile-cta-short {
+        display: inline;
     }
 }
 

--- a/blocksy-child/template-parts/site-header.php
+++ b/blocksy-child/template-parts/site-header.php
@@ -76,6 +76,28 @@ if ( function_exists( 'hu_get_primary_navigation_contract' ) ) {
 }
 
 /*
+ * Der Projekt-CTA für die mobile Leiste.
+ *
+ * Unter 1101px ist die Desktop-Nav ausgeblendet, und damit lag auch die
+ * einzige Handlung des Headers hinter dem Burger. Auf einer Seite, deren Zweck
+ * Anfragen sind, stand auf dem Telefon eine 64px-Leiste mit Wortmarke, Burger
+ * und 209px Nichts dazwischen. Der Energy-Header macht auf derselben Breite
+ * längst das Richtige (Wortmarke + Marktcheck); der globale Header zieht nach.
+ *
+ * Bewusst dieselbe Quelle wie die Desktop-Nav statt eines zweiten Labels: der
+ * CTA darf nicht auseinanderlaufen. Sichtbar ist immer nur eine der beiden
+ * Instanzen — die jeweils andere liegt auf display:none und damit auch aus dem
+ * Accessibility-Baum.
+ */
+$mobile_cta_item = null;
+foreach ( $strategy_nav_items as $strategy_nav_item ) {
+	if ( false !== strpos( (string) ( $strategy_nav_item['class'] ?? '' ), 'nav-project-link' ) ) {
+		$mobile_cta_item = $strategy_nav_item;
+		break;
+	}
+}
+
+/*
  * Visuelle Navigationsebene: Die drei Geschäftswege bleiben semantisch Teil
  * desselben Routing-Contracts, werden aber als kompakte Route-Cards gerendert.
  * Ergebnisse, Über Haşim und die Projekt-CTA bleiben bewusst ruhiger.
@@ -276,6 +298,21 @@ if ( is_file( $premium_header_css_path ) ) {
 			</nav>
 
 			<div class="nx-site-header__actions">
+				<?php if ( is_array( $mobile_cta_item ) ) : ?>
+					<a
+						class="nx-site-header__mobile-cta"
+						href="<?php echo esc_url( (string) ( $mobile_cta_item['url'] ?? home_url( '/kontakt/' ) ) ); ?>"
+						aria-label="<?php echo esc_attr( (string) ( $mobile_cta_item['label'] ?? 'Projekt anfragen' ) ); ?>"
+						data-track-action="cta_header_mobile_project"
+						data-track-category="<?php echo esc_attr( (string) ( $mobile_cta_item['category'] ?? 'lead_gen' ) ); ?>"
+						data-track-section="header_mobile"
+					>
+						<span class="nx-site-header__mobile-cta-full"><?php echo esc_html( (string) ( $mobile_cta_item['label'] ?? 'Projekt anfragen' ) ); ?></span>
+						<span class="nx-site-header__mobile-cta-short"><?php esc_html_e( 'Anfragen', 'blocksy-child' ); ?></span>
+						<span class="nx-site-header__mobile-cta-arrow" aria-hidden="true"><?php echo hu_arrow_up_right_svg( 13 ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static inline SVG ?></span>
+					</a>
+				<?php endif; ?>
+
 				<button
 					type="button"
 					class="nx-site-header__toggle"


### PR DESCRIPTION
Below 1101px the desktop nav is hidden, and with it the only action the header had. On a phone the bar was a wordmark, a burger and 209px of nothing between them — on a site whose entire purpose is producing inquiries, every visitor had to open a menu before seeing a way to get in touch.

The burger is not the problem and stays: three equal-weight paths belong in the full-screen chooser, and that chooser is good. What was missing next to it is one visible action. The energy header has done exactly this on the same widths for a while (wordmark + Marktcheck); the global header now follows.

The mobile CTA reads from the same navigation contract as the desktop one so the two cannot drift apart. Only ever one of them is rendered visible; the other sits on display:none and is therefore out of the accessibility tree as well. While the route chooser is open the bar CTA hides, because the panel carries its own.

Label width is measured, not guessed: wordmark, full label and burger first fit at about 380px and only with 2px to spare, which is luck rather than headroom given production runs a different typeface than the test harness. Below 430px the button therefore reads "Anfragen"; the full "Projekt anfragen" stays in the chooser and in the aria-label.

Verified in headless Chromium at 320, 360, 390, 414, 430, 480, 768, 1100, 1101 and 1280px: CTA and burger both 46px tall, wordmark never clipped, no horizontal overflow, CTA absent from 1101px up where the desktop nav carries it.


Claude-Session: https://claude.ai/code/session_01KCRRP8RLnxHQZkMuHbMSuh